### PR TITLE
Implement AVALON_LABEL

### DIFF
--- a/avalon/api.py
+++ b/avalon/api.py
@@ -25,6 +25,7 @@ from .pipeline import (
     Loader,
     Creator,
     discover,
+    session,
 
     register_root,
     register_host,
@@ -62,6 +63,7 @@ __all__ = [
     "Loader",
     "Creator",
     "discover",
+    "session",
 
     "register_host",
     "register_format",

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -12,7 +12,7 @@ from ..vendor import six
 from ..vendor.Qt import QtCore, QtWidgets
 
 self = sys.modules[__name__]
-self._menu = "avaloncore"  # Unique name of menu, for uninstall purposes
+self._menu = api.session["label"] + "menu"  # Unique name of menu
 self._events = dict()  # Registered Maya callbacks
 self._parent = None  # Main Window
 
@@ -68,7 +68,7 @@ def _install_menu():
 
     def deferred():
         cmds.menu(self._menu,
-                  label="Avalon",
+                  label=api.session["label"],
                   tearOff=True,
                   parent="MayaWindow")
 


### PR DESCRIPTION
Also an initial pass of #189, Session

`AVALON_LABEL` is used by the menu item in the hosts. The intent is to enable studios to customise the look of it, to merge better with their studio. I'm calling it `Mindbender` for the Mindbender guys.

I've also made a first pass of `api.session` which doesn't make any functional changes, apart from collecting variables used in `pipeline.py`. The goal is to see whether we can reference all state from this one dictionary. At that point, we can start having a look at making so that we can instantiate a new one within the same process, so as to enable #107 and simplified testing amongst other things.