### PR TITLE
Add list, tuple type support to `maya.imprint()` and other two minor tweak

### DIFF
--- a/avalon/maya/lib.py
+++ b/avalon/maya/lib.py
@@ -195,6 +195,10 @@ def imprint(node, data):
         elif isinstance(value, float):
             add_type = {"attributeType": "double"}
             set_type = {"keyable": False, "channelBox": True}
+        elif isinstance(value, (list, tuple)):
+            add_type = {"attributeType": "enum", "enumName": ":".join(value)}
+            set_type = {"keyable": False, "channelBox": True}
+            value = 0  # enum default
         else:
             raise TypeError("Unsupported type: %r" % type(value))
 

--- a/avalon/maya/lib.py
+++ b/avalon/maya/lib.py
@@ -82,7 +82,7 @@ def read(node):
 
     for attr in cmds.listAttr(node, userDefined=True) or list():
         try:
-            value = cmds.getAttr(node + "." + attr)
+            value = cmds.getAttr(node + "." + attr, asString=True)
         except ValueError:
             # Some attributes cannot be read directly,
             # such as mesh and color attributes. These

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -13,6 +13,8 @@ import inspect
 import traceback
 import importlib
 
+from collections import OrderedDict
+
 from . import (
     io,
     lib,
@@ -220,13 +222,14 @@ class Creator(object):
         self.options = options
 
         # Default data
-        self.data = dict({
-            "id": "pyblish.avalon.instance",
-            "family": self.family,
-            "asset": asset,
-            "subset": name,
-            "active": True
-        }, **(data or {}))
+        self.data = OrderedDict()
+        self.data["id"] = "pyblish.avalon.instance"
+        self.data["family"] = self.family
+        self.data["asset"] = asset
+        self.data["subset"] = name
+        self.data["active"] = True
+
+        self.data.update(data or {})
 
     def process(self):
         pass

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -363,9 +363,9 @@ class FamilyDescriptionWidget(QtWidgets.QWidget):
         icon.setSizePolicy(QtWidgets.QSizePolicy.Maximum,
                            QtWidgets.QSizePolicy.Maximum)
 
-        # Add 2 pixel padding to avoid icon being cut off
-        icon.setFixedWidth(self.SIZE + 2)
-        icon.setFixedHeight(self.SIZE + 2)
+        # Add 4 pixel padding to avoid icon being cut off
+        icon.setFixedWidth(self.SIZE + 4)
+        icon.setFixedHeight(self.SIZE + 4)
         icon.setStyleSheet("""
         QLabel {
             padding-right: 5px;


### PR DESCRIPTION
Hi, I made some tiny changes, here's short brief:

#### 1) `avalon.maya.lib.imprint()` add `list`, `tuple` type support
* Motivation
Thought that would be nice to have `imprint` to create enum type attribute for us.
Example use case, choosing cache format (abc, gpu, fbx...) to export with pointcache creator. 
![](https://i.imgur.com/zHJg3Bh.png)
* Implementation
Implemented with Maya's `enum` type attribute.

#### 2) Change the type of `avalon.pipeline.Creator.data` from `dict` to `OrderedDict`
* Motivation
After adding some custom attributes into `creator.data`, those attributes visualized in GUI (Maya Attribute Editor) without order is not very comfort to see, custom attributes often mixed in core attributes.
* Implementation
Use `OrderedDict`.

#### 3) Larger creator icon border padding
* Motivation
Some icon still get cropped with 2 padding.
* Implementation
Bump to 4. :smile:

Please let me know what you think, thanks !
