### PR TITLE
Add custom asset icons support in the AssetWidget

### DIFF
--- a/avalon/io.py
+++ b/avalon/io.py
@@ -27,10 +27,10 @@ def install():
         self._uri, serverSelectionTimeoutMS=self._timeout)
 
     # Backwards compatibility
-    if "avalon" in self._client.database_names():
-        self._database = self._client["avalon"]
-    else:
+    if "mindbender" in self._client.database_names():
         self._database = self._client["mindbender"]
+    else:
+        self._database = self._client["avalon"]
 
     for retry in range(3):
         try:

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -151,6 +151,7 @@ class Loader(list):
 
     families = list()
     representations = list()
+    order = 0
 
     def __init__(self, context):
         template = context["project"]["config"]["template"]["publish"]

--- a/avalon/tools/cbloader/widgets.py
+++ b/avalon/tools/cbloader/widgets.py
@@ -90,9 +90,14 @@ class SubsetWidget(QtWidgets.QWidget):
             self.echo("No compatible loaders available for this version.")
             return
 
+        def sorter(value):
+            """Sort the Loaders by their order and then their name"""
+            Plugin = value[1]
+            return Plugin.order, Plugin.__name__
+
         # List the available loaders
         menu = QtWidgets.QMenu(self)
-        for representation, loader in loaders:
+        for representation, loader in sorted(loaders, key=sorter):
 
             # Label
             label = getattr(loader, "label", None)

--- a/avalon/tools/cbloader/widgets.py
+++ b/avalon/tools/cbloader/widgets.py
@@ -1,5 +1,6 @@
 import datetime
 import pprint
+import inspect
 
 from ...vendor.Qt import QtWidgets, QtCore, QtGui
 from ... import io
@@ -103,6 +104,13 @@ class SubsetWidget(QtWidgets.QWidget):
 
             action = QtWidgets.QAction(label, menu)
             action.setData((representation, loader))
+
+            # Add tooltip and statustip from Loader docstring
+            tip = inspect.getdoc(loader)
+            if tip:
+                action.setToolTip(tip)
+                action.setStatusTip(tip)
+
             menu.addAction(action)
 
         # Show the context action menu

--- a/avalon/tools/cbloader/widgets.py
+++ b/avalon/tools/cbloader/widgets.py
@@ -3,6 +3,7 @@ import pprint
 import inspect
 
 from ...vendor.Qt import QtWidgets, QtCore, QtGui
+from ...vendor import qtawesome
 from ... import io
 from ... import api
 
@@ -115,6 +116,18 @@ class SubsetWidget(QtWidgets.QWidget):
             if tip:
                 action.setToolTip(tip)
                 action.setStatusTip(tip)
+
+            # Support font-awesome icons using the `.icon` and `.icon_color`
+            # attributes on plug-ins.
+            icon = getattr(loader, "icon", None)
+            if icon is not None:
+                try:
+                    key = "fa.{0}".format(icon)
+                    color = getattr(loader, "icon_color", "white")
+                    action.setIcon(qtawesome.icon(key, color=color))
+                except Exception as e:
+                    print("Unable to set icon for loader "
+                          "{}: {}".format(loader, e))
 
             menu.addAction(action)
 

--- a/avalon/tools/projectmanager/widget.py
+++ b/avalon/tools/projectmanager/widget.py
@@ -243,17 +243,32 @@ class AssetModel(TreeModel):
             node = index.internalPointer()
             if column == self.Name:
 
-                # define color, including darker state
-                # when the asset is deprecated
-                color = style.default
+                # Allow a custom icon and custom icon color to be defined
+                data = node["_document"]["data"]
+                icon = data.get("icon", None)
+                color = data.get("icon_color", style.default)
+
+                if icon is None:
+                    # Use default icons if no custom one is specified.
+                    # If it has children show a full folder, otherwise
+                    # show an open folder
+                    has_children = self.rowCount(index) > 0
+                    icon = "folder" if has_children else "folder-o"
+
+                # Make the color darker when the asset is deprecated
                 if node.get("deprecated", False):
                     color = QtGui.QColor(color).darker(250)
 
-                # If it has children show a full folder
-                if self.rowCount(index) > 0:
-                    return awesome.icon("fa.folder", color=color)
-                else:
-                    return awesome.icon("fa.folder-o", color=color)
+                try:
+                    key = "fa.{0}".format(icon)  # font-awesome key
+                    icon = awesome.icon(key, color=color)
+                    return icon
+                except Exception as exception:
+                    # Log an error message instead of erroring out completely
+                    # when the icon couldn't be created (e.g. invalid name)
+                    log.error(exception)
+
+                return
 
         if role == QtCore.Qt.ForegroundRole:        # font color
 

--- a/avalon/tools/projectmanager/widget.py
+++ b/avalon/tools/projectmanager/widget.py
@@ -246,7 +246,7 @@ class AssetModel(TreeModel):
                 # Allow a custom icon and custom icon color to be defined
                 data = node["_document"]["data"]
                 icon = data.get("icon", None)
-                color = data.get("icon_color", style.default)
+                color = data.get("color", style.default)
 
                 if icon is None:
                     # Use default icons if no custom one is specified.


### PR DESCRIPTION
This implements custom icons support in the asset widget, as such the `cbloader` and `projectmanager` will now show the custom icons as set in the database.

The data supported is:

```
asset["data"]["icon"] = "gear"        # a font-awesome icon name
asset["data"]["icon_color"] = "red"   # a qt color name or hex formatted string
```

Here's an example of the above:

![asset_icon](https://user-images.githubusercontent.com/2439881/27550394-c4ea2bb0-5a9f-11e7-8f4c-be8f03d5586a.png)

---

This is actually a single commit, specifically: 
https://github.com/Colorbleed/core/commit/54c81de29bb29eb6231cded88118fbc551a27924
But this was written on top of the code base of #211 as such this currently shows more commits until that PR is merged.