### PR TITLE
Add extra `cbloader` features: order, icons and tips!

### DIFF
--- a/avalon/io.py
+++ b/avalon/io.py
@@ -27,10 +27,10 @@ def install():
         self._uri, serverSelectionTimeoutMS=self._timeout)
 
     # Backwards compatibility
-    if "avalon" in self._client.database_names():
-        self._database = self._client["avalon"]
-    else:
+    if "mindbender" in self._client.database_names():
         self._database = self._client["mindbender"]
+    else:
+        self._database = self._client["avalon"]
 
     for retry in range(3):
         try:

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -151,6 +151,7 @@ class Loader(list):
 
     families = list()
     representations = list()
+    order = 0
 
     def __init__(self, context):
         template = context["project"]["config"]["template"]["publish"]

--- a/avalon/tools/cbloader/widgets.py
+++ b/avalon/tools/cbloader/widgets.py
@@ -117,13 +117,13 @@ class SubsetWidget(QtWidgets.QWidget):
                 action.setToolTip(tip)
                 action.setStatusTip(tip)
 
-            # Support font-awesome icons using the `.icon` and `.icon_color`
+            # Support font-awesome icons using the `.icon` and `.color`
             # attributes on plug-ins.
             icon = getattr(loader, "icon", None)
             if icon is not None:
                 try:
                     key = "fa.{0}".format(icon)
-                    color = getattr(loader, "icon_color", "white")
+                    color = getattr(loader, "color", "white")
                     action.setIcon(qtawesome.icon(key, color=color))
                 except Exception as e:
                     print("Unable to set icon for loader "

--- a/avalon/tools/cbloader/widgets.py
+++ b/avalon/tools/cbloader/widgets.py
@@ -90,9 +90,14 @@ class SubsetWidget(QtWidgets.QWidget):
             self.echo("No compatible loaders available for this version.")
             return
 
+        def sorter(value):
+            """Sort the Loaders by their order and then their name"""
+            Plugin = value[1]
+            return Plugin.order, Plugin.__name__
+
         # List the available loaders
         menu = QtWidgets.QMenu(self)
-        for representation, loader in loaders:
+        for representation, loader in sorted(loaders, key=sorter):
 
             # Label
             label = getattr(loader, "label", None)

--- a/avalon/tools/cbloader/widgets.py
+++ b/avalon/tools/cbloader/widgets.py
@@ -1,5 +1,6 @@
 import datetime
 import pprint
+import inspect
 
 from ...vendor.Qt import QtWidgets, QtCore, QtGui
 from ... import io
@@ -103,6 +104,13 @@ class SubsetWidget(QtWidgets.QWidget):
 
             action = QtWidgets.QAction(label, menu)
             action.setData((representation, loader))
+
+            # Add tooltip and statustip from Loader docstring
+            tip = inspect.getdoc(loader)
+            if tip:
+                action.setToolTip(tip)
+                action.setStatusTip(tip)
+
             menu.addAction(action)
 
         # Show the context action menu

--- a/avalon/tools/cbloader/widgets.py
+++ b/avalon/tools/cbloader/widgets.py
@@ -3,6 +3,7 @@ import pprint
 import inspect
 
 from ...vendor.Qt import QtWidgets, QtCore, QtGui
+from ...vendor import qtawesome
 from ... import io
 from ... import api
 
@@ -115,6 +116,18 @@ class SubsetWidget(QtWidgets.QWidget):
             if tip:
                 action.setToolTip(tip)
                 action.setStatusTip(tip)
+
+            # Support font-awesome icons using the `.icon` and `.icon_color`
+            # attributes on plug-ins.
+            icon = getattr(loader, "icon", None)
+            if icon is not None:
+                try:
+                    key = "fa.{0}".format(icon)
+                    color = getattr(loader, "icon_color", "white")
+                    action.setIcon(qtawesome.icon(key, color=color))
+                except Exception as e:
+                    print("Unable to set icon for loader "
+                          "{}: {}".format(loader, e))
 
             menu.addAction(action)
 


### PR DESCRIPTION
Add extra features to `avalon.tools.cbloader`:

- Loaders can now be sorted by an `.order` attribute on the Loader plug-in. This will influence how they are listed under the right-mouse context menu in the loader.
- Loaders can now have custom icons using a `.icon` string attribute, these should be font-awesome icon names.
- Additionally the icons can be colored using a `.icon_color` attribute. A string specifying a Qt color, this can also be hex formatted.
- The Loader's docstring is now also added the action's tool- and status-tip.

### Functionality

```python
class CustomLoader(api.Loader):
    """This docstring is the tooltip AND statustip!"""
    
    families = ["colorbleed.model"]
    representations = ["ma"]
    label = "Custom label"      # label shown on the action
    order = -10                 # sorting order of the actions menu for loaders
    icon = "code-fork"          # font-awesome icon name
    icon_color = "orange"       # qt color name or hex formatted string
```

### Example

Here's an example image with corresponding loaders in the code below.

![actions_new](https://user-images.githubusercontent.com/2439881/27549486-61076052-5a9c-11e7-9c7a-dafd49b04fc9.png)

```python
class ModelLoader(LogDebugLoader):
    """Load a model"""
    families = ["colorbleed.model"]
    representations = ["ma"]
    label = "Reference model"
    order = -10
    icon = "code-fork"
    icon_color = "orange"


class GpuCacheLoader(LogDebugLoader):
    """Import a GPU cache"""
    families = ["colorbleed.model", "colorbleed.animation"]
    representations = ["abc"]
    label = "Import GPU cache"
    order = -1
    icon = "download"
    icon_color = "white"
```

