### PR TITLE
Some minor changes and fixes

### DIFF
--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -24,6 +24,7 @@ self._events = dict()  # Registered Maya callbacks
 self._parent = None  # Main Window
 self._ignore_lock = False
 
+AVALON_CONTAINERS = ":AVALON_CONTAINERS"
 IS_HEADLESS = not hasattr(cmds, "about") or cmds.about(batch=True)
 
 
@@ -282,7 +283,7 @@ def containerise(name,
                  nodes,
                  context,
                  loader=None,
-                 suffix="_CON"):
+                 suffix="CON"):
     """Bundle `nodes` into an assembly and imprint it with metadata
 
     Containerisation enables a tracking of version, author and origin
@@ -300,7 +301,6 @@ def containerise(name,
         container (str): Name of container assembly
 
     """
-    AVALON_CONTAINERS = "AVALON_CONTAINERS"
     container = cmds.sets(nodes, name="%s_%s_%s" % (namespace, name, suffix))
 
     data = [
@@ -330,7 +330,6 @@ def containerise(name,
     else:
         main_container = main_container[0]
 
-    # addElement requires the set to which the items need to be added to
     cmds.sets(container, addElement=main_container)
 
     return container
@@ -338,15 +337,14 @@ def containerise(name,
 
 def parse_container(container, validate=True):
     """Return the container node's full container data.
-
+    
     Args:
-        container (str): A container node name.
+        container (str): A container node name. 
 
     Returns:
         dict: The container schema data for this container node.
-
+        
     """
-
     data = lib.read(container)
 
     # Backwards compatibility pre-schemas for containers

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -337,13 +337,13 @@ def containerise(name,
 
 def parse_container(container, validate=True):
     """Return the container node's full container data.
-    
+
     Args:
-        container (str): A container node name. 
+        container (str): A container node name.
 
     Returns:
         dict: The container schema data for this container node.
-        
+
     """
     data = lib.read(container)
 

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -820,7 +820,15 @@ def update(container, version=-1):
 
 
 def get_representation_path(representation):
-    """Get filename from representation id"""
+    """Get filename from representation document
+
+    Args:
+        representation(dict): representation document from the database
+
+    Returns:
+        str: fullpath of the representation
+
+    """
 
     version_, subset, asset, project = io.parenthood(representation)
     template_publish = project["config"]["template"]["publish"]

--- a/avalon/tools/cbloader/app.py
+++ b/avalon/tools/cbloader/app.py
@@ -207,7 +207,6 @@ class Window(QtWidgets.QDialog):
         if asset is None:
             return
 
-        asset_widget = self.data['model']['assets']
         if refresh:
             # Workaround:
             # Force a direct (non-scheduled) refresh prior to setting the
@@ -217,7 +216,8 @@ class Window(QtWidgets.QDialog):
             # scheduled refresh and the silo tabs are not shown.
             self._refresh()
 
-        asset_widget.model.set_silo(silo)
+        asset_widget = self.data['model']['assets']
+        asset_widget.set_silo(silo)
         asset_widget.select_assets([asset], expand=True)
 
     def echo(self, message):
@@ -263,7 +263,16 @@ def show(root=None, debug=False, parent=None, use_context=False):
     # Remember window
     if module.window is not None:
         try:
-            return module.window.show()
+            module.window.show()
+
+            # If the window is minimized then unminimize it.
+            if module.window.windowState() & QtCore.Qt.WindowMinimized:
+                module.window.setWindowState(QtCore.Qt.WindowActive)
+
+            # Raise and activate the window
+            module.window.raise_()             # for MacOS
+            module.window.activateWindow()     # for Windows
+            return
         except RuntimeError as e:
             if not e.message.rstrip().endswith("already deleted."):
                 raise

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -4,6 +4,7 @@ import inspect
 
 from ...vendor.Qt import QtWidgets, QtCore, QtGui
 from ...vendor import qtawesome
+from ...vendor import six
 from ... import api, io
 from .. import lib
 
@@ -407,7 +408,7 @@ class FamilyDescriptionWidget(QtWidgets.QWidget):
         # Support a font-awesome icon
         plugin = item.data(PluginRole)
         icon = getattr(plugin, "icon", "info-circle")
-        assert isinstance(icon, (str, unicode))
+        assert isinstance(icon, six.string_types)
         icon = qtawesome.icon("fa.{}".format(icon), color="white")
         pixmap = icon.pixmap(self.SIZE, self.SIZE)
         pixmap = pixmap.scaled(self.SIZE, self.SIZE)

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import inspect
 
 from ...vendor.Qt import QtWidgets, QtCore, QtGui
 from ...vendor import qtawesome
@@ -411,10 +412,13 @@ class FamilyDescriptionWidget(QtWidgets.QWidget):
         pixmap = icon.pixmap(self.SIZE, self.SIZE)
         pixmap = pixmap.scaled(self.SIZE, self.SIZE)
 
-        self.icon.setPixmap(pixmap)
+        # Parse a clean line from the Creator's docstring
+        docstring = inspect.getdoc(plugin)
+        help = docstring.splitlines()[0] if docstring else ""
 
+        self.icon.setPixmap(pixmap)
         self.family.setText(item.data(FamilyRole))
-        self.help.setText(item.data(HelpRole))
+        self.help.setText(help)
 
 
 def show(debug=False, parent=None):

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -1,7 +1,8 @@
 import os
 import sys
 
-from ...vendor.Qt import QtWidgets, QtCore
+from ...vendor.Qt import QtWidgets, QtCore, QtGui
+from ...vendor import qtawesome
 from ... import api, io
 from .. import lib
 
@@ -60,6 +61,10 @@ class Window(QtWidgets.QDialog):
         name_layout.setContentsMargins(0, 0, 0, 0)
 
         layout = QtWidgets.QVBoxLayout(container)
+
+        header = FamilyDescriptionWidget(parent=self)
+        layout.addWidget(header)
+
         layout.addWidget(QtWidgets.QLabel("Family"))
         layout.addWidget(listing)
         layout.addWidget(QtWidgets.QLabel("Asset"))
@@ -119,11 +124,12 @@ class Window(QtWidgets.QDialog):
         name.textChanged.connect(self.on_data_changed)
         asset.textChanged.connect(self.on_data_changed)
         listing.currentItemChanged.connect(self.on_selection_changed)
+        listing.currentItemChanged.connect(header.set_item)
 
         self.stateChanged.connect(self._on_state_changed)
 
         # Defaults
-        self.resize(220, 300)
+        self.resize(300, 400)
         name.setFocus()
         create_btn.setEnabled(False)
 
@@ -132,7 +138,7 @@ class Window(QtWidgets.QDialog):
         self.data['Create Button'].setEnabled(state)
 
     def _build_menu(self, default_names):
-        """Create optional predefines subset names
+        """Create optional predefined subset names
 
         Args:
             default_names(list): all predefined names
@@ -322,6 +328,93 @@ class Window(QtWidgets.QDialog):
         widget.show()
 
         lib.schedule(lambda: widget.setText(""), 5000, channel="message")
+
+
+class FamilyDescriptionWidget(QtWidgets.QWidget):
+    """A family description widget.
+
+    Shows a family icon, family name and a help description.
+    Used in creator header.
+
+     _________________
+    |  ____           |
+    | |icon| FAMILY   |
+    | |____| help     |
+    |_________________|
+
+    """
+
+    SIZE = 35
+
+    def __init__(self, parent=None):
+        super(FamilyDescriptionWidget, self).__init__(parent=parent)
+
+        # Header font
+        font = QtGui.QFont()
+        font.setBold(True)
+        font.setPointSize(14)
+
+        layout = QtWidgets.QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        icon = QtWidgets.QLabel()
+        icon.setSizePolicy(QtWidgets.QSizePolicy.Maximum,
+                           QtWidgets.QSizePolicy.Maximum)
+
+        # Add 2 pixel padding to avoid icon being cut off
+        icon.setFixedWidth(self.SIZE + 2)
+        icon.setFixedHeight(self.SIZE + 2)
+        icon.setStyleSheet("""
+        QLabel {
+            padding-right: 5px;
+        }
+        """)
+
+        label_layout = QtWidgets.QVBoxLayout()
+        label_layout.setSpacing(0)
+
+        family = QtWidgets.QLabel("family")
+        family.setFont(font)
+        family.setAlignment(QtCore.Qt.AlignBottom | QtCore.Qt.AlignLeft)
+
+        help = QtWidgets.QLabel("help")
+        help.setAlignment(QtCore.Qt.AlignTop | QtCore.Qt.AlignLeft)
+
+        label_layout.addWidget(family)
+        label_layout.addWidget(help)
+
+        layout.addWidget(icon)
+        layout.addLayout(label_layout)
+
+        self.help = help
+        self.family = family
+        self.icon = icon
+
+    def set_item(self, item):
+        """Update elements to display information of a family item.
+
+        Args:
+            family (dict): A family item as registered with name, help and icon
+
+        Returns:
+            None
+
+        """
+        if not item:
+            return
+
+        # Support a font-awesome icon
+        plugin = item.data(PluginRole)
+        icon = getattr(plugin, "icon", "info-circle")
+        assert isinstance(icon, (str, unicode))
+        icon = qtawesome.icon("fa.{}".format(icon), color="white")
+        pixmap = icon.pixmap(self.SIZE, self.SIZE)
+        pixmap = pixmap.scaled(self.SIZE, self.SIZE)
+
+        self.icon.setPixmap(pixmap)
+
+        self.family.setText(item.data(FamilyRole))
+        self.help.setText(item.data(HelpRole))
 
 
 def show(debug=False, parent=None):

--- a/avalon/tools/projectmanager/widget.py
+++ b/avalon/tools/projectmanager/widget.py
@@ -554,6 +554,10 @@ class AssetWidget(QtWidgets.QWidget):
         rows = selection.selectedRows()
         return [row.data(self.model.ObjectIdRole) for row in rows]
 
+    def set_silo(self, silo):
+        """Set the active silo tab"""
+        self.silo.set_current_silo(silo)
+
     def select_assets(self, assets, expand=True):
         """Select assets by name.
         


### PR DESCRIPTION
Changes:

- Fixes avalon containers getting a double underscore before `CON` suffix.
- Ensure `AVALON_CONTAINERS` are always added to the global namespace, even when currently working inside a namespace.
- Fix `get_representation_path` docstring
- Fix an issue where `cbloader` would open without the silo tabs loaded correctly when `use_context` is True.
- Fix #290 
- Add a descriptive header to `creator` tool, see:

![afbeelding](https://user-images.githubusercontent.com/2439881/31947184-01cbfefe-b8d4-11e7-8681-e7f938cfb5f7.png)

For this descriptive header this `Creator` class is used:

```python
class CreateSetDress(avalon.maya.Creator):
    """A grouped package of loaded content"""

    name = "setdress"
    label = "Set Dress"
    family = "colorbleed.setdress"
    icon = "cubes" # a font-awesome icon name
```

Note that the docstring will be added as the description label at the top. It's recommended therefore to keep the docstring short and concise.

Also note that some of these commits are currently already in avalon's core master branch, as such they won't be visual changes in the "file changes" overview in github. For example I believe this is already live: https://github.com/getavalon/core/pull/292/commits/b7a5569f2c60b503efa578e2ead4ee6764ce02b5

---

Sorry for the slightly mixed commits here.