### PR TITLE
Pin sphinx version to 1.7.9

### DIFF
--- a/Dockerfile-maya2016
+++ b/Dockerfile-maya2016
@@ -9,7 +9,9 @@ RUN wget https://bootstrap.pypa.io/get-pip.py && \
 		pyblish-base==1.4.2 \
 		pyblish-maya \
 		pymongo \
-		sphinx \
+		# Sphinx 1.8.0 fail to build doc, pin version to 1.7.9
+		# see https://github.com/sphinx-doc/sphinx/issues/5417
+		sphinx==1.7.9 \
 		six \
 		sphinxcontrib-napoleon \
 		python-coveralls


### PR DESCRIPTION
Latest Sphinx release `1.8.0` fail to build doc
```
Traceback (most recent call last):
  File "/usr/autodesk/maya/lib/python2.7/site-packages/sphinx/cmd/build.py", line 303, in build_main
    args.tags, args.verbosity, args.jobs, args.keep_going)
  File "/usr/autodesk/maya/lib/python2.7/site-packages/sphinx/application.py", line 224, in __init__
    self.setup_extension(extension)
  File "/usr/autodesk/maya/lib/python2.7/site-packages/sphinx/application.py", line 449, in setup_extension
    self.registry.load_extension(self, extname)
  File "/usr/autodesk/maya/lib/python2.7/site-packages/sphinx/registry.py", line 472, in load_extension
    mod = __import__(extname, None, None, ['setup'])
  File "/usr/autodesk/maya/lib/python2.7/site-packages/sphinx/builders/applehelp.py", line 20, in <module>
    from sphinx.builders.html import StandaloneHTMLBuilder
  File "/usr/autodesk/maya/lib/python2.7/site-packages/sphinx/builders/html.py", line 40, in <module>
    from sphinx.highlighting import PygmentsBridge
  File "/usr/autodesk/maya/lib/python2.7/site-packages/sphinx/highlighting.py", line 26, in <module>
    from sphinx.ext import doctest
SyntaxError: unqualified exec is not allowed in function 'run' it contains a nested function with free variables (doctest.py, line 97)
```

It has been labeled as bug at Sphinx's issue, and planned to fix it at next release (`1.8.1`).
This PR will pin version to `1.7.9` for the time being.
