### PR TITLE
Fix #206, remove registry of formats, return instance from maya Creator.

### DIFF
--- a/avalon/__init__.py
+++ b/avalon/__init__.py
@@ -7,7 +7,6 @@ the currently held state of avalon-core.
 
 """
 
-_registered_formats = list()
 _registered_plugins = dict()
 _registered_plugin_paths = dict()
 _registered_root = {"_": ""}

--- a/avalon/api.py
+++ b/avalon/api.py
@@ -28,7 +28,6 @@ from .pipeline import (
 
     register_root,
     register_host,
-    register_format,
     register_plugin_path,
     register_plugin,
 
@@ -38,7 +37,6 @@ from .pipeline import (
 
     deregister_plugin,
     deregister_plugin_path,
-    deregister_format,
 )
 
 from .lib import (
@@ -64,7 +62,6 @@ __all__ = [
     "discover",
 
     "register_host",
-    "register_format",
     "register_plugin_path",
     "register_plugin",
     "register_root",
@@ -75,7 +72,6 @@ __all__ = [
 
     "deregister_plugin",
     "deregister_plugin_path",
-    "deregister_format",
 
     "format_staging_dir",
     "format_version",

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -24,7 +24,6 @@ def install(config):
 
     """
 
-    _register_formats()
     _register_callbacks()
     _install_menu()
 
@@ -46,10 +45,6 @@ def uninstall():
     pyblish.deregister_host("mayabatch")
     pyblish.deregister_host("mayapy")
     pyblish.deregister_host("maya")
-
-    api.deregister_format(".ma")
-    api.deregister_format(".mb")
-    api.deregister_format(".abc")
 
 
 def _install_menu():
@@ -151,13 +146,6 @@ def _uninstall_menu():
     if menu:
         menu.deleteLater()
         del(menu)
-
-
-def _register_formats():
-    # These file-types will appear in the Loader GUI
-    api.register_format(".ma")
-    api.register_format(".mb")
-    api.register_format(".abc")
 
 
 def containerise(name,

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -316,6 +316,8 @@ class Creator(api.Creator):
         instance = cmds.sets(nodes, name=self.name)
         lib.imprint(instance, self.data)
 
+        return instance
+
 
 def create(name, asset, family, options=None, data=None):
     """Create a new instance

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -12,7 +12,6 @@ from . import (
     _registered_host,
     _registered_root,
     _registered_config,
-    _registered_formats,
     _registered_plugins,
     _registered_plugin_paths,
 )
@@ -333,22 +332,6 @@ def registered_root():
         _registered_root["_"] or
         os.getenv("AVALON_PROJECTS") or ""
     ).replace("\\", "/")
-
-
-def register_format(format):
-    """Register a supported format
-
-    A supported format is used to determine which of any available
-    representations are relevant to the currently registered host.
-
-    """
-
-    _registered_formats.append(format)
-
-
-def deregister_format(format):
-    """Deregister a supported format"""
-    _registered_formats.remove(format)
 
 
 def register_host(host):

--- a/avalon/tools/cbloader/widgets.py
+++ b/avalon/tools/cbloader/widgets.py
@@ -118,7 +118,11 @@ class SubsetWidget(QtWidgets.QWidget):
         # Run the loader for all selected indices, for those that have the
         # same representation available
         selection = self.view.selectionModel()
-        rows = selection.selectedRows()
+        rows = selection.selectedRows(column=0)
+
+        # Ensure active point index is also used as first column so we can
+        # correctly push it to the end in the rows list.
+        point_index = point_index.sibling(point_index.row(), 0)
 
         # Ensure point index is run first.
         try:


### PR DESCRIPTION
- Remove registry of formats (which was deprecated and unused currently)
- Fix #206: loader incorrectly loading twice
- Return the instance from `maya.pipeline.Creator.process()` so inheriting subclasses can override _process_, call `super` and then perform additional things on the created instance node.