### PR TITLE
normalise references to external paths

### DIFF
--- a/avalon/maya/__init__.py
+++ b/avalon/maya/__init__.py
@@ -9,6 +9,7 @@ from .pipeline import (
     uninstall,
 
     Creator,
+    Loader,
 
     ls,
     load,
@@ -39,6 +40,7 @@ __all__ = [
     "uninstall",
 
     "Creator",
+    "Loader",
 
     "ls",
     "load",

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -355,6 +355,14 @@ class Creator(api.Creator):
         return instance
 
 
+class Loader(api.Loader):
+    def __init__(self, context):
+        super(Loader, self).__init__(context)
+        self.fname = self.fname.replace(
+            api.registered_root(), "$AVALON_PROJECTS"
+        )
+
+
 def create(name, asset, family, options=None, data=None):
     """Create a new instance
 


### PR DESCRIPTION
#54 normalise references to external paths

By having your Loader inherit from `avalon.maya.Loader`, the `self.fname` now replaces the root portion of the path with `$AVALON_PROJECTS`.

**Before**

```bash
c:/projects/batman/assets/Bruce/publish/modelDefault/v003/modelDefault.ma
```

**After**

```bash
$AVALON_PROJECTS/batman/assets/Bruce/publish/modelDefault/v003/modelDefault.ma
```

Which means the project directory can reside on a different root, without affecting the internal path used by Maya. The same should/may apply to Nuke and other DCCs.