### PR TITLE
Fix manager

### DIFF
--- a/avalon/tools/cbsceneinventory/app.py
+++ b/avalon/tools/cbsceneinventory/app.py
@@ -208,7 +208,7 @@ class View(QtWidgets.QTreeView):
         versions_by_label = dict()
         labels = []
         for version in versions:
-            label = api.format_version(version["name"])
+            label = "v{0:03d}".format(version["name"])
             labels.append(label)
             versions_by_label[label] = version
 


### PR DESCRIPTION
I'm leaving the responsibility of formatting the version number to the manager itself here. Can see how it could be useful to reuse the one you use in the Loader, let's think about what the pros and cons is of that.

For now, this should be fine I think.