### PR TITLE
Load projects

### DIFF
--- a/avalon/inventory.py
+++ b/avalon/inventory.py
@@ -420,6 +420,7 @@ def _cli():
                         help="Save inventory from disk to database")
     parser.add_argument("--load",
                         nargs="?",
+                        default=False,
                         help="Load inventory from database to disk")
     parser.add_argument("--extract",
                         action="store_true",

--- a/avalon/inventory.py
+++ b/avalon/inventory.py
@@ -419,7 +419,7 @@ def _cli():
                         action="store_true",
                         help="Save inventory from disk to database")
     parser.add_argument("--load",
-                        action="store_true",
+                        nargs="?",
                         help="Load inventory from database to disk")
     parser.add_argument("--extract",
                         action="store_true",
@@ -436,9 +436,10 @@ def _cli():
     kwargs = parser.parse_args()
 
     root = kwargs.root or os.getcwd()
-    name = os.path.basename(root)
+    name = kwargs.load or os.path.basename(root)
 
-    if any([kwargs.load, kwargs.save, kwargs.upload, kwargs.init]):
+    if (any([kwargs.load, kwargs.save, kwargs.upload, kwargs.init]) or
+       kwargs.load is None):
         os.environ["AVALON_PROJECT"] = name
         io.install()
 
@@ -448,7 +449,7 @@ def _cli():
         _write(root, "inventory", inventory)
         print("Success!")
 
-    elif kwargs.load:
+    elif kwargs.load or kwargs.load is None:
         config, inventory = load(name)
         _write(root, "config", config)
         _write(root, "inventory", inventory)

--- a/avalon/inventory.py
+++ b/avalon/inventory.py
@@ -20,7 +20,7 @@ import sys
 import copy
 import json
 
-from avalon import schema, io, api
+from avalon import schema, io
 from avalon.vendor import toml
 
 self = sys.modules[__name__]

--- a/avalon/inventory.py
+++ b/avalon/inventory.py
@@ -197,8 +197,22 @@ def load(name):
     project = io.find_one({"type": "project"})
 
     if project is None:
-        raise Exception("'%s' not found, try --init "
-                        "to start a new project." % name)
+        msg = "'{0}' not found, try --init to start a new project".format(name)
+
+        projects = ""
+        for project in io.projects():
+            projects += "\n- {0}".format(project["name"])
+
+        if projects:
+            msg += (
+                ", or load a project from the database.\nProjects:{1}".format(
+                    name, projects
+                )
+            )
+        else:
+            msg += "."
+
+        raise Exception(msg)
 
     else:
         config = project["config"]

--- a/avalon/tests/test_inventory.py
+++ b/avalon/tests/test_inventory.py
@@ -261,6 +261,31 @@ def test_cli_load_overwrite():
 
 
 @with_setup(clean)
+def test_cli_load_by_name():
+    """Load project by name"""
+
+    inventory.save(
+        name=self._project["name"],
+        config=self._config,
+        inventory=self._inventory
+    )
+
+    return_code = subprocess.call(
+        [
+            sys.executable,
+            "-u",
+            "-m",
+            "avalon.inventory",
+            "--load",
+            self._project["name"]
+        ],
+        cwd=tempfile.mkdtemp(dir=self._tempdir)
+    )
+
+    assert 0 == return_code
+
+
+@with_setup(clean)
 def test_cli_save():
     """Saving uploads inventory to database"""
     with open(os.path.join(self._tempdir, ".inventory.toml"), "w") as f:


### PR DESCRIPTION
This PR is related to https://github.com/getavalon/setup/issues/4.

This enables the inventory to load project by name:

```bash
> python -u -m avalon.inventory --load myProject
```

Also if a project is not found, an error will inform the user about the available projects in the database:

```bash
(avalon-environment) C:\Users\admin\batman>avalon --load
Loading .inventory.toml and .config.toml..
'batman' not found, try --init to start a new project, or load a project from the database.
Projects:
- myProject
- mySecondProject
```
