### PR TITLE
Initial draft of event mechanism

### DIFF
--- a/avalon/__init__.py
+++ b/avalon/__init__.py
@@ -12,3 +12,4 @@ _registered_plugin_paths = dict()
 _registered_root = {"_": ""}
 _registered_host = {"_": None}
 _registered_config = {"_": None}
+_registered_event_handlers = dict()

--- a/avalon/api.py
+++ b/avalon/api.py
@@ -20,6 +20,9 @@ from .pipeline import (
     discover,
     session,
 
+    on,
+    emit,
+
     publish,
 
     loaders_by_representation,
@@ -53,6 +56,9 @@ __all__ = [
     "Creator",
     "discover",
     "session",
+
+    "on",
+    "emit",
 
     "publish",
 

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -353,6 +353,7 @@ def on(event, callback):
         ...    print("Init happened")
         ...
         >>> on("init", on_init)
+        >>> del on_init
 
     Arguments:
         event (str): Name of event
@@ -368,6 +369,22 @@ def on(event, callback):
 
 
 def emit(event):
+    """Trigger an `event`
+
+    Example:
+        >>> def on_init():
+        ...    print("Init happened")
+        ...
+        >>> on("init", on_init)
+        >>> emit("init")
+        Init happened
+        >>> del on_init
+
+    Arguments:
+        event (str): Name of event
+
+    """
+
     callbacks = _registered_event_handlers.get(event, set())
 
     for callback in callbacks:

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -4,7 +4,9 @@ import os
 import sys
 import types
 import logging
+import weakref
 import inspect
+import traceback
 import importlib
 
 from . import (
@@ -16,6 +18,7 @@ from . import (
     _registered_config,
     _registered_plugins,
     _registered_plugin_paths,
+    _registered_event_handlers,
 )
 
 from .vendor import six
@@ -338,6 +341,40 @@ def plugin_from_module(superclass, module):
         types.append(obj)
 
     return types
+
+
+def on(event, callback):
+    """Call `callback` on `event`
+
+    Register `callback` to be run when `event` occurs.
+
+    Example:
+        >>> def on_init():
+        ...    print("Init happened")
+        ...
+        >>> on("init", on_init)
+
+    Arguments:
+        event (str): Name of event
+        callback (callable): Any callable
+
+    """
+
+    if event not in _registered_event_handlers:
+        _registered_event_handlers[event] = weakref.WeakSet()
+
+    events = _registered_event_handlers[event]
+    events.add(callback)
+
+
+def emit(event):
+    callbacks = _registered_event_handlers.get(event, set())
+
+    for callback in callbacks:
+        try:
+            callback()
+        except Exception:
+            lib.logger.debug(traceback.format_exc())
 
 
 def register_plugin(superclass, obj):


### PR DESCRIPTION
At the moment, Avalon adds `mbId` to specific nodes relevant to how Mindbender does their shading.

I've separated this out into Mindbender's configuration and implemented an event framework for hooking things back into the core.

```python
from avalon import api

def on_new():
  print("A new scene was created!")

api.on("new", on_new)
api.emit("new")
# A new scene was created!
```

By default, these trigger on Maya `init`, `new` and `save`

- [Example use](https://github.com/mindbender-studio/config/blob/38ab00bdf662ffdeed24c3f51e147e28c83b6354/polly/maya/__init__.py#L27)

Let me know your thoughts @aardschok.