### PR TITLE
Immediate version info update on CBLoader

### DIFF
--- a/avalon/tools/cbloader/app.py
+++ b/avalon/tools/cbloader/app.py
@@ -3,7 +3,7 @@ import time
 
 from ..projectmanager.widget import AssetWidget, AssetModel
 
-from ...vendor.Qt import QtWidgets, QtCore, QtGui
+from ...vendor.Qt import QtWidgets, QtCore
 from ... import api, io, style
 from .. import lib
 

--- a/avalon/tools/cbloader/app.py
+++ b/avalon/tools/cbloader/app.py
@@ -56,7 +56,7 @@ class Window(QtWidgets.QDialog):
         split.addWidget(asset_filter_splitter)
         split.addWidget(subsets)
         split.addWidget(version)
-        split.setSizes([225, 925, 0])
+        split.setSizes([180, 950, 200])
         container_layout.addWidget(split)
 
         body_layout = QtWidgets.QHBoxLayout(body)
@@ -107,7 +107,7 @@ class Window(QtWidgets.QDialog):
         refresh_family_config()
 
         # Defaults
-        self.resize(1150, 700)
+        self.resize(1330, 700)
 
     # -------------------------------
     # Delay calling blocking methods

--- a/avalon/tools/cbloader/app.py
+++ b/avalon/tools/cbloader/app.py
@@ -101,7 +101,8 @@ class Window(QtWidgets.QDialog):
 
         families.active_changed.connect(subsets.set_family_filters)
         assets.selection_changed.connect(self.on_assetschanged)
-        subsets.active_changed.connect(self.on_versionschanged)
+        subsets.active_changed.connect(self.on_subsetschanged)
+        subsets.version_changed.connect(self.on_versionschanged)
 
         refresh_family_config()
 
@@ -117,12 +118,16 @@ class Window(QtWidgets.QDialog):
         lib.schedule(self._refresh, 50, channel="mongo")
 
     def on_assetschanged(self, *args):
-        self.echo("Fetching results..")
+        self.echo("Fetching asset..")
         lib.schedule(self._assetschanged, 50, channel="mongo")
 
-    def on_versionschanged(self, *args):
-        self.echo("Fetching results..")
+    def on_subsetschanged(self, *args):
+        self.echo("Fetching subset..")
         lib.schedule(self._versionschanged, 50, channel="mongo")
+
+    def on_versionschanged(self, *args):
+        self.echo("Fetching version..")
+        lib.schedule(self._versionschanged, 150, channel="mongo")
 
     def set_context(self, context, refresh=True):
         self.echo("Setting context: {}".format(context))

--- a/avalon/tools/cbloader/delegates.py
+++ b/avalon/tools/cbloader/delegates.py
@@ -107,6 +107,10 @@ class PrettyTimeDelegate(QtWidgets.QStyledItemDelegate):
 class VersionDelegate(QtWidgets.QStyledItemDelegate):
     """A delegate that display version integer formatted as version string."""
 
+    version_changed = QtCore.Signal()
+    first_run = False
+    lock = False
+
     def _format_version(self, value):
         """Formats integer to displayable version name"""
         return "v{0:03d}".format(value)
@@ -117,9 +121,22 @@ class VersionDelegate(QtWidgets.QStyledItemDelegate):
 
     def createEditor(self, parent, option, index):
         editor = QtWidgets.QComboBox(parent)
+
+        def commit_data():
+            if not self.first_run:
+                self.commitData.emit(editor)  # Update model data
+                self.version_changed.emit()   # Display model data
+        editor.currentIndexChanged.connect(commit_data)
+
+        self.first_run = True
+        self.lock = False
+
         return editor
 
     def setEditorData(self, editor, index):
+        if self.lock:
+            # Only set editor data once per delegation
+            return
 
         editor.clear()
 
@@ -140,7 +157,9 @@ class VersionDelegate(QtWidgets.QStyledItemDelegate):
             if version['name'] == value:
                 index = i
 
-        editor.setCurrentIndex(index)
+        editor.setCurrentIndex(index)  # Will trigger index-change signal
+        self.first_run = False
+        self.lock = True
 
     def setModelData(self, editor, model, index):
         """Apply the integer version back in the model"""

--- a/avalon/tools/cbloader/widgets.py
+++ b/avalon/tools/cbloader/widgets.py
@@ -268,7 +268,7 @@ class VersionTextEdit(QtWidgets.QTextEdit):
             "source": source_label
         }
 
-        self.setHtml("""
+        self.setHtml(u"""
 <h3>{subset} v{version:03d}</h3>
 <b>Comment</b><br>
 {comment}<br>

--- a/avalon/tools/cbloader/widgets.py
+++ b/avalon/tools/cbloader/widgets.py
@@ -240,6 +240,8 @@ class VersionTextEdit(QtWidgets.QTextEdit):
 
         self.setEnabled(True)
 
+        print("Querying..")
+
         version = io.find_one({"_id": version_id, "type": "version"})
         assert version, "Not a valid version id"
 

--- a/avalon/tools/cbloader/widgets.py
+++ b/avalon/tools/cbloader/widgets.py
@@ -84,6 +84,8 @@ class SubsetWidget(QtWidgets.QWidget):
         selection = view.selectionModel()
         selection.selectionChanged.connect(self.active_changed)
 
+        version_delegate.version_changed.connect(self.version_changed)
+
         self.filter.textChanged.connect(self.proxy.setFilterRegExp)
 
         self.model.refresh()


### PR DESCRIPTION
### Before:
![cbloader_before](https://user-images.githubusercontent.com/3357009/45664325-c0fceb00-bb3d-11e8-99bc-e8f7b1de5cfc.gif)

The change of version in subset view, require re-select subset so the version widget will update. 

### After:
![cbloader_after](https://user-images.githubusercontent.com/3357009/45664326-c2c6ae80-bb3d-11e8-85e0-232cc59acac1.gif)

Now the version widget will update immediately with reasonable database query counts.
You can scroll the version list and view comments smoothly.


### Minor tweak
* Supporting unicode comments.
* Version widget will expanded by default.

