### PR TITLE
Lock and before/after

### DIFF
--- a/avalon/api.py
+++ b/avalon/api.py
@@ -24,6 +24,8 @@ from .pipeline import (
     Session as session,
 
     on,
+    after,
+    before,
     emit,
 
     publish,
@@ -62,6 +64,8 @@ __all__ = [
     "session",
 
     "on",
+    "after",
+    "before",
     "emit",
 
     "publish",

--- a/avalon/inventory.py
+++ b/avalon/inventory.py
@@ -20,7 +20,7 @@ import sys
 import copy
 import json
 
-from avalon import schema, io, api
+from avalon import schema, io
 from avalon.vendor import toml
 
 self = sys.modules[__name__]
@@ -37,6 +37,10 @@ DEFAULTS = {
     "config": {
         "schema": "avalon-core:config-1.0",
         "apps": [
+            {
+                "name": "shell",
+                "label": "Shell"
+            },
             {
                 "name": "maya2016",
                 "label": "Autodesk Maya 2016"

--- a/avalon/maya/__init__.py
+++ b/avalon/maya/__init__.py
@@ -18,6 +18,11 @@ from .pipeline import (
     update,
     publish,
     containerise,
+
+    lock,
+    unlock,
+    is_locked,
+    lock_ignored,
 )
 
 from .lib import (
@@ -50,6 +55,11 @@ __all__ = [
     "update",
     "read",
     "publish",
+
+    "lock",
+    "unlock",
+    "is_locked",
+    "lock_ignored",
 
     "export_alembic",
     "lsattr",

--- a/avalon/maya/lib.py
+++ b/avalon/maya/lib.py
@@ -1,6 +1,8 @@
 """Standalone helper functions"""
 
+import os
 import contextlib
+
 from maya import cmds, mel
 from maya.api import OpenMaya as om
 

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -550,6 +550,10 @@ def _register_callbacks():
         OpenMaya.MSceneMessage.kBeforeSave, _on_scene_save
     )
 
+    self._events[_before_scene_save] = OpenMaya.MSceneMessage.addCheckCallback(
+        OpenMaya.MSceneMessage.kBeforeSaveCheck, _before_scene_save
+    )
+
     self._events[_on_scene_new] = OpenMaya.MSceneMessage.addCallback(
         OpenMaya.MSceneMessage.kAfterNew, _on_scene_new
     )
@@ -559,6 +563,7 @@ def _register_callbacks():
     )
 
     logger.info("Installed event handler _on_scene_save..")
+    logger.info("Installed event handler _before_scene_save..")
     logger.info("Installed event handler _on_scene_new..")
     logger.info("Installed event handler _on_maya_initialized..")
 
@@ -573,9 +578,13 @@ def _on_maya_initialized(_):
     }["MayaWindow"]
 
 
-def _on_scene_new(_):
-    api.emit("new")
+def _on_scene_new(*args):
+    api.emit("new", args)
 
 
-def _on_scene_save(_):
-    api.emit("save")
+def _on_scene_save(*args):
+    api.emit("save", args)
+
+
+def _before_scene_save(*args):
+    api.emit("before_save", args)

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -311,7 +311,15 @@ def on(event, callback):
     events.add(callback)
 
 
-def emit(event):
+def before(event, callback):
+    on("before_" + event, callback)
+
+
+def after(event, callback):
+    on("after_" + event, callback)
+
+
+def emit(event, args=None):
     """Trigger an `event`
 
     Example:
@@ -325,14 +333,16 @@ def emit(event):
 
     Arguments:
         event (str): Name of event
+        args (list, optional): List of arguments passed to callback
 
     """
 
     callbacks = _registered_event_handlers.get(event, set())
+    args = args or list()
 
     for callback in callbacks:
         try:
-            callback()
+            callback(*args)
         except Exception:
             log.debug(traceback.format_exc())
 


### PR DESCRIPTION
This implements a new feature and two aliases to `api.on`

```python
from avalon import api
api.before("save", before_save)
api.after("save", after_save)
```

Which calls the given function before a given signal. Here's how before is implemented in Maya.

```python
OpenMaya.MSceneMessage.addCheckCallback(
  OpenMaya.MSceneMessage.kBeforeSaveCheck, your_callback
)
```

And an example.

```python

def before_save(return_code, _):
    """Prevent accidental overwrite of locked scene"""
    OpenMaya.MScriptUtil.setBool(return_code, not maya.is_locked())

```

Which brings me to the new feature.

**Lock**

Prevent further modifications to a scene.

```python
from avalon import maya

maya.lock()
cmds.file(save=True)
# Blocked!

maya.unlock()
cmds.file(save=True)
# Ok

# Save scene with lock in place
with maya.lock_ignored():
  maya.lock()
  cmds.file(save=True)

assert maya.is_locked() == False
```