### PR TITLE
Simplify Loader and the arguments for `host.load`

### DIFF
--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -274,6 +274,11 @@ def load(Loader,
         "representation": representation,
     }
 
+    # Ensure data is a dictionary when no explicit data provided
+    if data is None:
+        data = dict()
+    assert isinstance(data, dict), "Data must be a dictionary"
+
     name = name or subset["name"]
     namespace = namespace or lib.unique_namespace(
         asset["name"] + "_",

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -243,19 +243,19 @@ def load(Loader,
          representation,
          name=None,
          namespace=None,
-         post_process=True,
-         preset=None):
+         data=None):
     """Load asset via database
 
     Arguments:
         Loader (api.Loader): The loader to process in host Maya.
         representation (dict, io.ObjectId or str): Address to representation
+        name (str, optional): Use pre-defined name
+        namespace (str, optional): Use pre-defined namespace
+        data (dict, optional): Additional settings dictionary
 
     """
 
     assert representation is not None, "This is a bug"
-
-    preset = preset or os.environ["AVALON_TASK"]
 
     if isinstance(representation, (six.string_types, io.ObjectId)):
         representation = io.find_one({"_id": io.ObjectId(str(representation))})
@@ -272,7 +272,6 @@ def load(Loader,
         "subset": subset,
         "version": version,
         "representation": representation,
-        "preset": {"name": preset}
     }
 
     name = name or subset["name"]
@@ -290,13 +289,10 @@ def load(Loader,
 
     try:
         loader = Loader(context)
-        loader.process(name, namespace, context)
+        loader.process(name, namespace, context, data)
     except OSError as e:
         print("WARNING: %s" % e)
         return list()
-
-    if post_process:
-        loader.post_process(name, namespace, context)
 
     return containerise(
         name=name,

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -173,10 +173,7 @@ class Loader(list):
 
         self.fname = fname
 
-    def process(self, name, namespace, context):
-        pass
-
-    def post_process(self, name, namespace, context):
+    def process(self, name, namespace, context, data):
         pass
 
 
@@ -513,8 +510,7 @@ def default_host():
              representation=None,
              name=None,
              namespace=None,
-             post_process=None,
-             preset=None):
+             data=None):
         return None
 
     def create(family):
@@ -566,8 +562,7 @@ def debug_host():
              representation=None,
              name=None,
              namespace=None,
-             post_process=None,
-             preset=None):
+             data=None):
         sys.stdout.write(pformat({
             "loader": Loader,
             "representation": representation


### PR DESCRIPTION

- Remove "preset" argument in `host.load`
- Remove "post_process" argument in `host.load`
- Add "data" argument in `host.load`; for additional settings of a loader

Note that already implemented Loaders in configs need to now also take in the "data" as argument into `Loader.process`.