### PR TITLE
enable host config uninstall

### DIFF
--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -53,11 +53,8 @@ def install(config):
     pyblish.register_host("mayapy")
     pyblish.register_host("maya")
 
-    try:
-        config = importlib.import_module(config.__name__ + ".maya")
-    except ImportError:
-        pass
-    else:
+    config = find_host_config(config)
+    if hasattr(config, "install"):
         config.install()
 
 
@@ -82,17 +79,23 @@ def _set_project():
     cmds.workspace(workdir, openWorkspace=True)
 
 
+def find_host_config(config):
+    try:
+        config = importlib.import_module(config.__name__ + ".maya")
+    except ImportError:
+        config = None
+
+    return config
+
+
 def uninstall(config):
     """Uninstall Maya-specific functionality of avalon-core.
 
     This function is called automatically on calling `api.uninstall()`.
 
     """
-    try:
-        config = importlib.import_module(config.__name__ + ".maya")
-    except ImportError:
-        pass
-    else:
+    config = find_host_config(config)
+    if hasattr(config, "uninstall"):
         config.uninstall()
 
     _uninstall_menu()

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -23,6 +23,7 @@ self._menu = "avalonmaya"  # Unique name of menu
 self._events = dict()  # Registered Maya callbacks
 self._parent = None  # Main Window
 self._ignore_lock = False
+self._host_config = None
 
 AVALON_CONTAINERS = ":AVALON_CONTAINERS"
 IS_HEADLESS = not hasattr(cmds, "about") or cmds.about(batch=True)
@@ -59,6 +60,7 @@ def install(config):
         pass
     else:
         config.install()
+        self._host_config = config
 
 
 def _set_project():
@@ -88,6 +90,11 @@ def uninstall():
     pyblish.deregister_host("mayabatch")
     pyblish.deregister_host("mayapy")
     pyblish.deregister_host("maya")
+
+    try:
+        self._host_config.uninstall()
+    except AttributeError:
+        pass
 
 
 def _install_menu():

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -23,7 +23,6 @@ self._menu = "avalonmaya"  # Unique name of menu
 self._events = dict()  # Registered Maya callbacks
 self._parent = None  # Main Window
 self._ignore_lock = False
-self._host_config = None
 
 AVALON_CONTAINERS = ":AVALON_CONTAINERS"
 IS_HEADLESS = not hasattr(cmds, "about") or cmds.about(batch=True)
@@ -60,7 +59,6 @@ def install(config):
         pass
     else:
         config.install()
-        self._host_config = config
 
 
 def _set_project():
@@ -84,17 +82,24 @@ def _set_project():
     cmds.workspace(workdir, openWorkspace=True)
 
 
-def uninstall():
+def uninstall(config):
+    """Uninstall Maya-specific functionality of avalon-core.
+
+    This function is called automatically on calling `api.uninstall()`.
+
+    """
+    try:
+        config = importlib.import_module(config.__name__ + ".maya")
+    except ImportError:
+        pass
+    else:
+        config.uninstall()
+
     _uninstall_menu()
 
     pyblish.deregister_host("mayabatch")
     pyblish.deregister_host("mayapy")
     pyblish.deregister_host("maya")
-
-    try:
-        self._host_config.uninstall()
-    except AttributeError:
-        pass
 
 
 def _install_menu():

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -95,13 +95,15 @@ def find_config():
 
 def uninstall():
     """Undo all of what `install()` did"""
+    config = registered_config()
+
     try:
-        registered_host().uninstall()
+        registered_host().uninstall(config)
     except AttributeError:
         pass
 
     try:
-        registered_config().uninstall()
+        config.uninstall()
     except AttributeError:
         pass
 


### PR DESCRIPTION
Was testing config swap by `Reload Pipeline` inside Maya, found that `avalon.pipeline.uninstall()` did trigger the uninstall of pipeline config, but host config's uninstall did not run.