### PR TITLE
Also update os.environ when `update_current_task` is called

### DIFF
--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -763,6 +763,9 @@ def update_current_task(task=None, asset=None, app=None):
     # Update the full session in one go to avoid half updates
     Session.update(changed)
 
+    # Update the environment
+    os.environ.update(changed)
+
     # Emit session change
     emit("taskChanged", changed.copy())
 


### PR DESCRIPTION
Fix reload pipeline reverting back to the original task context as discussed here: https://gitter.im/getavalon/Lobby?at=5a0ddb3571ad3f8736f25921