### PR TITLE
Manager - Remove container if exists when removing item

### DIFF
--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -522,8 +522,11 @@ def remove(container):
     fname = cmds.referenceQuery(reference_node, filename=True)
     cmds.file(fname, removeReference=True)
 
-    if cmds.objExists(node):
+    try:
         cmds.delete(node)
+    except ValueError:
+        # Already implicitly deleted by Maya upon removing reference
+        pass
 
     try:
         # If container is not automatically cleaned up by May (issue #118)

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -525,6 +525,7 @@ def remove(container):
     try:
         # If container is not automatically cleaned up by May (issue #118)
         cmds.namespace(removeNamespace=namespace, deleteNamespaceContent=True)
+        cmds.delete(node)
     except RuntimeError:
         pass
 

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -522,12 +522,14 @@ def remove(container):
     fname = cmds.referenceQuery(reference_node, filename=True)
     cmds.file(fname, removeReference=True)
 
+    if cmds.objExists(node):
+        cmds.delete(node)
+
     try:
         # If container is not automatically cleaned up by May (issue #118)
         cmds.namespace(removeNamespace=namespace, deleteNamespaceContent=True)
-        cmds.delete(node)
     except RuntimeError as e:
-        logger.warning(e)
+        logger.debug(e)
         pass
 
 

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -529,7 +529,6 @@ def remove(container):
         # If container is not automatically cleaned up by May (issue #118)
         cmds.namespace(removeNamespace=namespace, deleteNamespaceContent=True)
     except RuntimeError as e:
-        logger.debug(e)
         pass
 
 

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -526,7 +526,8 @@ def remove(container):
         # If container is not automatically cleaned up by May (issue #118)
         cmds.namespace(removeNamespace=namespace, deleteNamespaceContent=True)
         cmds.delete(node)
-    except RuntimeError:
+    except RuntimeError as e:
+        logger.warning(e)
         pass
 
 

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -528,7 +528,7 @@ def remove(container):
     try:
         # If container is not automatically cleaned up by May (issue #118)
         cmds.namespace(removeNamespace=namespace, deleteNamespaceContent=True)
-    except RuntimeError as e:
+    except RuntimeError:
         pass
 
 


### PR DESCRIPTION
Fix #253 

Added extra check ( `cmds.objExists(node)` ) to counter error where the container is already removed.
When removing a referenced Alembic the removal includes the container when removing referenced Maya Ascii it might linger after the file has been removed from references.