### PR TITLE
#195

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,4 @@
+python:
+  enabled: true
+
+fail_on_violations: true

--- a/avalon/api.py
+++ b/avalon/api.py
@@ -29,6 +29,12 @@ from .pipeline import (
     emit,
 
     publish,
+    create,
+    load,
+    update,
+    remove,
+
+    get_representation_path,
 
     register_root,
     register_host,
@@ -67,6 +73,12 @@ __all__ = [
     "emit",
 
     "publish",
+    "create",
+    "load",
+    "update",
+    "remove",
+
+    "get_representation_path",
 
     "register_host",
     "register_plugin_path",
@@ -79,6 +91,8 @@ __all__ = [
 
     "deregister_plugin",
     "deregister_plugin_path",
+
+    "get_representation_path",
 
     "logger",
     "time",

--- a/avalon/api.py
+++ b/avalon/api.py
@@ -92,8 +92,6 @@ __all__ = [
     "deregister_plugin",
     "deregister_plugin_path",
 
-    "get_representation_path",
-
     "logger",
     "time",
 ]

--- a/avalon/maya/__init__.py
+++ b/avalon/maya/__init__.py
@@ -12,10 +12,6 @@ from .pipeline import (
     Loader,
 
     ls,
-    load,
-    create,
-    remove,
-    update,
     publish,
     containerise,
 
@@ -49,12 +45,8 @@ __all__ = [
     "Loader",
 
     "ls",
-    "load",
-    "create",
-    "remove",
-    "update",
-    "read",
     "publish",
+    "containerise",
 
     "lock",
     "unlock",
@@ -73,5 +65,4 @@ __all__ = [
     "maintained_selection",
     "suspended_refresh",
 
-    "containerise",
 ]

--- a/avalon/maya/__init__.py
+++ b/avalon/maya/__init__.py
@@ -12,6 +12,10 @@ from .pipeline import (
     Loader,
 
     ls,
+    load,               # deprecated (old load api)
+    create,             # deprecated (old creator api)
+    remove,             # deprecated (old load api)
+    update,             # deprecated (old load api)
     publish,
     containerise,
 
@@ -19,6 +23,7 @@ from .pipeline import (
     unlock,
     is_locked,
     lock_ignored,
+
 )
 
 from .lib import (
@@ -45,8 +50,11 @@ __all__ = [
     "Loader",
 
     "ls",
+    "load",
+    "create",
+    "remove",
+    "update",
     "publish",
-    "containerise",
 
     "lock",
     "unlock",
@@ -56,6 +64,7 @@ __all__ = [
     "export_alembic",
     "lsattr",
     "lsattrs",
+    "read",
 
     "unique_name",
     "unique_namespace",

--- a/avalon/maya/__init__.py
+++ b/avalon/maya/__init__.py
@@ -12,6 +12,9 @@ from .pipeline import (
     Loader,
 
     ls,
+    create,
+    load,
+    update,
     publish,
     containerise,
 
@@ -45,6 +48,10 @@ __all__ = [
     "Loader",
 
     "ls",
+    "read",
+    "load",
+    "create",
+    "update",
     "publish",
     "containerise",
 

--- a/avalon/maya/__init__.py
+++ b/avalon/maya/__init__.py
@@ -12,9 +12,6 @@ from .pipeline import (
     Loader,
 
     ls,
-    create,
-    load,
-    update,
     publish,
     containerise,
 
@@ -48,10 +45,6 @@ __all__ = [
     "Loader",
 
     "ls",
-    "read",
-    "load",
-    "create",
-    "update",
     "publish",
     "containerise",
 

--- a/avalon/maya/compat.py
+++ b/avalon/maya/compat.py
@@ -11,6 +11,8 @@ import avalon.pipeline
 
 log = logging.getLogger(__name__)
 
+create = avalon.pipeline.create
+
 
 def remove_googleapiclient():
     """Check if the compatibility must be maintained
@@ -42,7 +44,7 @@ def load(Loader,
          namespace=None,
          data=None):
     """Load asset via database
-    
+
     Deprecated; this functionality is replaced by `api.load()`
 
     Arguments:
@@ -121,7 +123,7 @@ def load(Loader,
 
 def update(container, version=-1):
     """Update `container` to `version`
-    
+
     Deprecated; this functionality is replaced by `api.update()`
 
     This function relies on a container being referenced. At the time of this
@@ -207,7 +209,7 @@ def update(container, version=-1):
 
 def remove(container):
     """Remove an existing `container` from Maya scene
-    
+
     Deprecated; this functionality is replaced by `api.remove()`
 
     Arguments:
@@ -248,10 +250,10 @@ class BackwardsCompatibleLoader(avalon.pipeline.Loader):
     """A backwards compatible loader.
 
     This triggers the old-style `process` through the old Maya's host `load`,
-    `update` and `remove` methods and exposes it through the new-style Loader 
+    `update` and `remove` methods and exposes it through the new-style Loader
     api.
-    
-    Note: This inherits from `avalon.pipeline.Loader` and *not* from 
+
+    Note: This inherits from `avalon.pipeline.Loader` and *not* from
         `avalon.maya.pipeline.Loader`
 
     """

--- a/avalon/maya/compat.py
+++ b/avalon/maya/compat.py
@@ -261,15 +261,15 @@ class BackwardsCompatibleLoader(avalon.pipeline.Loader):
              name=None,
              namespace=None,
              data=None):
-        load(Loader=self.__class__,
-             representation=context['representation'],
-             name=name,
-             namespace=namespace,
-             data=data)
+        return load(Loader=self.__class__,
+                    representation=context['representation'],
+                    name=name,
+                    namespace=namespace,
+                    data=data)
 
     def remove(self, container):
-        remove(container)
+        return remove(container)
 
     def update(self, container, representation):
         version = representation['context']['version']
-        update(container, version=version)
+        return update(container, version=version)

--- a/avalon/maya/compat.py
+++ b/avalon/maya/compat.py
@@ -7,7 +7,6 @@ import maya.cmds as cmds
 import os
 import logging
 
-# Get the Maya's host loader
 import avalon.pipeline
 
 log = logging.getLogger(__name__)

--- a/avalon/maya/compat.py
+++ b/avalon/maya/compat.py
@@ -5,6 +5,12 @@ is maintained.
 """
 import maya.cmds as cmds
 import os
+import logging
+
+# Get the Maya's host loader
+import avalon.pipeline
+
+log = logging.getLogger(__name__)
 
 
 def remove_googleapiclient():
@@ -29,3 +35,242 @@ def install():
     """Run all compatibility functions"""
     if cmds.about(version=True) == "2018":
         remove_googleapiclient()
+
+
+def load(Loader,
+         representation,
+         name=None,
+         namespace=None,
+         data=None):
+    """Load asset via database
+    
+    Deprecated; this functionality is replaced by `api.load()`
+
+    Arguments:
+        Loader (api.Loader): The loader to process in host Maya.
+        representation (dict, io.ObjectId or str): Address to representation
+        name (str, optional): Use pre-defined name
+        namespace (str, optional): Use pre-defined namespace
+        data (dict, optional): Additional settings dictionary
+
+    """
+
+    from avalon.vendor import six
+    from avalon import io
+    from avalon.maya import lib
+    from avalon.maya.pipeline import containerise
+
+    assert representation is not None, "This is a bug"
+
+    if isinstance(representation, (six.string_types, io.ObjectId)):
+        representation = io.find_one({"_id": io.ObjectId(str(representation))})
+
+    version, subset, asset, project = io.parenthood(representation)
+
+    assert all([representation, version, subset, asset, project]), (
+        "This is a bug"
+    )
+
+    context = {
+        "project": project,
+        "asset": asset,
+        "subset": subset,
+        "version": version,
+        "representation": representation,
+    }
+
+    # Ensure data is a dictionary when no explicit data provided
+    if data is None:
+        data = dict()
+    assert isinstance(data, dict), "Data must be a dictionary"
+
+    name = name or subset["name"]
+    namespace = namespace or lib.unique_namespace(
+        asset["name"] + "_",
+        prefix="_" if asset["name"][0].isdigit() else "",
+        suffix="_",
+    )
+
+    # TODO(roy): add compatibility check, see `tools.cbloader.lib`
+
+    Loader.log.info(
+        "Running '%s' on '%s'" % (Loader.__name__, asset["name"])
+    )
+
+    try:
+        loader = Loader(context)
+
+        with lib.maintained_selection():
+            loader.process(name, namespace, context, data)
+
+    except OSError as e:
+        log.info("WARNING: %s" % e)
+        return list()
+
+    # Only containerize if any nodes were loaded by the Loader
+    nodes = loader[:]
+    if not nodes:
+        return
+
+    return containerise(
+        name=name,
+        namespace=namespace,
+        nodes=loader[:],
+        context=context,
+        loader=Loader.__name__)
+
+
+def update(container, version=-1):
+    """Update `container` to `version`
+    
+    Deprecated; this functionality is replaced by `api.update()`
+
+    This function relies on a container being referenced. At the time of this
+    writing, all assets - models, rigs, animations, shaders - are referenced
+    and should pose no problem. But should there be an asset that isn't
+    referenced then this function will need to see an update.
+
+    Arguments:
+        container (avalon-core:container-1.0): Container to update,
+            from `host.ls()`.
+        version (int, optional): Update the container to this version.
+            If no version is passed, the latest is assumed.
+
+    """
+
+    from avalon import io
+    from avalon import api
+
+    node = container["objectName"]
+
+    # Assume asset has been referenced
+    reference_node = next((node for node in cmds.sets(node, query=True)
+                          if cmds.nodeType(node) == "reference"), None)
+
+    assert reference_node, ("Imported container not supported; "
+                            "container must be referenced.")
+
+    current_representation = io.find_one({
+        "_id": io.ObjectId(container["representation"])
+    })
+
+    assert current_representation is not None, "This is a bug"
+
+    version_, subset, asset, project = io.parenthood(current_representation)
+
+    if version == -1:
+        new_version = io.find_one({
+            "type": "version",
+            "parent": subset["_id"]
+        }, sort=[("name", -1)])
+    else:
+        new_version = io.find_one({
+            "type": "version",
+            "parent": subset["_id"],
+            "name": version,
+        })
+
+    new_representation = io.find_one({
+        "type": "representation",
+        "parent": new_version["_id"],
+        "name": current_representation["name"]
+    })
+
+    assert new_version is not None, "This is a bug"
+
+    template_publish = project["config"]["template"]["publish"]
+    fname = template_publish.format(**{
+        "root": api.registered_root(),
+        "project": project["name"],
+        "asset": asset["name"],
+        "silo": asset["silo"],
+        "subset": subset["name"],
+        "version": new_version["name"],
+        "representation": current_representation["name"],
+    })
+
+    file_type = {
+        "ma": "mayaAscii",
+        "mb": "mayaBinary",
+        "abc": "Alembic"
+    }.get(new_representation["name"])
+
+    assert file_type, ("Unsupported representation: %s" % new_representation)
+
+    assert os.path.exists(fname), "%s does not exist." % fname
+    cmds.file(fname, loadReference=reference_node, type=file_type)
+
+    # Update metadata
+    cmds.setAttr(container["objectName"] + ".representation",
+                 str(new_representation["_id"]),
+                 type="string")
+
+
+def remove(container):
+    """Remove an existing `container` from Maya scene
+    
+    Deprecated; this functionality is replaced by `api.remove()`
+
+    Arguments:
+        container (avalon-core:container-1.0): Which container
+            to remove from scene.
+
+    """
+
+    node = container["objectName"]
+
+    # Assume asset has been referenced
+    reference_node = next((node for node in cmds.sets(node, query=True)
+                          if cmds.nodeType(node) == "reference"), None)
+
+    assert reference_node, ("Imported container not supported; "
+                            "container must be referenced.")
+
+    log.info("Removing '%s' from Maya.." % container["name"])
+
+    namespace = cmds.referenceQuery(reference_node, namespace=True)
+    fname = cmds.referenceQuery(reference_node, filename=True)
+    cmds.file(fname, removeReference=True)
+
+    try:
+        cmds.delete(node)
+    except ValueError:
+        # Already implicitly deleted by Maya upon removing reference
+        pass
+
+    try:
+        # If container is not automatically cleaned up by May (issue #118)
+        cmds.namespace(removeNamespace=namespace, deleteNamespaceContent=True)
+    except RuntimeError:
+        pass
+
+
+class BackwardsCompatibleLoader(avalon.pipeline.Loader):
+    """A backwards compatible loader.
+
+    This triggers the old-style `process` through the old Maya's host `load`,
+    `update` and `remove` methods and exposes it through the new-style Loader 
+    api.
+    
+    Note: This inherits from `avalon.pipeline.Loader` and *not* from 
+        `avalon.maya.pipeline.Loader`
+
+    """
+
+    def load(self,
+             context,
+             name=None,
+             namespace=None,
+             data=None):
+        load(Loader=self.__class__,
+             representation=context['representation'],
+             name=name,
+             namespace=namespace,
+             data=data)
+
+    def remove(self, container):
+        remove(container)
+
+    def update(self, container, representation):
+        version = representation['context']['version']
+        update(container, version=version)

--- a/avalon/maya/lib.py
+++ b/avalon/maya/lib.py
@@ -111,6 +111,12 @@ def export_alembic(nodes,
 
     """
 
+    if frame_range is None:
+        frame_range = (
+            cmds.playbackOptions(query=True, ast=True),
+            cmds.playbackOptions(query=True, aet=True)
+        )
+
     options = [
         ("file", file),
         ("frameRange", "%s %s" % frame_range),
@@ -129,12 +135,6 @@ def export_alembic(nodes,
 
     if write_visibility:
         options.append(("writeVisibility", ""))
-
-    if frame_range is None:
-        frame_range = (
-            cmds.playbackOptions(query=True, ast=True),
-            cmds.playbackOptions(query=True, aet=True)
-        )
 
     # Generate MEL command
     mel_args = list()

--- a/avalon/maya/lib.py
+++ b/avalon/maya/lib.py
@@ -63,6 +63,10 @@ def unique_namespace(namespace, format="%02d", prefix="", suffix=""):
     iteration = 1
     unique = prefix + (namespace + format % iteration) + suffix
 
+    # The `existing` set does not just contain the namespaces but *all* nodes
+    # within "current namespace". We need all because the namespace could
+    # also clash with a node name. To be truly unique and valid one needs to
+    # check against all.
     existing = set(cmds.namespaceInfo(listNamespace=True))
     while unique in existing:
         iteration += 1

--- a/avalon/maya/lib.py
+++ b/avalon/maya/lib.py
@@ -63,7 +63,8 @@ def unique_namespace(namespace, format="%02d", prefix="", suffix=""):
     iteration = 1
     unique = prefix + (namespace + format % iteration) + suffix
 
-    while unique in cmds.namespaceInfo(listNamespace=True):
+    existing = set(cmds.namespaceInfo(listNamespace=True))
+    while unique in existing:
         iteration += 1
         unique = prefix + (namespace + format % iteration) + suffix
 

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -408,9 +408,6 @@ class ReferenceLoader(Loader):
              data=None):
 
         asset = context['asset']['name']
-        subset = context['subset']['name']
-
-        name = name or subset
         namespace = namespace or lib.unique_namespace(
             asset + "_",
             prefix="_" if asset[0].isdigit() else "",

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -331,6 +331,30 @@ def containerise(name,
     return container
 
 
+def parse_container(container, validate=True):
+    """Return the container node's full container data.
+    
+    Args:
+        container (str): A container node name. 
+
+    Returns:
+        dict: The container schema data for this container node.
+        
+    """
+    data = lib.read(container)
+
+    # Backwards compatibility pre-schemas for containers
+    data["schema"] = data.get("schema", "avalon-core:container-1.0")
+
+    # Append transient data
+    data["objectName"] = container
+
+    if validate:
+        schema.validate(data)
+
+    return data
+
+
 def ls():
     """List containers from active Maya scene
 
@@ -346,16 +370,7 @@ def ls():
         containers += lib.lsattr("id", identifier)
 
     for container in sorted(containers):
-        data = lib.read(container)
-
-        # Backwards compatibility pre-schemas for containers
-        data["schema"] = data.get("schema", "avalon-core:container-1.0")
-
-        # Append transient data
-        data["objectName"] = container
-
-        schema.validate(data)
-
+        data = parse_container(container)
         yield data
 
 

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -272,262 +272,6 @@ def lock_ignored():
         self._ignore_lock = False
 
 
-def load(Loader,
-         representation,
-         name=None,
-         namespace=None,
-         data=None):
-    """Load asset via database
-    Arguments:
-        Loader (api.Loader): The loader to process in host Maya.
-        representation (dict, io.ObjectId or str): Address to representation
-        name (str, optional): Use pre-defined name
-        namespace (str, optional): Use pre-defined namespace
-        data (dict, optional): Additional settings dictionary
-    """
-
-    assert representation is not None, "This is a bug"
-
-    if isinstance(representation, (six.string_types, io.ObjectId)):
-        representation = io.find_one({"_id": io.ObjectId(str(representation))})
-
-    version, subset, asset, project = io.parenthood(representation)
-
-    assert all([representation, version, subset, asset, project]), (
-        "This is a bug"
-    )
-
-    context = {
-        "project": project,
-        "asset": asset,
-        "subset": subset,
-        "version": version,
-        "representation": representation,
-    }
-
-    # Ensure data is a dictionary when no explicit data provided
-    if data is None:
-        data = dict()
-    assert isinstance(data, dict), "Data must be a dictionary"
-
-    name = name or subset["name"]
-    namespace = namespace or lib.unique_namespace(
-        asset["name"] + "_",
-        prefix="_" if asset["name"][0].isdigit() else "",
-        suffix="_",
-    )
-
-    # TODO(roy): add compatibility check, see `tools.cbloader.lib`
-
-    Loader.log.info(
-        "Running '%s' on '%s'" % (Loader.__name__, asset["name"])
-    )
-
-    try:
-        loader = Loader(context)
-
-        with lib.maintained_selection():
-            loader.process(name, namespace, context, data)
-
-    except OSError as e:
-        logger.info("WARNING: %s" % e)
-        return list()
-
-    # Only containerize if any nodes were loaded by the Loader
-    nodes = loader[:]
-    if not nodes:
-        return
-
-    return containerise(
-        name=name,
-        namespace=namespace,
-        nodes=loader[:],
-        context=context,
-        loader=Loader.__name__)
-
-
-class Creator(api.Creator):
-    def process(self):
-        nodes = list()
-
-        if (self.options or {}).get("useSelection"):
-            nodes = cmds.ls(selection=True)
-
-        instance = cmds.sets(nodes, name=self.name)
-        lib.imprint(instance, self.data)
-
-        return instance
-
-
-class Loader(api.Loader):
-    def __init__(self, context):
-        super(Loader, self).__init__(context)
-        self.fname = self.fname.replace(
-            api.registered_root(), "$AVALON_PROJECTS"
-        )
-
-
-def create(name, asset, family, options=None, data=None):
-    """Create a new instance
-    Associate nodes with a subset and family. These nodes are later
-    validated, according to their `family`, and integrated into the
-    shared environment, relative their `subset`.
-    Data relative each family, along with default data, are imprinted
-    into the resulting objectSet. This data is later used by extractors
-    and finally asset browsers to help identify the origin of the asset.
-    Arguments:
-        name (str): Name of subset
-        asset (str): Name of asset
-        family (str): Name of family
-        options (dict, optional): Additional options from GUI
-        data (dict, optional): Additional data from GUI
-    Raises:
-        NameError on `subset` already exists
-        KeyError on invalid dynamic property
-        RuntimeError on host error
-    Returns:
-        Name of instance
-    """
-
-    plugins = list()
-    for Plugin in api.discover(api.Creator):
-        has_family = family == Plugin.family
-
-        if not has_family:
-            continue
-
-        Plugin.log.info(
-            "Creating '%s' with '%s'" % (name, Plugin.__name__)
-        )
-
-        try:
-            plugin = Plugin(name, asset, options, data)
-
-            with lib.maintained_selection():
-                instance = plugin.process()
-        except Exception as e:
-            logger.info("WARNING: %s" % e)
-            continue
-
-        plugins.append(plugin)
-
-    assert plugins, "No Creator plug-ins were run, this is a bug"
-    return instance
-
-
-def update(container, version=-1):
-    """Update `container` to `version`
-    This function relies on a container being referenced. At the time of this
-    writing, all assets - models, rigs, animations, shaders - are referenced
-    and should pose no problem. But should there be an asset that isn't
-    referenced then this function will need to see an update.
-    Arguments:
-        container (avalon-core:container-1.0): Container to update,
-            from `host.ls()`.
-        version (int, optional): Update the container to this version.
-            If no version is passed, the latest is assumed.
-    """
-
-    node = container["objectName"]
-
-    # Assume asset has been referenced
-    reference_node = next((node for node in cmds.sets(node, query=True)
-                          if cmds.nodeType(node) == "reference"), None)
-
-    assert reference_node, ("Imported container not supported; "
-                            "container must be referenced.")
-
-    current_representation = io.find_one({
-        "_id": io.ObjectId(container["representation"])
-    })
-
-    assert current_representation is not None, "This is a bug"
-
-    version_, subset, asset, project = io.parenthood(current_representation)
-
-    if version == -1:
-        new_version = io.find_one({
-            "type": "version",
-            "parent": subset["_id"]
-        }, sort=[("name", -1)])
-    else:
-        new_version = io.find_one({
-            "type": "version",
-            "parent": subset["_id"],
-            "name": version,
-        })
-
-    new_representation = io.find_one({
-        "type": "representation",
-        "parent": new_version["_id"],
-        "name": current_representation["name"]
-    })
-
-    assert new_version is not None, "This is a bug"
-
-    template_publish = project["config"]["template"]["publish"]
-    fname = template_publish.format(**{
-        "root": api.registered_root(),
-        "project": project["name"],
-        "asset": asset["name"],
-        "silo": asset["silo"],
-        "subset": subset["name"],
-        "version": new_version["name"],
-        "representation": current_representation["name"],
-    })
-
-    file_type = {
-        "ma": "mayaAscii",
-        "mb": "mayaBinary",
-        "abc": "Alembic"
-    }.get(new_representation["name"])
-
-    assert file_type, ("Unsupported representation: %s" % new_representation)
-
-    assert os.path.exists(fname), "%s does not exist." % fname
-    cmds.file(fname, loadReference=reference_node, type=file_type)
-
-    # Update metadata
-    cmds.setAttr(container["objectName"] + ".representation",
-                 str(new_representation["_id"]),
-                 type="string")
-
-
-def remove(container):
-    """Remove an existing `container` from Maya scene
-    Arguments:
-        container (avalon-core:container-1.0): Which container
-            to remove from scene.
-    """
-
-    node = container["objectName"]
-
-    # Assume asset has been referenced
-    reference_node = next((node for node in cmds.sets(node, query=True)
-                          if cmds.nodeType(node) == "reference"), None)
-
-    assert reference_node, ("Imported container not supported; "
-                            "container must be referenced.")
-
-    logger.info("Removing '%s' from Maya.." % container["name"])
-
-    namespace = cmds.referenceQuery(reference_node, namespace=True)
-    fname = cmds.referenceQuery(reference_node, filename=True)
-    cmds.file(fname, removeReference=True)
-
-    try:
-        cmds.delete(node)
-    except ValueError:
-        # Already implicitly deleted by Maya upon removing reference
-        pass
-
-    try:
-        # If container is not automatically cleaned up by May (issue #118)
-        cmds.namespace(removeNamespace=namespace, deleteNamespaceContent=True)
-    except RuntimeError:
-        pass
-
-
 def containerise(name,
                  namespace,
                  nodes,
@@ -535,8 +279,10 @@ def containerise(name,
                  loader=None,
                  suffix="_CON"):
     """Bundle `nodes` into an assembly and imprint it with metadata
+
     Containerisation enables a tracking of version, author and origin
     for loaded assets.
+
     Arguments:
         name (str): Name of resulting assembly
         namespace (str): Namespace under which to host container
@@ -544,8 +290,10 @@ def containerise(name,
         context (dict): Asset information
         loader (str, optional): Name of loader used to produce this container.
         suffix (str, optional): Suffix of container, defaults to `_CON`.
+
     Returns:
         container (str): Name of container assembly
+
     """
     AVALON_CONTAINERS = "AVALON_CONTAINERS"
     container = cmds.sets(nodes, name="%s_%s_%s" % (namespace, name, suffix))

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -359,82 +359,6 @@ def ls():
         yield data
 
 
-def load(Loader,
-         representation,
-         name=None,
-         namespace=None,
-         data=None):
-    """Load asset via database
-
-    Arguments:
-        Loader (api.Loader): The loader to process in host Maya.
-        representation (dict, io.ObjectId or str): Address to representation
-        name (str, optional): Use pre-defined name
-        namespace (str, optional): Use pre-defined namespace
-        data (dict, optional): Additional settings dictionary
-
-    """
-
-    assert representation is not None, "This is a bug"
-
-    if isinstance(representation, (six.string_types, io.ObjectId)):
-        representation = io.find_one({"_id": io.ObjectId(str(representation))})
-
-    version, subset, asset, project = io.parenthood(representation)
-
-    assert all([representation, version, subset, asset, project]), (
-        "This is a bug"
-    )
-
-    context = {
-        "project": project,
-        "asset": asset,
-        "subset": subset,
-        "version": version,
-        "representation": representation,
-    }
-
-    # Ensure data is a dictionary when no explicit data provided
-    if data is None:
-        data = dict()
-    assert isinstance(data, dict), "Data must be a dictionary"
-
-    name = name or subset["name"]
-    namespace = namespace or lib.unique_namespace(
-        asset["name"] + "_",
-        prefix="_" if asset["name"][0].isdigit() else "",
-        suffix="_",
-    )
-
-    # TODO(roy): add compatibility check, see `tools.cbloader.lib`
-
-    Loader.log.info(
-        "Running '%s' on '%s'" % (Loader.__name__, asset["name"])
-    )
-
-    try:
-        loader = Loader(context)
-
-        with lib.maintained_selection():
-            loader.process(name, namespace, context, data)
-
-    except OSError as e:
-        logger.info("WARNING: %s" % e)
-        return list()
-
-    # Only containerize if any nodes were loaded by the Loader
-    nodes = loader[:]
-    if not nodes:
-        return
-
-    return containerise(
-        name=name,
-        namespace=namespace,
-        nodes=loader[:],
-        context=context,
-        loader=Loader.__name__)
-
-
 class Creator(api.Creator):
     def process(self):
         nodes = list()
@@ -449,6 +373,8 @@ class Creator(api.Creator):
 
 
 class Loader(api.Loader):
+    hosts = ["maya"]
+
     def __init__(self, context):
         super(Loader, self).__init__(context)
         self.fname = self.fname.replace(
@@ -456,176 +382,139 @@ class Loader(api.Loader):
         )
 
 
-def create(name, asset, family, options=None, data=None):
-    """Create a new instance
-
-    Associate nodes with a subset and family. These nodes are later
-    validated, according to their `family`, and integrated into the
-    shared environment, relative their `subset`.
-
-    Data relative each family, along with default data, are imprinted
-    into the resulting objectSet. This data is later used by extractors
-    and finally asset browsers to help identify the origin of the asset.
-
-    Arguments:
-        name (str): Name of subset
-        asset (str): Name of asset
-        family (str): Name of family
-        options (dict, optional): Additional options from GUI
-        data (dict, optional): Additional data from GUI
-
-    Raises:
-        NameError on `subset` already exists
-        KeyError on invalid dynamic property
-        RuntimeError on host error
-
-    Returns:
-        Name of instance
-
+class ReferenceLoader(Loader):
+    """A basic loader that loads a Maya reference
+    
+    For backwards compatibility you can update your old Maya loaders from this
+    and it should work with the new loader methodology without `host.load`, 
+    `host.remove` and `host.update`. All you need to implement is the same
+    `process()` method as before.
+    
     """
 
-    plugins = list()
-    for Plugin in api.discover(api.Creator):
-        has_family = family == Plugin.family
+    representations = ["ma", "mb", "abc"]
 
-        if not has_family:
-            continue
-
-        Plugin.log.info(
-            "Creating '%s' with '%s'" % (name, Plugin.__name__)
-        )
-
-        try:
-            plugin = Plugin(name, asset, options, data)
-
-            with lib.maintained_selection():
-                instance = plugin.process()
-        except Exception as e:
-            logger.info("WARNING: %s" % e)
-            continue
-
-        plugins.append(plugin)
-
-    assert plugins, "No Creator plug-ins were run, this is a bug"
-    return instance
-
-
-def update(container, version=-1):
-    """Update `container` to `version`
-
-    This function relies on a container being referenced. At the time of this
-    writing, all assets - models, rigs, animations, shaders - are referenced
-    and should pose no problem. But should there be an asset that isn't
-    referenced then this function will need to see an update.
-
-    Arguments:
-        container (avalon-core:container-1.0): Container to update,
-            from `host.ls()`.
-        version (int, optional): Update the container to this version.
-            If no version is passed, the latest is assumed.
-
-    """
-
-    node = container["objectName"]
-
-    # Assume asset has been referenced
-    reference_node = next((node for node in cmds.sets(node, query=True)
-                          if cmds.nodeType(node) == "reference"), None)
-
-    assert reference_node, ("Imported container not supported; "
-                            "container must be referenced.")
-
-    current_representation = io.find_one({
-        "_id": io.ObjectId(container["representation"])
-    })
-
-    assert current_representation is not None, "This is a bug"
-
-    version_, subset, asset, project = io.parenthood(current_representation)
-
-    if version == -1:
-        new_version = io.find_one({
-            "type": "version",
-            "parent": subset["_id"]
-        }, sort=[("name", -1)])
-    else:
-        new_version = io.find_one({
-            "type": "version",
-            "parent": subset["_id"],
-            "name": version,
-        })
-
-    new_representation = io.find_one({
-        "type": "representation",
-        "parent": new_version["_id"],
-        "name": current_representation["name"]
-    })
-
-    assert new_version is not None, "This is a bug"
-
-    template_publish = project["config"]["template"]["publish"]
-    fname = template_publish.format(**{
-        "root": api.registered_root(),
-        "project": project["name"],
-        "asset": asset["name"],
-        "silo": asset["silo"],
-        "subset": subset["name"],
-        "version": new_version["name"],
-        "representation": current_representation["name"],
-    })
-
-    file_type = {
+    # Extension to maya file type conversion - for `update()` method
+    file_types = {
         "ma": "mayaAscii",
         "mb": "mayaBinary",
         "abc": "Alembic"
-    }.get(new_representation["name"])
+    }
 
-    assert file_type, ("Unsupported representation: %s" % new_representation)
+    def load(self,
+             context,
+             name=None,
+             namespace=None,
+             data=None):
 
-    assert os.path.exists(fname), "%s does not exist." % fname
-    cmds.file(fname, loadReference=reference_node, type=file_type)
+        asset = context['asset']['name']
+        subset = context['subset']['name']
 
-    # Update metadata
-    cmds.setAttr(container["objectName"] + ".representation",
-                 str(new_representation["_id"]),
-                 type="string")
+        name = name or subset
+        namespace = namespace or lib.unique_namespace(
+            asset + "_",
+            prefix="_" if asset[0].isdigit() else "",
+            suffix="_",
+        )
 
+        try:
+            with lib.maintained_selection():
+                self.process(name, namespace, context, data)
+        except OSError as e:
+            logger.info("WARNING: %s" % e)
+            return list()
 
-def remove(container):
-    """Remove an existing `container` from Maya scene
+        # Only containerize if any nodes were loaded by the Loader
+        nodes = self[:]
+        if not nodes:
+            return
 
-    Arguments:
-        container (avalon-core:container-1.0): Which container
-            to remove from scene.
+        return containerise(
+            name=name,
+            namespace=namespace,
+            nodes=nodes,
+            context=context,
+            loader=self.__class__.__name__)
 
-    """
+    def update(self, container, new_representation):
+        """
+        
+        This function relies on a container being referenced. At the time of 
+        this writing, all assets - models, rigs, animations, shaders - are 
+        referenced and should pose no problem. But should there be an asset 
+        that isn't referenced then this function will need to see an update.
+        
+        """
 
-    node = container["objectName"]
+        fname = api.get_representation_path(new_representation)
+        node = container["objectName"]
 
-    # Assume asset has been referenced
-    reference_node = next((node for node in cmds.sets(node, query=True)
-                          if cmds.nodeType(node) == "reference"), None)
+        # Assume asset has been referenced
+        reference_node = next((node for node in cmds.sets(node, query=True)
+                               if cmds.nodeType(node) == "reference"), None)
 
-    assert reference_node, ("Imported container not supported; "
-                            "container must be referenced.")
+        assert reference_node, ("Imported container not supported; "
+                                "container must be referenced.")
 
-    logger.info("Removing '%s' from Maya.." % container["name"])
+        file_type = self.file_types.get(new_representation["name"])
 
-    namespace = cmds.referenceQuery(reference_node, namespace=True)
-    fname = cmds.referenceQuery(reference_node, filename=True)
-    cmds.file(fname, removeReference=True)
+        assert file_type, ("Unsupported representation: %s" %
+                           new_representation)
 
-    try:
-        cmds.delete(node)
-    except ValueError:
-        # Already implicitly deleted by Maya upon removing reference
-        pass
+        assert os.path.exists(fname), "%s does not exist." % fname
+        cmds.file(fname, loadReference=reference_node, type=file_type)
 
-    try:
-        # If container is not automatically cleaned up by May (issue #118)
-        cmds.namespace(removeNamespace=namespace, deleteNamespaceContent=True)
-    except RuntimeError:
-        pass
+        # Update metadata
+        cmds.setAttr(container["objectName"] + ".representation",
+                     str(new_representation["_id"]),
+                     type="string")
+
+    def remove(self, container):
+        """Remove an existing `container` from Maya scene
+
+        Arguments:
+            container (avalon-core:container-1.0): Which container
+                to remove from scene.
+
+        """
+
+        node = container["objectName"]
+
+        # Assume asset has been referenced
+        reference_node = next((node for node in cmds.sets(node, query=True)
+                               if cmds.nodeType(node) == "reference"), None)
+
+        assert reference_node, ("Imported container not supported; "
+                                "container must be referenced.")
+
+        logger.info("Removing '%s' from Maya.." % container["name"])
+
+        namespace = cmds.referenceQuery(reference_node, namespace=True)
+        fname = cmds.referenceQuery(reference_node, filename=True)
+        cmds.file(fname, removeReference=True)
+
+        try:
+            cmds.delete(node)
+        except ValueError:
+            # Already implicitly deleted by Maya upon removing reference
+            pass
+
+        try:
+            # If container is not automatically cleaned up by May (issue #118)
+            cmds.namespace(removeNamespace=namespace,
+                           deleteNamespaceContent=True)
+        except RuntimeError:
+            pass
+
+    def process(self, name, namespace, context, data):
+        """This method is here to preserve backwards compatibility.
+        
+        
+        """
+        self.log.error("When inheriting from `ReferenceLoader` you must "
+                       "implement the `process()` method.")
+        raise RuntimeError("No ReferenceLoader process implemented. "
+                           "See log for details.")
 
 
 def publish():

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -13,8 +13,10 @@ from .. import api, schema
 from ..vendor.Qt import QtCore, QtWidgets
 
 # Backwards compatibility
-from .compat import load, update, remove
-from ..pipeline import create
+load = compat.load
+update = compat.update
+remove = compat.remove
+create = compat.create
 
 self = sys.modules[__name__]
 self._menu = "avalonmaya"  # Unique name of menu
@@ -336,14 +338,15 @@ def containerise(name,
 
 def parse_container(container, validate=True):
     """Return the container node's full container data.
-    
+
     Args:
-        container (str): A container node name. 
+        container (str): A container node name.
 
     Returns:
         dict: The container schema data for this container node.
-        
+
     """
+
     data = lib.read(container)
 
     # Backwards compatibility pre-schemas for containers

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -167,7 +167,7 @@ class Loader(list):
 
         """
         raise NotImplementedError("Loader.load() must be "
-                                  "implemented by subclasses")
+                                  "implemented by subclass")
 
     def update(self, container, representation):
         """Update `container` to `representation`
@@ -178,8 +178,8 @@ class Loader(list):
             representation (dict): Update the container to this representation.
 
         """
-        raise NotImplementedError("Loader.load() must be "
-                                  "implemented by subclasses")
+        raise NotImplementedError("Loader.update() must be "
+                                  "implemented by subclass")
 
     def remove(self, container):
         """Remove a container
@@ -192,8 +192,8 @@ class Loader(list):
             bool: Whether the container was deleted
             
         """
-        raise NotImplementedError("Loader.load() must be "
-                                  "implemented by subclasses")
+        raise NotImplementedError("Loader.remove() must be "
+                                  "implemented by subclass")
 
 
 @lib.log

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -707,6 +707,10 @@ def load(Loader, representation, namespace=None, name=None, data=None):
         data = dict()
     assert isinstance(data, dict), "Data must be a dictionary"
 
+    # Fallback to subset when name is None
+    if name is None:
+        name = context['subset']['name']
+
     # todo(roy): Ensure the Loader is valid for the representation
 
     log.info(

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -699,26 +699,6 @@ def _get_representation_context(representation):
 
 
 def load(Loader, representation, namespace=None, name=None, data=None):
-    if hasattr(Loader, "process"):
-        from .maya.pipeline import load
-        return load(
-            Loader,
-            representation,
-            namespace=None,
-            name=None,
-            data=None
-        )
-
-    return _load(
-        Loader,
-        representation,
-        namespace=None,
-        name=None,
-        data=None
-    )
-
-
-def _load(Loader, representation, namespace=None, name=None, data=None):
 
     context = _get_representation_context(representation)
 

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -183,15 +183,16 @@ class Loader(list):
 
     def remove(self, container):
         """Remove a container
-        
+
         Arguments:
             container (avalon-core:container-1.0): Container to remove,
                 from `host.ls()`.
-                
+
         Returns:
             bool: Whether the container was deleted
-            
+
         """
+
         raise NotImplementedError("Loader.remove() must be "
                                   "implemented by subclass")
 
@@ -665,6 +666,7 @@ def create(name, asset, family, options=None, data=None):
             plugin = Plugin(name, asset, options, data)
 
             with host.maintained_selection():
+                print("Running %s" % plugin)
                 instance = plugin.process()
         except Exception as e:
             log.warning(e)
@@ -673,6 +675,7 @@ def create(name, asset, family, options=None, data=None):
         plugins.append(plugin)
 
     assert plugins, "No Creator plug-ins were run, this is a bug"
+    print("Here: %s" % instance)
     return instance
 
 
@@ -703,13 +706,13 @@ def _get_representation_context(representation):
 
 def _make_backwards_compatible_loader(Loader):
     """Convert a old-style Loaders with `process` method to new-style Loader
-    
+
     This will make a dynamic class inheriting the old-style loader together
     with a BackwardsCompatibleLoader. This backwards compatible loader will
     expose `load`, `remove` and `update` in the same old way for Maya loaders.
-    
+
     The `load` method will then call `process()` just like before.
-    
+
     """
 
     # Assume new-style loader when no `process` method is exposed
@@ -723,14 +726,13 @@ def _make_backwards_compatible_loader(Loader):
 
 
 def load(Loader, representation, namespace=None, name=None, data=None):
-
     Loader = _make_backwards_compatible_loader(Loader)
-
     context = _get_representation_context(representation)
 
     # Ensure data is a dictionary when no explicit data provided
     if data is None:
         data = dict()
+
     assert isinstance(data, dict), "Data must be a dictionary"
 
     # Fallback to subset when name is None

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -154,11 +154,43 @@ class Loader(list):
         data["silo"] = context["asset"]["silo"]
 
         fname = template.format(**data)
-
         self.fname = fname
 
-    def process(self, name, namespace, context, data):
+    def load(self, context, name=None, namespace=None, data=None):
+        """Load asset via database
+
+        Arguments:
+            context (dict): Full parenthood of representation to load
+            name (str, optional): Use pre-defined name
+            namespace (str, optional): Use pre-defined namespace
+            data (dict, optional): Additional settings dictionary
+
+        """
         pass
+
+    def update(self, container, representation):
+        """Update `container` to `representation`
+
+        Arguments:
+            container (avalon-core:container-1.0): Container to update,
+                from `host.ls()`.
+            representation (dict): Update the container to this representation.
+
+        """
+        pass
+
+    def remove(self, container):
+        """Remove a container
+        
+        Arguments:
+            container (avalon-core:container-1.0): Container to remove,
+                from `host.ls()`.
+                
+        Returns:
+            bool: Whether the container was deleted
+            
+        """
+        return False
 
 
 @lib.log
@@ -255,6 +287,14 @@ def plugin_from_module(superclass, module):
 
     types = list()
 
+    def recursive_bases(klass):
+        r = []
+        bases = klass.__bases__
+        r.extend(bases)
+        for base in bases:
+            r.extend(recursive_bases(base))
+        return r
+
     for name in dir(module):
 
         # It could be anything at this point
@@ -263,15 +303,14 @@ def plugin_from_module(superclass, module):
         if not inspect.isclass(obj):
             continue
 
-        bases = obj.__bases__
-
         # These are subclassed from nothing, not even `object`
-        if not len(bases) > 0:
+        if not len(obj.__bases__) > 0:
             continue
 
         # Use string comparison rather than `issubclass`
         # in order to support reloading of this module.
-        if bases[0].__name__ != superclass.__name__:
+        bases = recursive_bases(obj)
+        if not any(base.__name__ == superclass.__name__ for base in bases):
             continue
 
         types.append(obj)
@@ -422,26 +461,7 @@ def register_host(host):
 
     """
     signatures = {
-        "load": [
-            "Loader",
-            "representation"
-        ],
-        "create": [
-            "name",
-            "family",
-            "asset",
-            "options",
-            "data"
-        ],
-        "ls": [
-        ],
-        "update": [
-            "container",
-            "version"
-        ],
-        "remove": [
-            "container"
-        ],
+        "ls": []
     }
 
     _validate_signature(host, signatures)
@@ -555,24 +575,8 @@ def default_host():
     def ls():
         return list()
 
-    def load(Loader=None,
-             representation=None,
-             name=None,
-             namespace=None,
-             data=None):
-        return None
-
-    def create(family):
-        return "instanceFromDefaultHost"
-
-    def remove(container):
-        print("Removing '%s' from defaultHost.." % container["name"])
-
     host.__dict__.update({
-        "ls": ls,
-        "load": load,
-        "create": create,
-        "remove": remove,
+        "ls": ls
     })
 
     return host
@@ -580,7 +584,6 @@ def default_host():
 
 def debug_host():
     """A debug host, useful to debugging features that depend on a host"""
-    from pprint import pformat
 
     host = types.ModuleType("debugHost")
 
@@ -607,40 +610,187 @@ def debug_host():
         for container in containers:
             yield container
 
-    def load(Loader,
-             representation=None,
-             name=None,
-             namespace=None,
-             data=None):
-        sys.stdout.write(pformat({
-            "loader": Loader,
-            "representation": representation
-        }) + "\n"),
-
-        return None
-
-    def create(name, asset, family, options=None, data=None):
-        sys.stdout.write(pformat({
-            "family": family,
-        }))
-        return "instanceFromDebugHost"
-
-    def update(container, version=-1):
-        print("Grading '{name}' from '{from_}' to '{to_}'".format(
-            name=container["name"],
-            from_=container["version"],
-            to_=version
-        ))
-
-    def remove(container):
-        print("Removing '%s' from debugHost.." % container["name"])
-
     host.__dict__.update({
-        "ls": ls,
-        "load": load,
-        "create": create,
-        "update": update,
-        "remove": remove,
+        "ls": ls
     })
 
     return host
+
+
+def create(name, asset, family, options=None, data=None):
+    """Create a new instance
+
+    Associate nodes with a subset and family. These nodes are later
+    validated, according to their `family`, and integrated into the
+    shared environment, relative their `subset`.
+
+    Data relative each family, along with default data, are imprinted
+    into the resulting objectSet. This data is later used by extractors
+    and finally asset browsers to help identify the origin of the asset.
+
+    Arguments:
+        name (str): Name of subset
+        asset (str): Name of asset
+        family (str): Name of family
+        options (dict, optional): Additional options from GUI
+        data (dict, optional): Additional data from GUI
+
+    Raises:
+        NameError on `subset` already exists
+        KeyError on invalid dynamic property
+        RuntimeError on host error
+
+    Returns:
+        Name of instance
+
+    """
+
+    host = registered_host()
+
+    plugins = list()
+    for Plugin in discover(Creator):
+        has_family = family == Plugin.family
+
+        if not has_family:
+            continue
+
+        Plugin.log.info(
+            "Creating '%s' with '%s'" % (name, Plugin.__name__)
+        )
+
+        try:
+            plugin = Plugin(name, asset, options, data)
+
+            with host.maintained_selection():
+                instance = plugin.process()
+        except Exception as e:
+            log.warning(e)
+            continue
+
+        plugins.append(plugin)
+
+    assert plugins, "No Creator plug-ins were run, this is a bug"
+    return instance
+
+
+def _get_representation_context(representation):
+
+    assert representation is not None, "This is a bug"
+
+    if isinstance(representation, (six.string_types, io.ObjectId)):
+        representation = io.find_one(
+            {"_id": io.ObjectId(str(representation))})
+
+    version, subset, asset, project = io.parenthood(representation)
+
+    assert all([representation, version, subset, asset, project]), (
+        "This is a bug"
+    )
+
+    context = {
+        "project": project,
+        "asset": asset,
+        "subset": subset,
+        "version": version,
+        "representation": representation,
+    }
+
+    return context
+
+
+def load(Loader, representation, namespace=None, name=None, data=None):
+
+    context = _get_representation_context(representation)
+
+    # Ensure data is a dictionary when no explicit data provided
+    if data is None:
+        data = dict()
+    assert isinstance(data, dict), "Data must be a dictionary"
+
+    # todo(roy): Ensure the Loader is valid for the representation
+
+    log.info(
+        "Running '%s' on '%s'" % (Loader.__name__, context['asset']["name"])
+    )
+
+    loader = Loader(context)
+    return loader.load(context, namespace, name, data)
+
+
+def _get_container_loader(container):
+    """Return the Loader corresponding to the container"""
+
+    loader = container['loader']
+    for Plugin in discover(Loader):
+
+        # TODO: Ensure the loader is valid
+        if Plugin.__name__ == loader:
+            return Plugin
+
+
+def remove(container):
+    """Remove a container"""
+
+    Loader = _get_container_loader(container)
+    if not Loader:
+        raise RuntimeError("Can't remove container. See log for details.")
+
+    loader = Loader(_get_representation_context(container['representation']))
+    return loader.remove(container)
+
+
+def update(container, version=-1):
+    """Update a container"""
+
+    # Compute the different version from 'representation'
+    current_representation = io.find_one({
+        "_id": io.ObjectId(container["representation"])
+    })
+
+    assert current_representation is not None, "This is a bug"
+
+    current_version, subset, asset, project = io.parenthood(
+        current_representation)
+
+    if version == -1:
+        new_version = io.find_one({
+            "type": "version",
+            "parent": subset["_id"]
+        }, sort=[("name", -1)])
+    else:
+        new_version = io.find_one({
+            "type": "version",
+            "parent": subset["_id"],
+            "name": version,
+        })
+
+    new_representation = io.find_one({
+        "type": "representation",
+        "parent": new_version["_id"],
+        "name": current_representation["name"]
+    })
+
+    assert new_version is not None, "This is a bug"
+
+    # Run update on the Loader for this container
+    Loader = _get_container_loader(container)
+    if not Loader:
+        raise RuntimeError("Can't update container. See log for details.")
+    loader = Loader(_get_representation_context(container['representation']))
+    return loader.update(container, new_representation)
+
+
+def get_representation_path(representation):
+    """Get filename from representation id"""
+
+    version_, subset, asset, project = io.parenthood(representation)
+    template_publish = project["config"]["template"]["publish"]
+    return template_publish.format(**{
+        "root": registered_root(),
+        "project": project["name"],
+        "asset": asset["name"],
+        "silo": asset["silo"],
+        "subset": subset["name"],
+        "version": version_["name"],
+        "representation": representation["name"],
+    })

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -166,7 +166,8 @@ class Loader(list):
             data (dict, optional): Additional settings dictionary
 
         """
-        pass
+        raise NotImplementedError("Loader.load() must be "
+                                  "implemented by subclasses")
 
     def update(self, container, representation):
         """Update `container` to `representation`
@@ -177,7 +178,8 @@ class Loader(list):
             representation (dict): Update the container to this representation.
 
         """
-        pass
+        raise NotImplementedError("Loader.load() must be "
+                                  "implemented by subclasses")
 
     def remove(self, container):
         """Remove a container
@@ -190,7 +192,8 @@ class Loader(list):
             bool: Whether the container was deleted
             
         """
-        return False
+        raise NotImplementedError("Loader.load() must be "
+                                  "implemented by subclasses")
 
 
 @lib.log

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -718,7 +718,10 @@ def load(Loader, representation, namespace=None, name=None, data=None):
     )
 
     loader = Loader(context)
-    return loader.load(context, namespace, name, data)
+    return loader.load(context=context,
+                       name=name,
+                       namespace=namespace,
+                       data=data)
 
 
 def _get_container_loader(container):

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -675,7 +675,6 @@ def create(name, asset, family, options=None, data=None):
         plugins.append(plugin)
 
     assert plugins, "No Creator plug-ins were run, this is a bug"
-    print("Here: %s" % instance)
     return instance
 
 

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -699,6 +699,26 @@ def _get_representation_context(representation):
 
 
 def load(Loader, representation, namespace=None, name=None, data=None):
+    if hasattr(Loader, "process"):
+        from .maya.pipeline import load
+        return load(
+            Loader,
+            representation,
+            namespace=None,
+            name=None,
+            data=None
+        )
+
+    return _load(
+        Loader,
+        representation,
+        namespace=None,
+        name=None,
+        data=None
+    )
+
+
+def _load(Loader, representation, namespace=None, name=None, data=None):
 
     context = _get_representation_context(representation)
 

--- a/avalon/tests/test_pipeline.py
+++ b/avalon/tests/test_pipeline.py
@@ -36,10 +36,6 @@ def setup():
     host = types.ModuleType("Test")
     host.__dict__.update({
         "ls": lambda: [],
-        "create": lambda name, asset, family, options, data: None,
-        "load": lambda Loader, representation: None,
-        "update": lambda container, version: None,
-        "remove": lambda container: None,
     })
 
     pipeline.register_host(host)

--- a/avalon/tools/cbloader/lib.py
+++ b/avalon/tools/cbloader/lib.py
@@ -75,6 +75,6 @@ def run_loader(Loader,
 
     return api.load(Loader,
                     representation=representation,
-                    name=name,
                     namespace=namespace,
+                    name=name,
                     data=data)

--- a/avalon/tools/cbloader/lib.py
+++ b/avalon/tools/cbloader/lib.py
@@ -73,9 +73,8 @@ def run_loader(Loader,
     if not is_compatible_loader(Loader, context):
         raise RuntimeError("Loader is not compatible.")
 
-    host = api.registered_host()
-    return host.load(Loader,
-                     representation=representation,
-                     name=name,
-                     namespace=namespace,
-                     data=data)
+    return api.load(Loader,
+                    representation=representation,
+                    name=name,
+                    namespace=namespace,
+                    data=data)

--- a/avalon/tools/cbsceneinventory/app.py
+++ b/avalon/tools/cbsceneinventory/app.py
@@ -67,13 +67,12 @@ class View(QtWidgets.QTreeView):
     def build_item_menu(self, items):
         """Create menu for the selected items"""
 
-        host = api.registered_host()
         menu = QtWidgets.QMenu(self)
 
         # update to latest version
         def _on_update_to_latest(items):
             for item in items:
-                host.update(item, -1)
+                api.update(item, -1)
             self.data_changed.emit()
 
         update_icon = qta.icon("fa.angle-double-up", color=DEFAULT_COLOR)
@@ -223,9 +222,8 @@ class View(QtWidgets.QTreeView):
 
         if label:
             version = versions_by_label[label]["name"]
-            host = api.registered_host()
             for item in items:
-                host.update(item, version)
+                api.update(item, version)
             # refresh model when done
             self.data_changed.emit()
 
@@ -247,7 +245,7 @@ class View(QtWidgets.QTreeView):
 
         host = api.registered_host()
         for item in items:
-            host.remove(item)
+            api.remove(item)
         self.data_changed.emit()
 
 

--- a/avalon/tools/cbsceneinventory/app.py
+++ b/avalon/tools/cbsceneinventory/app.py
@@ -183,8 +183,6 @@ class View(QtWidgets.QTreeView):
 
         active = items[-1]
 
-        print active
-
         # Get available versions for active representation
         representation_id = io.ObjectId(active["representation"])
         representation = io.find_one({"_id": representation_id})

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -301,13 +301,12 @@ class Window(QtWidgets.QDialog):
             return
 
         try:
-            host = api.registered_host()
-            host.create(subset_name,
-                        asset,
-                        family,
-                        options={"useSelection":
-                                 useselection_chk.checkState()}
-                        )
+            api.create(subset_name,
+                       asset,
+                       family,
+                       options={"useSelection":
+                                useselection_chk.checkState()}
+                       )
 
         except NameError as e:
             self.echo(e)

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -34,7 +34,7 @@ class Window(QtWidgets.QDialog):
         asset = QtWidgets.QLineEdit()
         name = QtWidgets.QLineEdit()
         result = QtWidgets.QLineEdit()
-        result.setReadOnly(True)
+        result.setEnabled(False)
 
         # region Menu for default subset names
 

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -16,6 +16,9 @@ PluginRole = QtCore.Qt.UserRole + 5
 
 
 class Window(QtWidgets.QDialog):
+
+    stateChanged = QtCore.Signal(bool)
+
     def __init__(self, parent=None):
         super(Window, self).__init__(parent)
         self.setWindowTitle("Instance Creator")
@@ -23,6 +26,11 @@ class Window(QtWidgets.QDialog):
 
         # Store the widgets for lookup in here
         self.data = dict()
+
+        # Store internal states in here
+        self.state = {
+            "valid": False
+        }
 
         body = QtWidgets.QWidget()
         lists = QtWidgets.QWidget()
@@ -112,10 +120,16 @@ class Window(QtWidgets.QDialog):
         asset.textChanged.connect(self.on_data_changed)
         listing.currentItemChanged.connect(self.on_selection_changed)
 
+        self.stateChanged.connect(self._on_state_changed)
+
         # Defaults
         self.resize(220, 300)
         name.setFocus()
         create_btn.setEnabled(False)
+
+    def _on_state_changed(self, state):
+        self.state['valid'] = state
+        self.data['Create Button'].setEnabled(state)
 
     def _build_menu(self, default_names):
         """Create optional predefines subset names
@@ -196,16 +210,22 @@ class Window(QtWidgets.QDialog):
             item.setData(ExistsRole, False)
             self.echo("'%s' not found .." % asset_name)
 
-        button.setEnabled(
+        # Update the valid state
+        valid = (
             subset_name.strip() != "" and
             asset_name.strip() != "" and
             item.data(QtCore.Qt.ItemIsEnabled) and
             item.data(ExistsRole)
         )
+        self.stateChanged.emit(valid)
 
     def on_data_changed(self, *args):
-        button = self.data["Create Button"]
-        button.setEnabled(False)
+
+        # Set invalid state until it's reconfirmed to be valid by the
+        # scheduled callback so any form of creation is held back until
+        # valid again
+        self.stateChanged.emit(False)
+
         lib.schedule(self._on_data_changed, 500, channel="gui")
 
     def on_selection_changed(self, *args):
@@ -261,6 +281,10 @@ class Window(QtWidgets.QDialog):
         listing.setCurrentItem(listing.item(0))
 
     def on_create(self):
+
+        # Do not allow creation in an invalid state
+        if not self.state['valid']:
+            return
 
         asset = self.data["Asset"]
         listing = self.data["Listing"]

--- a/avalon/tools/loader/app.py
+++ b/avalon/tools/loader/app.py
@@ -805,9 +805,7 @@ QSlider::handle:horizontal:enabled {
                     ])
                 )
 
-                host = api.registered_host()
-                host.load(Loader=loader,
-                          representation=_id)
+                api.load(Loader=loader, representation=_id)
 
             except StopIteration:
                 raise IndexError("No loaders available")

--- a/avalon/tools/manager/app.py
+++ b/avalon/tools/manager/app.py
@@ -318,7 +318,7 @@ class Window(QtWidgets.QDialog):
         if messagebox.exec_() == messagebox.Yes:
 
             self.echo("Removing '%s'.." % container["name"])
-            api.registered_host().remove(container)
+            api.remove(container)
 
             if autoclose_checkbox.checkState():
                 self.close()
@@ -347,7 +347,7 @@ class Window(QtWidgets.QDialog):
                         version=version["name"])
             )
 
-            api.registered_host().update(
+            api.update(
                 container=container,
                 version=version["name"]
             )


### PR DESCRIPTION
Here's a draft api revamp for #195.

Basicallly the idea is that not the `host` decides how something is loaded and managed but the `Loader` implements all the logic. As such these loaders will now manage the `load`, `update`,  `remove` functionality.

At this point it's not 100% backwards compatible, here's the catch:

- You'll need to update all your Loaders to use the new `Loader.load` method.
    - For Maya there's `avalon.maya.pipeline.ReferenceLoader` - when you inherit your Loader from that specific loader you can keep your old `process` logic and it should work as expected.
- Any calls to `host.load`, `host.update` or `host.remove` should be respectively refactored to `api.load`, `api.update`, `api.remove`.
    - Also check for this in your current Loaders! If you trigger a `host.load` from your plug-in make sure to also refactor that to use the new `api.load()` method.

---

Other notes:

- The logic for "inheritance" check in `discover` has changed so that it allows checking multiple inheritance instead of only name of direct parent class.
- This could have some other commits that haven't been pulled into getavalon/core yet, but they should be minor.
- Note that the `update` method on the Loader plug-in doesn't have the same signature as the `api.update` method. (Because the `api.update` method already gets the representation for you based on version number alone so that logic doesn't have to be pushed into the Loader and Avalon's core handles the main logic there.)
- *Renaming the Loader can have confusing results* - currently the loader that's picked to remove or update a _container_ is based on its `loader` data, which is purely the Loader's class name. As such, when a Loader class is renamed (or removed!) it cannot be managed anymore. @mottosso Not sure how to deal with that otherwise?

---

> Note: *I've tested some tools but of course take a run with this yourself to see whether it's stable!*