### PR TITLE
Deadline

### DIFF
--- a/avalon/io.py
+++ b/avalon/io.py
@@ -161,6 +161,10 @@ def _from_environment():
             # Address to Sentry
             ("AVALON_SENTRY", None),
 
+            # Address to Deadline Web Service
+            # E.g. http://192.167.0.1:8082
+            ("AVALON_DEADLINE", None),
+
             # Enable features not necessarily stable, at the user's own risk
             ("AVALON_EARLY_ADOPTER", None),
         )

--- a/avalon/io.py
+++ b/avalon/io.py
@@ -6,7 +6,7 @@ import time
 import logging
 import functools
 
-from . import schema, lib, Session
+from . import schema, Session
 from .vendor.six.moves import urllib
 
 # Third-party dependencies
@@ -91,7 +91,7 @@ def _install_sentry():
         from raven.conf import setup_logging
     except ImportError:
         # Note: There was a Sentry address in this Session
-        return lib.log.warning("Sentry disabled, raven not installed")
+        return log.warning("Sentry disabled, raven not installed")
 
     client = Client(Session["AVALON_SENTRY"])
 


### PR DESCRIPTION
This merely adds `AVALON_DEADLINE` to Session, with the intent of a configuration to use this address for submitting to Deadline.

E.g. 

```python
import json
import getpass
import requests

from avalon import api

url = api.Session["AVALON_DEADLINE"] + "/api/jobs"
payload = {
    "JobInfo": {
        "Name": "My render",
        "UserName": getpass.getuser(),
        "Plugin": "MayaBatch",
        "Frames": "1000.0-1003.0x1",
    },
    "PluginInfo": {
        "SceneFile": "/share/my_file.ma",
        "Version": "2016",
        "OutputFilePath": "/share"
    },
    "AuxFiles": []
}

payload = json.dumps(payload)
response = requests.post(url, data=payload)
```