### PR TITLE
Display project tasks when no asset tasks are found.

### DIFF
--- a/avalon/tools/projectmanager/model.py
+++ b/avalon/tools/projectmanager/model.py
@@ -230,7 +230,7 @@ class TasksModel(TreeModel):
 
         # If no asset tasks are defined, use the project tasks.
         if assets and not tasks:
-            project = io.parenthood(assets[0])[0]
+            project = io.find_one({"type": "project"})
             tasks.update(
                 [task["name"] for task in project["config"].get("tasks", [])]
             )

--- a/avalon/tools/projectmanager/model.py
+++ b/avalon/tools/projectmanager/model.py
@@ -228,6 +228,13 @@ class TasksModel(TreeModel):
             asset_tasks = asset.get("data", {}).get("tasks", [])
             tasks.update(asset_tasks)
 
+        # If no asset tasks are defined, use the project tasks.
+        if assets and not tasks:
+            project = io.parenthood(assets[0])[0]
+            tasks.update(
+                [task["name"] for task in project["config"].get("tasks", [])]
+            )
+
         self.clear()
         self.beginResetModel()
 


### PR DESCRIPTION
**Problem**

When browsing assets without tasks, no tasks are displayed. This is different from the Launcher, where it fetches the project tasks if no assets tasks are found.

**Solution**

Use project tasks in the Tasks model when no asset tasks are found.

This fixes both the Project Manager and Context Manager.