### PR TITLE
Implement new Scene Inventory

### DIFF
--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -58,7 +58,8 @@ def _install_menu():
         loader,
         manager,
         publish,
-        cbloader
+        cbloader,
+        cbsceneinventory
     )
 
     from . import interactive
@@ -80,7 +81,10 @@ def _install_menu():
         cmds.menuItem("Publish...",
                       command=lambda *args: publish.show(parent=self._parent),
                       image=publish.ICON)
-        cmds.menuItem("Manage...",
+        cmds.menuItem("Manage... (new)",
+                      command=lambda *args: cbsceneinventory.show(
+                          parent=self._parent))
+        cmds.menuItem("Manage... (old)",
                       command=lambda *args: manager.show(parent=self._parent))
 
         cmds.menuItem(divider=True)

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -528,20 +528,20 @@ def debug_host():
     def ls():
         containers = [
             {
+                "representation": "ee-ft-a-uuid1",
                 "schema": "avalon-core:container-1.0",
                 "name": "Bruce01",
-                "asset": "Bruce",
-                "subset": "rigDefault",
+                "objectName": "Bruce01_node",
+                "namespace": "_bruce01_",
                 "version": 3,
-                "silo": "assets",
             },
             {
+                "representation": "aa-bc-s-uuid2",
                 "schema": "avalon-core:container-1.0",
                 "name": "Bruce02",
-                "asset": "Bruce",
-                "subset": "modelDefault",
+                "objectName": "Bruce01_node",
+                "namespace": "_bruce02_",
                 "version": 2,
-                "silo": "assets",
             }
         ]
 

--- a/avalon/tools/cbsceneinventory/__init__.py
+++ b/avalon/tools/cbsceneinventory/__init__.py
@@ -1,0 +1,7 @@
+from .app import (
+    show,
+)
+
+__all__ = [
+    "show",
+]

--- a/avalon/tools/cbsceneinventory/app.py
+++ b/avalon/tools/cbsceneinventory/app.py
@@ -1,0 +1,421 @@
+import sys
+import getpass
+
+from ...vendor.Qt import QtWidgets, QtCore
+from ...vendor import qtawesome as qta
+from ... import io
+from .. import lib as tools_lib
+
+import os
+import subprocess
+
+from .proxy import FilterProxyModel
+from .model import InventoryModel
+from ... import api
+
+# todo(roy): refactor loading from other tools
+from ..projectmanager.widget import (
+    preserve_expanded_rows,
+    preserve_selection
+)
+from ..cbloader.delegates import VersionDelegate
+from ..cbloader.lib import get_representation_context
+
+DEFAULT_COLOR = "#fb9c15"
+
+module = sys.modules[__name__]
+module.window = None
+
+
+def get_representation_path(representation):
+    """Return full path for a representation in current project."""
+    context = get_representation_context(representation)
+
+    # template data from context
+    data = dict()
+    for key, value in context.items():
+        data[key] = value['name']
+
+    # additional parameters
+    data['root'] = api.registered_root()
+    data['silo'] = context['asset']['silo']
+
+    # todo(roy): Implement additional parameters.
+    # see https://getavalon.github.io/2.0/reference/#project-configuration-api
+    data['user'] = getpass.getuser()
+    data['app'] = os.environ.get("AVALON_APP", "")
+    data['task'] = os.environ.get("AVALON_TASK", "")
+
+    # get project template for published files
+    template = context['project']['config']['template']['publish']
+
+    return template.format(**data)
+
+
+class View(QtWidgets.QTreeView):
+    data_changed = QtCore.Signal()
+
+    def __init__(self, parent=None):
+        super(View, self).__init__(parent=parent)
+
+        # view settings
+        self.setIndentation(12)
+        self.setAlternatingRowColors(True)
+        self.setSortingEnabled(True)
+        self.setSelectionMode(self.ExtendedSelection)
+        self.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+        self.customContextMenuRequested.connect(self.show_right_mouse_menu)
+        # self.doubleClicked.connect(self.on_double_click)
+
+    def build_item_menu(self, items):
+        """Create menu for the selected items"""
+
+        host = api.registered_host()
+        menu = QtWidgets.QMenu(self)
+
+        # update to latest version
+        def _on_update_to_latest(items):
+            for item in items:
+                host.update(item, -1)
+            self.data_changed.emit()
+
+        update_icon = qta.icon("fa.angle-double-up", color=DEFAULT_COLOR)
+        updatetolatest_action = QtWidgets.QAction(update_icon,
+                                                  "Update to latest", menu)
+        updatetolatest_action.triggered.connect(
+            lambda: _on_update_to_latest(items))
+
+        # set version
+        setversion_icon = qta.icon("fa.hashtag", color=DEFAULT_COLOR)
+        setversion_action = QtWidgets.QAction(setversion_icon,
+                                              "Set version", menu)
+        setversion_action.triggered.connect(
+            lambda: self.show_version_dialog(items))
+
+        # select
+        # highlight_icon = qta.icon("fa.hand-o-up", color=DEFAULT_COLOR)
+        # highlight_action = QtWidgets.QAction(highlight_icon,
+        #                                      "Select items", menu, )
+        # highlight_action.triggered.connect(lambda: api.select(items))
+
+        # remove
+        remove_icon = qta.icon("fa.remove", color=DEFAULT_COLOR)
+        remove_action = QtWidgets.QAction(remove_icon, "Remove items", menu)
+        remove_action.triggered.connect(
+            lambda: self.show_remove_warning_dialog(items))
+
+        # show in explorer
+        explorer_icon = qta.icon("fa.folder-open-o", color=DEFAULT_COLOR)
+        explorer_action = QtWidgets.QAction(explorer_icon,
+                                            "Show in explorer ...", menu)
+        explorer_action.triggered.connect(lambda: self.show_in_explorer(items))
+
+        # expand all items
+        expandall_action = QtWidgets.QAction(menu, text="Expand all items")
+        expandall_action.triggered.connect(self.expandAll)
+
+        # collapse all items
+        collapse_action = QtWidgets.QAction(menu, text="Collapse all items")
+        collapse_action.triggered.connect(self.collapseAll)
+
+        # add the actions
+        menu.addAction(updatetolatest_action)
+        menu.addAction(setversion_action)
+
+        menu.addSeparator()
+        # menu.addAction(highlight_action)
+        menu.addAction(remove_action)
+
+        menu.addSeparator()
+        menu.addAction(explorer_action)
+
+        menu.addSeparator()
+        menu.addAction(expandall_action)
+        menu.addAction(collapse_action)
+
+        return menu
+
+    def show_right_mouse_menu(self, pos):
+        """Display the menu when at the position of the item clicked"""
+
+        active = self.currentIndex()  # index under mouse
+        active = active.sibling(active.row(), 0)  # get first column
+        globalpos = self.viewport().mapToGlobal(pos)
+
+        # move index under mouse
+        indices = self.get_indices()
+        if not active.parent().isValid():
+            assert active in indices, "No active item found in the selection"
+
+            # Push the active one as 'last' to selected
+            indices.remove(active)
+            indices.append(active)
+
+        # Extend to the sub-items
+        all_indices = self.extend_to_children(indices)
+        nodes = [dict(i.data(InventoryModel.NodeRole)) for i in all_indices
+                 if i.parent().isValid()]
+
+        menu = self.build_item_menu(nodes)
+        menu.exec_(globalpos)
+
+    # def on_double_click(self):
+    #     """Select the items when double clicking a row"""
+    #
+    #     indices = self.get_indices()
+    #     if not indices:
+    #         return
+    #
+    #     nodes = [dict(i.data(InventoryModel.NodeRole)) for i in indices]
+    #     api.select(nodes)
+
+    def get_indices(self):
+        """Get the selected rows"""
+        selection_model = self.selectionModel()
+        return selection_model.selectedRows()
+
+    def extend_to_children(self, indices):
+        """Extend the indices to the children indices.
+
+        Top-level indices are extended to its children indices. Sub-items
+        are kept as is.
+
+        :param indices: The indices to extend.
+        :type indices: list
+
+        :return: The children indices
+        :rtype: list
+        """
+
+        subitems = set()
+        for i in indices:
+            valid_parent = i.parent().isValid()
+            if valid_parent and i not in subitems:
+                subitems.add(i)
+            else:
+                # is top level node
+                model = i.model()
+                rows = model.rowCount(parent=i)
+                for row in range(rows):
+                    child = model.index(row, 0, parent=i)
+                    subitems.add(child)
+
+        return list(subitems)
+
+    def show_version_dialog(self, items):
+        """Create a dialog with the available versions for the selected file
+
+        :param items: list of items to run the 'set_version' for
+        :type items: list
+
+        :returns: None
+        """
+
+        active = items[-1]
+
+        print active
+
+        # Get available versions for active representation
+        representation_id = io.ObjectId(active['representation'])
+        representation = io.find_one({"_id": representation_id})
+        version = io.find_one({"_id": representation['parent']})
+
+        versions = io.find({"parent": version['parent']},
+                           sort=[("name", 1)])
+        versions = list(versions)
+
+        current_version = active['version']
+
+        # Get index among the listed versions
+        index = len(versions) - 1
+        for i, version in enumerate(versions):
+            if version['name'] == current_version:
+                index = i
+                break
+
+        versions_by_label = dict()
+        labels = []
+        for version in versions:
+            label = api.format_version(version['name'])
+            labels.append(label)
+            versions_by_label[label] = version
+
+        label, state = QtWidgets.QInputDialog.getItem(self,
+                                                      "Set version..",
+                                                      "Set version number "
+                                                      "to",
+                                                      labels,
+                                                      current=index,
+                                                      editable=False)
+        if not state:
+            return
+
+        if label:
+            version = versions_by_label[label]['name']
+            host = api.registered_host()
+            for item in items:
+                host.update(item, version)
+            # refresh model when done
+            self.data_changed.emit()
+
+    def show_remove_warning_dialog(self, items):
+        """Prompt a dialog to inform the user the action will remove items"""
+
+        accept = QtWidgets.QMessageBox.Ok
+        buttons = accept | QtWidgets.QMessageBox.Cancel
+
+        message = ("Are you sure you want to remove "
+                   "{} item(s)".format(len(items)))
+        state = QtWidgets.QMessageBox.question(self, "Are you sure?",
+                                               message,
+                                               buttons=buttons,
+                                               defaultButton=accept)
+
+        if state != accept:
+            return
+
+        host = api.registered_host()
+        for item in items:
+            host.remove(item)
+        self.data_changed.emit()
+
+    def show_in_explorer(self, items):
+        """Open the directory of the first selected item
+
+        :param items: a list of items
+        :type items: list
+
+        :return: None 
+        """
+
+        # last item is the under the mouse
+        item = items[-1]
+
+        # define the path on disk for this file
+        path = get_representation_path(item['representation'])
+        path = os.path.realpath(path)
+        path = os.path.abspath(str(path))
+
+        # show in explorer
+        # todo(roy): Make this cross-OS compatible; now it's windows-only
+        subprocess.Popen('explorer /select,"{0}"'.format(path))
+
+
+class Window(QtWidgets.QDialog):
+    """Scene Inventory window"""
+
+    def __init__(self, parent=None):
+        QtWidgets.QDialog.__init__(self, parent)
+
+        self.resize(1100, 480)
+        self.setWindowTitle(
+            "Scene Inventory 1.0 - %s/%s" % (
+                api.registered_root(),
+                os.getenv("AVALON_PROJECT")))
+        self.setObjectName("SceneInventory")
+        self.setProperty("saveWindowPref", True)  # Maya only property!
+
+        layout = QtWidgets.QVBoxLayout(self)
+
+        # region control
+        control_layout = QtWidgets.QHBoxLayout()
+        filter_label = QtWidgets.QLabel("Search")
+        text_filter = QtWidgets.QLineEdit()
+
+        outdated_only = QtWidgets.QCheckBox("Filter to outdated")
+        outdated_only.setToolTip("Show outdated files only")
+        outdated_only.setChecked(False)
+
+        icon = qta.icon("fa.refresh", color="white")
+        refresh_button = QtWidgets.QPushButton()
+        refresh_button.setIcon(icon)
+
+        control_layout.addWidget(filter_label)
+        control_layout.addWidget(text_filter)
+        control_layout.addWidget(outdated_only)
+        control_layout.addWidget(refresh_button)
+        # endregion control
+
+        model = InventoryModel()
+        proxy = FilterProxyModel()
+        view = View()
+        view.setModel(proxy)
+
+        # apply delegates
+        version_delegate = VersionDelegate(self)
+        column = model.COLUMNS.index("version")
+        view.setItemDelegateForColumn(column, version_delegate)
+
+        layout.addLayout(control_layout)
+        layout.addWidget(view)
+
+        self.filter = text_filter
+        self.outdated_only = outdated_only
+        self.view = view
+        self.refresh_button = refresh_button
+        self.model = model
+        self.proxy = proxy
+
+        # signals
+        text_filter.textChanged.connect(self.proxy.setFilterRegExp)
+        outdated_only.stateChanged.connect(self.proxy.set_filter_enabled)
+        refresh_button.clicked.connect(self.refresh)
+        view.data_changed.connect(self.refresh)
+
+        # proxy settings
+        proxy.setSourceModel(self.model)
+        proxy.setDynamicSortFilter(True)
+        proxy.setFilterCaseSensitivity(QtCore.Qt.CaseInsensitive)
+
+        self.data = {
+            "delegates": {
+                "version": version_delegate
+            }
+        }
+
+        # set some nice default widths for the view
+        self.view.setColumnWidth(0, 250)  # name
+        self.view.setColumnWidth(1, 55)  # version
+        self.view.setColumnWidth(2, 55)  # count
+        self.view.setColumnWidth(3, 150)  # family
+        self.view.setColumnWidth(4, 100)  # namespace
+
+    def refresh(self):
+        with preserve_expanded_rows(tree_view=self.view,
+                                    role=self.model.UniqueRole):
+            with preserve_selection(tree_view=self.view,
+                                    role=self.model.UniqueRole):
+                self.model.refresh()
+
+
+def show(root=None, debug=False, parent=None):
+    """Display Loader GUI
+
+    Arguments:
+        debug (bool, optional): Run loader in debug-mode,
+            defaults to False
+
+    """
+
+    try:
+        module.window.close()
+        del module.window
+    except (RuntimeError, AttributeError):
+        pass
+
+    if debug is True:
+        io.install()
+
+        any_project = next(
+            project for project in io.projects()
+            if project.get("active", True) is not False
+        )
+
+        io.activate_project(any_project)
+
+    with tools_lib.application():
+        window = Window(parent)
+        window.show()
+        window.refresh()
+
+        module.window = window

--- a/avalon/tools/cbsceneinventory/app.py
+++ b/avalon/tools/cbsceneinventory/app.py
@@ -34,18 +34,18 @@ def get_representation_path(representation):
     # template data from context
     data = dict()
     for key, value in context.items():
-        data[key] = value['name']
+        data[key] = value["name"]
 
     # additional parameters
     # see https://getavalon.github.io/2.0/reference/#project-configuration-api
-    data['root'] = api.registered_root()
-    data['silo'] = context['asset']['silo']
-    data['user'] = getpass.getuser()
-    data['app'] = os.environ.get("AVALON_APP", "")
-    data['task'] = os.environ.get("AVALON_TASK", "")
+    data["root"] = api.registered_root()
+    data["silo"] = context["asset"]["silo"]
+    data["user"] = getpass.getuser()
+    data["app"] = os.environ.get("AVALON_APP", "")
+    data["task"] = os.environ.get("AVALON_TASK", "")
 
     # get project template for published files
-    template = context['project']['config']['template']['publish']
+    template = context["project"]["config"]["template"]["publish"]
 
     return template.format(**data)
 
@@ -129,7 +129,7 @@ class View(QtWidgets.QTreeView):
         if not active.parent().isValid():
             assert active in indices, "No active item found in the selection"
 
-            # Push the active one as 'last' to selected
+            # Push the active one as *last* to selected
             indices.remove(active)
             indices.append(active)
 
@@ -177,7 +177,7 @@ class View(QtWidgets.QTreeView):
     def show_version_dialog(self, items):
         """Create a dialog with the available versions for the selected file
 
-        :param items: list of items to run the 'set_version' for
+        :param items: list of items to run the "set_version" for
         :type items: list
 
         :returns: None
@@ -188,27 +188,27 @@ class View(QtWidgets.QTreeView):
         print active
 
         # Get available versions for active representation
-        representation_id = io.ObjectId(active['representation'])
+        representation_id = io.ObjectId(active["representation"])
         representation = io.find_one({"_id": representation_id})
-        version = io.find_one({"_id": representation['parent']})
+        version = io.find_one({"_id": representation["parent"]})
 
-        versions = io.find({"parent": version['parent']},
+        versions = io.find({"parent": version["parent"]},
                            sort=[("name", 1)])
         versions = list(versions)
 
-        current_version = active['version']
+        current_version = active["version"]
 
         # Get index among the listed versions
         index = len(versions) - 1
         for i, version in enumerate(versions):
-            if version['name'] == current_version:
+            if version["name"] == current_version:
                 index = i
                 break
 
         versions_by_label = dict()
         labels = []
         for version in versions:
-            label = api.format_version(version['name'])
+            label = api.format_version(version["name"])
             labels.append(label)
             versions_by_label[label] = version
 
@@ -223,7 +223,7 @@ class View(QtWidgets.QTreeView):
             return
 
         if label:
-            version = versions_by_label[label]['name']
+            version = versions_by_label[label]["name"]
             host = api.registered_host()
             for item in items:
                 host.update(item, version)

--- a/avalon/tools/cbsceneinventory/app.py
+++ b/avalon/tools/cbsceneinventory/app.py
@@ -92,23 +92,11 @@ class View(QtWidgets.QTreeView):
         setversion_action.triggered.connect(
             lambda: self.show_version_dialog(items))
 
-        # select
-        # highlight_icon = qta.icon("fa.hand-o-up", color=DEFAULT_COLOR)
-        # highlight_action = QtWidgets.QAction(highlight_icon,
-        #                                      "Select items", menu, )
-        # highlight_action.triggered.connect(lambda: api.select(items))
-
         # remove
         remove_icon = qta.icon("fa.remove", color=DEFAULT_COLOR)
         remove_action = QtWidgets.QAction(remove_icon, "Remove items", menu)
         remove_action.triggered.connect(
             lambda: self.show_remove_warning_dialog(items))
-
-        # show in explorer
-        explorer_icon = qta.icon("fa.folder-open-o", color=DEFAULT_COLOR)
-        explorer_action = QtWidgets.QAction(explorer_icon,
-                                            "Show in explorer ...", menu)
-        explorer_action.triggered.connect(lambda: self.show_in_explorer(items))
 
         # expand all items
         expandall_action = QtWidgets.QAction(menu, text="Expand all items")
@@ -123,11 +111,7 @@ class View(QtWidgets.QTreeView):
         menu.addAction(setversion_action)
 
         menu.addSeparator()
-        # menu.addAction(highlight_action)
         menu.addAction(remove_action)
-
-        menu.addSeparator()
-        menu.addAction(explorer_action)
 
         menu.addSeparator()
         menu.addAction(expandall_action)
@@ -158,16 +142,6 @@ class View(QtWidgets.QTreeView):
 
         menu = self.build_item_menu(nodes)
         menu.exec_(globalpos)
-
-    # def on_double_click(self):
-    #     """Select the items when double clicking a row"""
-    #
-    #     indices = self.get_indices()
-    #     if not indices:
-    #         return
-    #
-    #     nodes = [dict(i.data(InventoryModel.NodeRole)) for i in indices]
-    #     api.select(nodes)
 
     def get_indices(self):
         """Get the selected rows"""
@@ -278,27 +252,6 @@ class View(QtWidgets.QTreeView):
         for item in items:
             host.remove(item)
         self.data_changed.emit()
-
-    def show_in_explorer(self, items):
-        """Open the directory of the first selected item
-
-        :param items: a list of items
-        :type items: list
-
-        :return: None 
-        """
-
-        # last item is the under the mouse
-        item = items[-1]
-
-        # define the path on disk for this file
-        path = get_representation_path(item['representation'])
-        path = os.path.realpath(path)
-        path = os.path.abspath(str(path))
-
-        # show in explorer
-        # todo(roy): Make this cross-OS compatible; now it's windows-only
-        subprocess.Popen('explorer /select,"{0}"'.format(path))
 
 
 class Window(QtWidgets.QDialog):

--- a/avalon/tools/cbsceneinventory/app.py
+++ b/avalon/tools/cbsceneinventory/app.py
@@ -37,11 +37,9 @@ def get_representation_path(representation):
         data[key] = value['name']
 
     # additional parameters
+    # see https://getavalon.github.io/2.0/reference/#project-configuration-api
     data['root'] = api.registered_root()
     data['silo'] = context['asset']['silo']
-
-    # todo(roy): Implement additional parameters.
-    # see https://getavalon.github.io/2.0/reference/#project-configuration-api
     data['user'] = getpass.getuser()
     data['app'] = os.environ.get("AVALON_APP", "")
     data['task'] = os.environ.get("AVALON_TASK", "")

--- a/avalon/tools/cbsceneinventory/model.py
+++ b/avalon/tools/cbsceneinventory/model.py
@@ -1,0 +1,155 @@
+from collections import defaultdict
+
+from ... import api
+from ... import io
+from ...vendor.Qt import QtCore, QtGui
+from ...vendor import qtawesome as qta
+
+# todo(roy): refactor loading from other tools
+from ..projectmanager.model import (
+    TreeModel, Node
+)
+from ..projectmanager import style
+
+
+class InventoryModel(TreeModel):
+    """The model for the inventory"""
+
+    COLUMNS = ["name", "version", "count", "family", "objectName"]
+
+    OUTDATED_COLOR = QtGui.QColor(235, 30, 30)
+
+    UniqueRole = QtCore.Qt.UserRole + 2     # unique label role
+
+    def data(self, index, role):
+
+        if not index.isValid():
+            return
+
+        if role == QtCore.Qt.FontRole:
+            # Make top-level entries bold
+            parent = index.parent()
+            if not parent.isValid():
+                font = QtGui.QFont()
+                font.setBold(True)
+                return font
+
+        node = index.internalPointer()
+        if role == QtCore.Qt.ForegroundRole:
+            # Set the text color to the OUTDATED_COLOR when the
+            # collected version is not the same as the highest version
+            parent = index.parent()
+            if not parent.isValid():
+                key = self.COLUMNS[index.column()]
+                if key == "version":  # version
+                    version = node.get("version", None)
+                    highest = node.get("highest_version", None)
+                    if version != highest:
+                        return self.OUTDATED_COLOR
+
+        # Add icons
+        if role == QtCore.Qt.DecorationRole:
+            if index.column() == 0:
+                if not index.parent().isValid(): # group-item
+                    return qta.icon("fa.folder", color=style.default)
+                if index.column() == 0:
+                    return qta.icon("fa.folder-o", color=style.default)
+
+        if role == self.UniqueRole:
+            node = index.internalPointer()
+            return node['representation'] + node.get("objectName", "<none>")
+
+        return super(InventoryModel, self).data(index, role)
+
+    def refresh(self):
+        """Refresh the model"""
+
+        host = api.registered_host()
+        items = host.ls()
+        self.clear()
+        self.add_items(items)
+
+    def add_items(self, items):
+        """Add the items to the model.
+
+        The items should be formatted similar to `api.ls()` returns, an item
+        is then represented as:
+            {"filename_v001.ma": [full/filename/of/loaded/filename_v001.ma,
+                                  full/filename/of/loaded/filename_v001.ma],
+             "nodetype" : "reference",
+             "node": "referenceNode1"}
+
+        Note: When performing an additional call to `add_items` it will *not*
+            group the new items with previously existing item groups of the
+            same type.
+
+        :param group_items: the items to be processed as returned by `ls()`
+        :type group_items: list
+
+        :return: root node which has children added based on the data
+        :rtype: node.Node
+        """
+
+        # construct the generator results
+        items = list(items)
+
+        self.beginResetModel()
+
+        # Group by representation
+        grouped = defaultdict(list)
+        for item in items:
+            grouped[item['representation']].append(item)
+
+        # Add to model
+        for representation_id, group_items in sorted(grouped.items()):
+
+            # Get parenthood per group
+            representation = io.find_one({
+                "_id": io.ObjectId(representation_id)
+            })
+            version = io.find_one({"_id": representation["parent"]})
+            subset = io.find_one({"_id": version["parent"]})
+            asset = io.find_one({"_id": subset["parent"]})
+
+            # Get the primary family
+            family = version['data'].get("family", "")
+            if not family:
+                families = version['data'].get("families", [])
+                if families:
+                    family = families[0]
+
+            # Store the highest available version so the model can know
+            # whether current version is currently up-to-date.
+            highest_version = io.find_one({
+                "type": "version",
+                "parent": subset["_id"]
+            }, sort=[("name", -1)])
+
+            # create the group header
+            group_node = Node()
+            group_node["name"] = "%s_%s: (%s)" % (asset['name'],
+                                                  subset['name'],
+                                                  representation["name"])
+            group_node["representation"] = representation_id
+            group_node["version"] = version['name']
+            group_node["highest_version"] = highest_version['name']
+            group_node["family"] = family
+            group_node["count"] = len(group_items)
+            self.add_child(group_node)
+
+            for item in group_items:
+                item_node = Node()
+                item_node.update(item)
+
+                # set name from namespace (unique identifier for the `item`
+                # todo(marcus): should this remapping be necessary?
+                item_node["name"] = item["namespace"]
+
+                # store the current version on the item
+                item_node["version"] = version['name']
+
+                self.add_child(item_node, parent=group_node)
+
+        self.endResetModel()
+
+        return self._root_node

--- a/avalon/tools/cbsceneinventory/proxy.py
+++ b/avalon/tools/cbsceneinventory/proxy.py
@@ -1,0 +1,80 @@
+import re
+from ...vendor.Qt import QtCore
+
+
+class RecursiveSortFilterProxyModel(QtCore.QSortFilterProxyModel):
+    """Filters to the regex if any of the children matches allow parent"""
+
+    def filterAcceptsRow(self, row, parent):
+
+        regex = self.filterRegExp()
+        if not regex.isEmpty():
+            pattern = regex.pattern()
+            pattern = re.escape(pattern)
+            model = self.sourceModel()
+            source_index = model.index(row, self.filterKeyColumn(), parent)
+            if source_index.isValid():
+
+                # Check current index itself
+                key = model.data(source_index, self.filterRole())
+                if re.search(pattern, key, re.IGNORECASE):
+                    return True
+
+                # Check children
+                rows = model.rowCount(source_index)
+                for i in range(rows):
+                    if self.filterAcceptsRow(i, source_index):
+                        return True
+
+                # Otherwise filter it
+                return False
+
+        return super(RecursiveSortFilterProxyModel,
+                     self).filterAcceptsRow(row, parent)
+
+
+class FilterProxyModel(RecursiveSortFilterProxyModel):
+    """Filter model to where key column's value is in the filtered tags"""
+
+    def __init__(self, *args, **kwargs):
+        super(FilterProxyModel, self).__init__(*args, **kwargs)
+        self._enabled = False
+
+    def set_filter_enabled(self, state):
+        state = bool(state)
+
+        if state != self._enabled:
+            self._enabled = bool(state)
+            self.invalidateFilter()
+
+    def filterAcceptsRow(self, source_row, source_parent):
+
+        state = super(FilterProxyModel, self).filterAcceptsRow(source_row,
+                                                               source_parent)
+        # If not allowed by parent class then disallow it, otherwise
+        # continue filtering
+        if not state:
+            return False
+
+        if not self._enabled:
+            return True
+
+        model = self.sourceModel()
+        column = self.filterKeyColumn()
+        index = model.index(source_row, column, source_parent)
+
+        # Filter to those that have the different version numbers
+        node = index.internalPointer()
+        version = node.get("version", None)
+        highest = node.get("highest_version", None)
+
+        # Always allow indices that have no version data at all
+        if version is None and highest is None:
+            return True
+
+        # If either a version or highest is present but not the other
+        # consider the item invalid
+        if version is None or highest is None:
+            return False
+
+        return version != highest

--- a/avalon/tools/projectmanager/model.py
+++ b/avalon/tools/projectmanager/model.py
@@ -56,7 +56,7 @@ class Node(dict):
             siblings = self.parent().children()
             return siblings.index(self)
 
-    def addChild(self, child):
+    def add_child(self, child):
         """Add a child to this node"""
         child._parent = self
         self._children.append(child)
@@ -167,7 +167,7 @@ class TreeModel(QtCore.QAbstractItemModel):
         if parent is None:
             parent = self._root_node
 
-        parent.addChild(node)
+        parent.add_child(node)
 
     def column_name(self, column):
         """Return column key by index"""


### PR DESCRIPTION
This PR implements a new Scene Inventory to replace the current "manager".

It currently looks like this:

![scene_inventory](https://user-images.githubusercontent.com/2439881/27481475-061f2386-581d-11e7-87bd-27a70a84a367.jpg)

### Features

- Groups the same representations (asset/subset/version/representation) into a collapsible item. As such many of the same items are shown together.
- Manage versions or remove many items at once by selecting them simultaneously.
- Set a specific version for many items at once.
- Find the actual file on disk (by "exploring" it; currently windows-only)
