### PR TITLE
 Minor improvement on cbloader & Rename `api.load()` arg `data` to `options`

### DIFF
--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -999,7 +999,7 @@ def load(Loader, representation, namespace=None, name=None, options=None,
     if options is None:
         options = kwargs.get("data", dict())  # "data" for backward compat
 
-    assert isinstance(options, dict), "Data must be a dictionary"
+    assert isinstance(options, dict), "Options must be a dictionary"
 
     # Fallback to subset when name is None
     if name is None:

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -997,7 +997,7 @@ def load(Loader, representation, namespace=None, name=None, options=None,
 
     # Ensure options is a dictionary when no explicit options provided
     if options is None:
-        options = kwargs.get("data", dict())  # "data" for backward compact
+        options = kwargs.get("data", dict())  # "data" for backward compat
 
     assert isinstance(options, dict), "Data must be a dictionary"
 

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -970,7 +970,8 @@ def load(Loader, representation, namespace=None, name=None, data=None):
 
     Args:
         Loader (Loader): The loader class to trigger.
-        representation (str or io.ObjectId): The representation id.
+        representation (str or io.ObjectId or dict): The representation id
+            or full representation as returned by the database.
         namespace (str, Optional): The namespace to assign. Defaults to None.
         name (str, Optional): The name to assign. Defaults to subset name.
         data (dict, Optional): Additional custom data to pass on to the loader.

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -169,14 +169,14 @@ class Loader(list):
         fname = template.format(**data)
         self.fname = fname
 
-    def load(self, context, name=None, namespace=None, data=None):
+    def load(self, context, name=None, namespace=None, options=None):
         """Load asset via database
 
         Arguments:
             context (dict): Full parenthood of representation to load
             name (str, optional): Use pre-defined name
             namespace (str, optional): Use pre-defined namespace
-            data (dict, optional): Additional settings dictionary
+            options (dict, optional): Additional settings dictionary
 
         """
         raise NotImplementedError("Loader.load() must be "
@@ -965,7 +965,8 @@ def _make_backwards_compatible_loader(Loader):
     return type(Loader.__name__, (BackwardsCompatibleLoader, Loader), {})
 
 
-def load(Loader, representation, namespace=None, name=None, data=None):
+def load(Loader, representation, namespace=None, name=None, options=None,
+         **kwargs):
     """Use Loader to load a representation.
 
     Args:
@@ -974,7 +975,7 @@ def load(Loader, representation, namespace=None, name=None, data=None):
             or full representation as returned by the database.
         namespace (str, Optional): The namespace to assign. Defaults to None.
         name (str, Optional): The name to assign. Defaults to subset name.
-        data (dict, Optional): Additional custom data to pass on to the loader.
+        options (dict, Optional): Additional options to pass on to the loader.
 
     Returns:
         The return of the `loader.load()` method.
@@ -994,11 +995,11 @@ def load(Loader, representation, namespace=None, name=None, data=None):
                                       "{}".format(Loader.__name__,
                                                   context["subset"]["name"]))
 
-    # Ensure data is a dictionary when no explicit data provided
-    if data is None:
-        data = dict()
+    # Ensure options is a dictionary when no explicit options provided
+    if options is None:
+        options = kwargs.get("data", dict())  # "data" for backward compact
 
-    assert isinstance(data, dict), "Data must be a dictionary"
+    assert isinstance(options, dict), "Data must be a dictionary"
 
     # Fallback to subset when name is None
     if name is None:
@@ -1009,10 +1010,7 @@ def load(Loader, representation, namespace=None, name=None, data=None):
     )
 
     loader = Loader(context)
-    return loader.load(context=context,
-                       name=name,
-                       namespace=namespace,
-                       data=data)
+    return loader.load(context, name, namespace, options)
 
 
 def _get_container_loader(container):

--- a/avalon/tools/cbloader/widgets.py
+++ b/avalon/tools/cbloader/widgets.py
@@ -197,11 +197,8 @@ class SubsetWidget(QtWidgets.QWidget):
                           ))
                 continue
 
-            data = representation.get("data", None)
             try:
-                api.load(Loader=loader,
-                         representation=representation,
-                         data=data)
+                api.load(Loader=loader, representation=representation)
             except pipeline.IncompatibleLoaderError as exc:
                 self.echo(exc)
                 continue

--- a/avalon/tools/cbloader/widgets.py
+++ b/avalon/tools/cbloader/widgets.py
@@ -186,13 +186,13 @@ class SubsetWidget(QtWidgets.QWidget):
         # Trigger
         for row in rows:
             node = row.data(self.model.NodeRole)
-            version_id = node['version_document']['_id']
+            version_id = node["version_document"]["_id"]
             representation = io.find_one({"type": "representation",
                                           "name": representation_name,
                                           "parent": version_id})
             if not representation:
                 self.echo("Subset '{}' has no representation '{}'".format(
-                          node['subset'],
+                          node["subset"],
                           representation_name
                           ))
                 continue

--- a/avalon/tools/cbloader/widgets.py
+++ b/avalon/tools/cbloader/widgets.py
@@ -197,8 +197,11 @@ class SubsetWidget(QtWidgets.QWidget):
                 ))
                 continue
 
+            data = representation.get("data", None)
             try:
-                api.load(Loader=loader, representation=representation)
+                api.load(Loader=loader,
+                         representation=representation,
+                         data=data)
             except pipeline.IncompatibleLoaderError as exc:
                 self.echo(exc)
                 continue

--- a/avalon/tools/cbloader/widgets.py
+++ b/avalon/tools/cbloader/widgets.py
@@ -192,9 +192,9 @@ class SubsetWidget(QtWidgets.QWidget):
                                           "parent": version_id})
             if not representation:
                 self.echo("Subset '{}' has no representation '{}'".format(
-                        node['subset'],
-                        representation_name
-                ))
+                          node['subset'],
+                          representation_name
+                          ))
                 continue
 
             data = representation.get("data", None)

--- a/avalon/tools/cbloader/widgets.py
+++ b/avalon/tools/cbloader/widgets.py
@@ -198,7 +198,7 @@ class SubsetWidget(QtWidgets.QWidget):
                 continue
 
             try:
-                api.load(Loader=loader, representation=representation['_id'])
+                api.load(Loader=loader, representation=representation)
             except pipeline.IncompatibleLoaderError as exc:
                 self.echo(exc)
                 continue


### PR DESCRIPTION
Little changes...

#### Motivation

I use `cbloader` and the `data` of representation object is required but the tool did not pass it.

#### Implementation

Add one line to extract `data` from representation and pass to `api.load`.

Also, I noticed that instead passing the `ObjectId` of representation to `api.load`, directly pass the representation object can reduce one database query, since the function [`get_representation_context`](https://github.com/getavalon/core/blob/b639ba3c00102d076fcab8c89da26cd744b20d09/avalon/pipeline.py#L830-L835) which been used [here](https://github.com/getavalon/core/blob/b639ba3c00102d076fcab8c89da26cd744b20d09/avalon/pipeline.py#L988), is able to accept both form.