### PR TITLE
Added `active` attribute to Creator.data

### DIFF
--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -213,7 +213,8 @@ class Creator(object):
             "id": "pyblish.avalon.instance",
             "family": self.family,
             "asset": asset,
-            "subset": name
+            "subset": name,
+            "active": True
         }, **(data or {}))
 
     def process(self):


### PR DESCRIPTION
Resolved #298

## Additional note
Each instance collector plugin in the configuration will need to be updated to translate the key to Pyblish logic. 

Example translation (also keeps things backwards compatible ;) )
```python
if "active" in data:
    data["publish"] = data["active"]
```