### PR TITLE
Sentry

### DIFF
--- a/avalon/__init__.py
+++ b/avalon/__init__.py
@@ -13,3 +13,5 @@ _registered_root = {"_": ""}
 _registered_host = {"_": None}
 _registered_config = {"_": None}
 _registered_event_handlers = dict()
+
+Session = {}

--- a/avalon/api.py
+++ b/avalon/api.py
@@ -20,6 +20,9 @@ from .pipeline import (
     discover,
     Session,
 
+    # Deprectated
+    Session as session,
+
     on,
     emit,
 
@@ -56,6 +59,7 @@ __all__ = [
     "Creator",
     "discover",
     "Session",
+    "session",
 
     "on",
     "emit",

--- a/avalon/api.py
+++ b/avalon/api.py
@@ -18,7 +18,7 @@ from .pipeline import (
     Loader,
     Creator,
     discover,
-    session,
+    Session,
 
     on,
     emit,
@@ -55,7 +55,7 @@ __all__ = [
     "Loader",
     "Creator",
     "discover",
-    "session",
+    "Session",
 
     "on",
     "emit",

--- a/avalon/inventory.py
+++ b/avalon/inventory.py
@@ -20,7 +20,7 @@ import sys
 import copy
 import json
 
-from avalon import schema, io
+from avalon import schema, io, api
 from avalon.vendor import toml
 
 self = sys.modules[__name__]
@@ -132,8 +132,6 @@ def save(name, config, inventory):
 
     """
 
-    io.activate_project(name)
-
     config = copy.deepcopy(config)
     inventory = copy.deepcopy(inventory)
 
@@ -174,7 +172,6 @@ def init(name):
 
     """
 
-    io.activate_project(name)
     project = io.find_one({"type": "project"})
 
     if project is not None:
@@ -197,7 +194,6 @@ def load(name):
 
     print("Loading .inventory.toml and .config.toml..")
 
-    io.activate_project(name)
     project = io.find_one({"type": "project"})
 
     if project is None:
@@ -429,6 +425,7 @@ def _cli():
     name = os.path.basename(root)
 
     if any([kwargs.load, kwargs.save, kwargs.upload, kwargs.init]):
+        os.environ["AVALON_PROJECT"] = name
         io.install()
 
     if kwargs.init:

--- a/avalon/io.py
+++ b/avalon/io.py
@@ -5,7 +5,7 @@ import sys
 import time
 import functools
 
-from . import schema, lib
+from . import schema, lib, Session
 
 # Third-party dependencies
 import pymongo
@@ -32,17 +32,12 @@ __all__ = [
     "parenthood",
 ]
 
-AVALON_DB = os.getenv("AVALON_DB", "avalon")
-AVALON_TIMEOUT = int(os.getenv("AVALON_TIMEOUT", "1000"))
-AVALON_MONGO = os.getenv("AVALON_MONGO", "mongodb://localhost:27017")
-
 self = sys.modules[__name__]
 self._client = None
 self._database = None
 self._collection = None
 self._is_installed = False
 self._is_activated = False
-self._timeout = AVALON_TIMEOUT
 
 
 def install():
@@ -50,8 +45,11 @@ def install():
     if self._is_installed:
         return
 
+    Session.update(_from_environment())
+
+    timeout = Session["AVALON_TIMEOUT"]
     self._client = pymongo.MongoClient(
-        AVALON_MONGO, serverSelectionTimeoutMS=self._timeout)
+        Session["AVALON_MONGO"], serverSelectionTimeoutMS=timeout)
 
     for retry in range(3):
         try:
@@ -61,17 +59,17 @@ def install():
         except Exception:
             lib.logger.error("Retrying..")
             time.sleep(1)
-            self._timeout *= 1.5
+            timeout *= 1.5
 
         else:
             break
 
     else:
         raise IOError("ERROR: Couldn't connect to %s in "
-                      "less than %.3f ms" % (AVALON_MONGO, self._timeout))
+                      "less than %.3f ms" % (Session["AVALON_MONGO"], timeout))
 
     lib.logger.info("Connected to server, delay %.3f s" % (time.time() - t1))
-    self._database = self._client[AVALON_DB]
+    self._database = self._client[Session["AVALON_DB"]]
     self._is_installed = True
 
 
@@ -89,6 +87,46 @@ def uninstall():
     self._is_activated = False
 
 
+def _from_environment():
+    return {
+        item[0]: os.getenv(item[0], item[1])
+        for item in (
+            # Root directory of projects on disk
+            ("AVALON_PROJECTS", None),
+
+            # Name of current Project
+            ("AVALON_PROJECT", None),
+
+            # Name of current Asset
+            ("AVALON_ASSET", None),
+
+            # Name of current Config
+            # TODO(marcus): Establish a suitable default config
+            ("AVALON_CONFIG", "no_config"),
+
+            # Name of Avalon in graphical user interfaces
+            # Use this to customise the visual appearance of Avalon
+            # to better integrate with your surrounding pipeline
+            ("AVALON_LABEL", "Avalon"),
+
+            # Used during any connections to the outside world
+            ("AVALON_TIMEOUT", "1000"),
+
+            # Address to Asset Database
+            ("AVALON_MONGO", "mongodb://localhost:27017"),
+
+            # Name of database used in MongoDB
+            ("AVALON_DB", "avalon"),
+
+            # Address to Sentry
+            ("AVALON_SENTRY", None),
+
+            # Enable features not necessarily stable, at the user's own risk
+            ("AVALON_EARLY_ADOPTER", None),
+        )
+    }
+
+
 def active_project():
     """Return the name of the active project"""
     return self._collection.name
@@ -96,14 +134,7 @@ def active_project():
 
 def activate_project(project):
     """Establish a connection to a given collection within the database"""
-    try:
-        # Support passing dictionary object
-        project = project["name"]
-    except TypeError:
-        pass
-
-    self._collection = self._database[project]
-    self._is_activated = True
+    print("io.activate_project is deprecated")
 
 
 def requires_install(f):
@@ -148,7 +179,6 @@ def projects():
             yield document
 
 
-@requires_activation
 def locate(path):
     """Traverse a hierarchy from top-to-bottom
 
@@ -195,64 +225,60 @@ def locate(path):
     return parent
 
 
-@requires_activation
 def insert_one(item):
     assert isinstance(item, dict), "item must be of type <dict>"
     schema.validate(item)
-    return self._collection.insert_one(item)
+    return self._database[Session["AVALON_PROJECT"]].insert_one(item)
 
 
-@requires_activation
 def find(filter, projection=None, sort=None):
-    return self._collection.find(
+    return self._database[Session["AVALON_PROJECT"]].find(
         filter=filter,
         projection=projection,
         sort=sort
     )
 
 
-@requires_activation
 def find_one(filter, projection=None, sort=None):
     assert isinstance(filter, dict), "filter must be <dict>"
 
-    return self._collection.find_one(
+    return self._database[Session["AVALON_PROJECT"]].find_one(
         filter=filter,
         projection=projection,
         sort=sort
     )
 
 
-@requires_activation
 def save(*args, **kwargs):
-    return self._collection.save(*args, **kwargs)
+    return self._database[Session["AVALON_PROJECT"]].save(
+        *args, **kwargs)
 
 
-@requires_activation
 def replace_one(filter, replacement):
-    return self._collection.replace_one(filter, replacement)
+    return self._database[Session["AVALON_PROJECT"]].replace_one(
+        filter, replacement)
 
 
-@requires_activation
 def update_many(filter, update):
-    return self._collection.update_many(filter, update)
+    return self._database[Session["AVALON_PROJECT"]].update_many(
+        filter, update)
 
 
-@requires_activation
 def distinct(*args, **kwargs):
-    return self._collection.distinct(*args, **kwargs)
+    return self._database[Session["AVALON_PROJECT"]].distinct(
+        *args, **kwargs)
 
 
-@requires_activation
 def drop(*args, **kwargs):
-    return self._collection.drop(*args, **kwargs)
+    return self._database[Session["AVALON_PROJECT"]].drop(
+        *args, **kwargs)
 
 
-@requires_activation
 def delete_many(*args, **kwargs):
-    return self._collection.delete_many(*args, **kwargs)
+    return self._database[Session["AVALON_PROJECT"]].delete_many(
+        *args, **kwargs)
 
 
-@requires_activation
 def parenthood(document):
     assert document is not None, "This is a bug"
 

--- a/avalon/lib.py
+++ b/avalon/lib.py
@@ -8,8 +8,10 @@ import datetime
 from . import schema
 from .vendor import six, toml
 
-logging.basicConfig()
-logger = logging.getLogger("avalon")
+log_ = logging.getLogger(__name__)
+
+# Backwards compatibility
+logger = log_
 
 __all__ = [
     "time",
@@ -146,12 +148,12 @@ def get_application(name, environment=None):
     try:
         with open(application_definition) as f:
             app = toml.load(f)
-            logger.debug(json.dumps(app, indent=4))
+            log_.debug(json.dumps(app, indent=4))
             schema.validate(app, "application")
     except (schema.ValidationError,
             schema.SchemaError,
             toml.TomlDecodeError) as e:
-        logger.error("%s was invalid." % application_definition)
+        log_.error("%s was invalid." % application_definition)
         raise
 
     executable = which(name)
@@ -165,12 +167,12 @@ def get_application(name, environment=None):
     try:
         app = dict_format(app, **environment)
     except KeyError as e:
-        logger.error(
+        log_.error(
             "One of the {variables} defined in the application "
             "definition wasn't found in this session.\n"
             "The variable was %s " % e
         )
-        logger.error(json.dumps(environment, indent=4, sort_keys=True))
+        log_.error(json.dumps(environment, indent=4, sort_keys=True))
 
         raise ValueError(
             "This is typically a bug in the pipeline, "
@@ -187,7 +189,7 @@ def get_application(name, environment=None):
             environment[key] = value
 
         else:
-            logger.error(
+            log_.error(
                 "%s: Unsupported environment reference in %s"
                 % (value, name)
             )

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -17,7 +17,6 @@ self._menu = "avalonmaya"  # Unique name of menu
 self._events = dict()  # Registered Maya callbacks
 self._parent = None  # Main Window
 
-AVALON_EARLY_ADOPTER = bool(os.getenv("AVALON_EARLY_ADOPTER"))
 IS_HEADLESS = not hasattr(cmds, "about") or cmds.about(batch=True)
 
 
@@ -29,7 +28,7 @@ def install(config):
     """
 
     # Inherit globally set name
-    self._menu = api.session["label"] + "menu"
+    self._menu = api.Session["AVALON_LABEL"] + "menu"
 
     _register_callbacks()
     _set_project()
@@ -88,7 +87,7 @@ def _install_menu():
 
     def deferred():
         cmds.menu(self._menu,
-                  label=api.session["label"],
+                  label=api.Session["AVALON_LABEL"],
                   tearOff=True,
                   parent="MayaWindow")
 
@@ -97,7 +96,7 @@ def _install_menu():
         cmds.menuItem("Load...",
                       command=lambda *args: cbloader.show(parent=self._parent))
 
-        if AVALON_EARLY_ADOPTER:
+        if api.Session["AVALON_EARLY_ADOPTER"]:
             cmds.menuItem("Load... (old)",
                           command=lambda *args:
                           loader.show(parent=self._parent))
@@ -109,7 +108,7 @@ def _install_menu():
                       command=lambda *args: cbsceneinventory.show(
                           parent=self._parent))
 
-        if AVALON_EARLY_ADOPTER:
+        if api.Session["AVALON_EARLY_ADOPTER"]:
             cmds.menuItem("Manage... (old)",
                           command=lambda *args:
                           manager.show(parent=self._parent))

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -29,6 +29,8 @@ self = sys.modules[__name__]
 self._is_installed = False
 self._config = None
 
+log = logging.getLogger(__name__)
+
 
 def install(host):
     """Install `host` into the running Python session.
@@ -52,7 +54,7 @@ def install(host):
     )
 
     project = Session["AVALON_PROJECT"]
-    lib.logger.info("Activating %s.." % project)
+    log.info("Activating %s.." % project)
 
     config = find_config()
 
@@ -67,18 +69,19 @@ def install(host):
 
     self._is_installed = True
     self._config = config
-    lib.logger.info("Successfully installed Avalon!")
+    log.info("Successfully installed Avalon!")
 
 
 def find_config():
-    lib.logger.info("Finding configuration for project..")
+    log.info("Finding configuration for project..")
+
     config = Session["AVALON_CONFIG"]
 
     if not config:
         raise EnvironmentError("No configuration found in "
                                "the project nor environment")
 
-    lib.logger.info("Found %s, loading.." % config)
+    log.info("Found %s, loading.." % config)
     return importlib.import_module(config)
 
 
@@ -99,7 +102,7 @@ def uninstall():
 
     io.uninstall()
 
-    self.lib.logger.info("Successfully uninstalled Avalon!")
+    log.info("Successfully uninstalled Avalon!")
 
 
 def is_installed():
@@ -331,7 +334,7 @@ def emit(event):
         try:
             callback()
         except Exception:
-            lib.logger.debug(traceback.format_exc())
+            log.debug(traceback.format_exc())
 
 
 def register_plugin(superclass, obj):
@@ -391,7 +394,7 @@ def deregister_plugin_path(superclass, path):
 
 def register_root(path):
     """Register currently active root"""
-    lib.logger.info("Registering root: %s" % path)
+    log.info("Registering root: %s" % path)
     _registered_root["_"] = path
 
 

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -72,13 +72,7 @@ def install(host):
 
 def find_config():
     lib.logger.info("Finding configuration for project..")
-
-    project = io.find_one({"type": "project"})
-
-    try:
-        config = project["config"]["name"]
-    except (TypeError, KeyError):
-        config = Session["AVALON_CONFIG"]
+    config = Session["AVALON_CONFIG"]
 
     if not config:
         raise EnvironmentError("No configuration found in "

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -13,6 +13,8 @@ from . import (
     io,
     lib,
 
+    Session,
+
     _registered_host,
     _registered_root,
     _registered_config,
@@ -24,36 +26,8 @@ from . import (
 from .vendor import six
 
 self = sys.modules[__name__]
-
-self.log = logging.getLogger("avalon-core")
 self._is_installed = False
 self._config = None
-self.session = {}
-
-# Environment is parsed once on start-up, and should
-# never again be referenced directly.
-self.session = {
-    key[0]: os.getenv("AVALON_" + key[0].upper(), key[1])
-    for key in (
-        # Root directory of projects on disk
-        ("projects", None),
-
-        # Name of current Project
-        ("project", None),
-
-        # Name of current Asset
-        ("asset", None),
-
-        # Name of current Config
-        # TODO(marcus): Establish a suitable default config
-        ("config", "no_config"),
-
-        # Name of Avalon in graphical user interfaces
-        # Use this to customise the visual appearance of Avalon
-        # to better integrate with your surrounding pipeline
-        ("label", "Avalon"),
-    )
-}
 
 
 def install(host):
@@ -65,11 +39,11 @@ def install(host):
 
     """
 
-    reset()
+    io.install()
 
     missing = list()
-    for key in ("project", "asset"):
-        if self.session[key] is None:
+    for key in ("AVALON_PROJECT", "AVALON_ASSET"):
+        if Session[key] is None:
             missing.append(key)
 
     assert not missing, (
@@ -77,11 +51,8 @@ def install(host):
             "AVALON_" + env.upper() for env in missing)
     )
 
-    project = self.session["project"]
+    project = Session["AVALON_PROJECT"]
     lib.logger.info("Activating %s.." % project)
-
-    io.install()
-    io.activate_project(project)
 
     config = find_config()
 
@@ -96,32 +67,7 @@ def install(host):
 
     self._is_installed = True
     self._config = config
-    self.log.info("Successfully installed Avalon!")
-
-
-def reset():
-    self.session.update({
-        key[0]: os.getenv("AVALON_" + key[0].upper(), key[1])
-        for key in (
-            # Root directory of projects on disk
-            ("projects", None),
-
-            # Name of current Project
-            ("project", None),
-
-            # Name of current Asset
-            ("asset", None),
-
-            # Name of current Config
-            # TODO(marcus): Establish a suitable default config
-            ("config", "no_config"),
-
-            # Name of Avalon in graphical user interfaces
-            # Use this to customise the visual appearance of Avalon
-            # to better integrate with your surrounding pipeline
-            ("label", "Avalon"),
-        )
-    })
+    lib.logger.info("Successfully installed Avalon!")
 
 
 def find_config():
@@ -132,7 +78,7 @@ def find_config():
     try:
         config = project["config"]["name"]
     except (TypeError, KeyError):
-        config = os.getenv("AVALON_CONFIG")
+        config = Session["AVALON_CONFIG"]
 
     if not config:
         raise EnvironmentError("No configuration found in "
@@ -159,7 +105,7 @@ def uninstall():
 
     io.uninstall()
 
-    self.log.info("Successfully uninstalled Avalon!")
+    self.lib.logger.info("Successfully uninstalled Avalon!")
 
 
 def is_installed():
@@ -451,7 +397,7 @@ def deregister_plugin_path(superclass, path):
 
 def register_root(path):
     """Register currently active root"""
-    self.log.info("Registering root: %s" % path)
+    lib.logger.info("Registering root: %s" % path)
     _registered_root["_"] = path
 
 
@@ -459,7 +405,7 @@ def registered_root():
     """Return currently registered root"""
     return (
         _registered_root["_"] or
-        self.session["projects"] or ""
+        Session.get("AVALON_PROJECTS") or ""
     ).replace("\\", "/")
 
 

--- a/avalon/schema.py
+++ b/avalon/schema.py
@@ -19,7 +19,7 @@ import logging
 
 from .vendor import jsonschema
 
-_log = logging.getLogger("avalon-core")
+log_ = logging.getLogger(__name__)
 
 ValidationError = jsonschema.ValidationError
 SchemaError = jsonschema.SchemaError
@@ -100,7 +100,7 @@ def _precache():
         if not os.path.isfile(os.path.join(_SCHEMA_DIR, schema)):
             continue
         with open(os.path.join(_SCHEMA_DIR, schema)) as f:
-            _log.debug("Installing schema '%s'.." % schema)
+            log_.debug("Installing schema '%s'.." % schema)
             _cache[schema] = json.load(f)
 
 

--- a/avalon/schema/session-1.0.json
+++ b/avalon/schema/session-1.0.json
@@ -78,6 +78,19 @@
             "type": "string",
             "pattern": "^[A-Z_.]*$",
             "example": "Mindbender"
+        },
+        "AVALON_SENTRY": {
+            "description": "Address to Sentry",
+            "type": "string",
+            "pattern": "^[A-Z_.]*$",
+            "example": "http://5b872b280de742919b115bdc8da076a5:8d278266fe764361b8fa6024af004a9c@logs.mindbender.com/2"
+        },
+        "AVALON_TIMEOUT": {
+            "description": "Wherever there is a need for a timeout, this is the default value.",
+            "type": "string",
+            "pattern": "^[A-Z_.]*$",
+            "default": "1000",
+            "example": "1000"
         }
     }
 }

--- a/avalon/session.py
+++ b/avalon/session.py
@@ -1,14 +1,17 @@
 import os
 import time
 import errno
+import logging
 import shutil
 import getpass
 
 # Third-party dependencies
 import pymongo
 
-from avalon import api, lib
+from avalon import lib
 from avalon.vendor import six
+
+log = logging.getLogger(__name__)
 
 
 def new(**kwargs):
@@ -157,7 +160,7 @@ class _Session(dict):
                 client.server_info()
 
             except OSError:
-                api.logger.error("Retrying..")
+                log.error("Retrying..")
                 time.sleep(1)
 
             else:
@@ -167,7 +170,7 @@ class _Session(dict):
             raise IOError("ERROR: Couldn't connect to %s in "
                           "less than %.3f ms" % (self["AVALON_MONGO"], 2000))
 
-        api.logger.info("Connected to server, delay %.3f s" % (
+        log.info("Connected to server, delay %.3f s" % (
             time.time() - t1))
 
         database = client[self["AVALON_DB"]]

--- a/avalon/tests/test_inventory.py
+++ b/avalon/tests/test_inventory.py
@@ -64,8 +64,8 @@ self._inventory = {
 
 def setup():
     assert_equals.__self__.maxDiff = None
+    os.environ["AVALON_PROJECT"] = PROJECT_NAME
     io.install()
-    io.activate_project(PROJECT_NAME)
     self._tempdir = tempfile.mkdtemp()
 
 

--- a/avalon/tools/cbloader/app.py
+++ b/avalon/tools/cbloader/app.py
@@ -236,7 +236,7 @@ def show(root=None, debug=False, parent=None):
             if project.get("active", True) is not False
         )
 
-        io.activate_project(any_project)
+        api.Session["AVALON_PROJECT"] = any_project["name"]
         module.project = any_project["name"]
 
     with lib.application():

--- a/avalon/tools/cbsceneinventory/app.py
+++ b/avalon/tools/cbsceneinventory/app.py
@@ -3,7 +3,7 @@ import getpass
 
 from ...vendor.Qt import QtWidgets, QtCore
 from ...vendor import qtawesome as qta
-from ... import io
+from ... import io, api
 from .. import lib as tools_lib
 
 import os
@@ -11,7 +11,6 @@ import subprocess
 
 from .proxy import FilterProxyModel
 from .model import InventoryModel
-from ... import api
 
 # todo(roy): refactor loading from other tools
 from ..projectmanager.widget import (
@@ -362,7 +361,7 @@ def show(root=None, debug=False, parent=None):
             if project.get("active", True) is not False
         )
 
-        io.activate_project(any_project)
+        api.Session["AVALON_PROJECT"] = any_project["name"]
 
     with tools_lib.application():
         window = Window(parent)

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -260,7 +260,7 @@ def show(debug=False, parent=None):
             if project.get("active", True) is not False
         )
 
-        io.activate_project(any_project)
+        api.Session["AVALON_PROJECT"] = any_project["name"]
         module.project = any_project["name"]
 
     with lib.application():

--- a/avalon/tools/loader/app.py
+++ b/avalon/tools/loader/app.py
@@ -652,7 +652,7 @@ def show(root=None, debug=False, parent=None):
             if project.get("active", True) is not False
         )
 
-        io.activate_project(any_project)
+        api.Session["AVALON_PROJECT"] = any_project["name"]
         module.project = any_project["name"]
 
     with lib.application():

--- a/avalon/tools/manager/app.py
+++ b/avalon/tools/manager/app.py
@@ -176,7 +176,7 @@ class Window(QtWidgets.QDialog):
             if container["schema"] == "avalon-core:container-1.0":
                 name = container["objectName"]
                 container["representation"] = str(io.locate([
-                    api.session["project"],
+                    api.Session["AVALON_PROJECT"],
                     container["asset"],
                     container["subset"],
                     container["version"],
@@ -406,7 +406,7 @@ def show(root=None, debug=False, parent=None):
             if project.get("active", True) is not False
         )
 
-        io.activate_project(any_project)
+        api.Session["AVALON_PROJECT"] = any_project["name"]
 
     with lib.application():
         window = Window(parent)

--- a/avalon/tools/projectmanager/app.py
+++ b/avalon/tools/projectmanager/app.py
@@ -1,7 +1,7 @@
 import sys
 
 from ...vendor.Qt import QtWidgets, QtCore
-from ... import io, schema
+from ... import io, schema, api
 from .. import lib as parentlib
 from . import widget
 
@@ -240,5 +240,7 @@ def cli(args):
     project = args.project
 
     io.install()
-    io.activate_project(project)
+
+    api.Session["AVALON_PROJECT"] = project
+
     show()


### PR DESCRIPTION
This implements #128, aggregated logging.

Setting `AVALON_SENTRY` to the address of your own Sentry instance will cause Avalon to upload log messages and exceptions.

- http://logs.mindbender.com/

Exceptions are uploaded via `sys.excepthook`, which would include exceptions external to Avalon; basically every single exception happening for the duration of the Python session. There are filters to pinpoint exact messages so it shouldn't be a problem, and odds are we'll need those to determine whether a user error was due to us, someone else, or a combination.

What should happen is for each studio to host their own instance of Sentry. @BigRoy considering what do you think about having both of our messages aggregated here? It'll be more messy, but I'm expecting filters to help and ultimately this thing is meant to handle millions of log messages each day. I'm curious to see how it handles it. Finally, setting one up was a pain. I wouldn't want to expose you to that.

It has a notion of "projects" too, and "teams". So it's possible we could separate our messages that way too. But initially I'm interested in *all* messages being made by Avalon.

### Session

I've also taken another stab at `api.Session`.

At first I figured I'd store variables as lowercase, non-prefixed with `AVALON_` as I wanted to move away from storing things in `os.environ` and thus environment variables at all. I figured we'd gain more control this way and didn't have to rely on the environment at atll.

But it quickly occurred to me that these variables *will* be tightly related to environment variables anyway as it is through the environment that most of these variables are configured.

So they've retained their original name to correspond to what they look like in the environment.

Another thing I discarded was `io.activate_project()`. This was always an exact replica of `os.environ["AVALON_PROJECT"]` and now it is so once more. Except this time, it's coming from Session.

At the moment, Session is hand-modified at various points in the code. This is good I think, it highlights where we've been doing this already through other means, and whether our hand-modifications are local to the particular function, or whether they are global and are expected to affect more than a single function. For example, in the `tools.loader`, `api.Session` is modified during debug-mode so as to manually specify a random project from the database. This is no good, what should really happen is for this debug mode to have *it's own* session that it can use, without affecting global state.