### PR TITLE
Update Maya fileDialog's start-dir when task changed

### DIFF
--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -4,7 +4,7 @@ import errno
 import importlib
 import contextlib
 
-from maya import cmds, mel, OpenMaya
+from maya import cmds, OpenMaya
 from pyblish import api as pyblish
 
 from . import lib, compat
@@ -567,13 +567,10 @@ def _on_task_changed(*args):
     workdir = api.Session["AVALON_WORKDIR"]
     if os.path.exists(workdir):
         logger.info("Updating Maya workspace for task change to %s", workdir)
+
         _set_project()
 
-        # Update file dialog starting dir
-        # (NOTE) using `mel.eval` because this `workspace` Python cmd failed
-        #   in Maya 2017 +
-        frule_scene = mel.eval("workspace -q -fileRuleEntry \"scene\"")
-
+        frule_scene = cmds.workspace(fileRuleEntry="scene")
         cmds.optionVar(stringValue=("browserLocationmayaBinaryscene",
                                     workdir + "/" + frule_scene))
 

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -577,15 +577,3 @@ def _on_task_changed(*args):
     else:
         logger.warning("Can't set project for new context because "
                        "path does not exist: %s", workdir)
-
-        asset = api.Session["AVALON_ASSET"]
-        task = api.Session["AVALON_TASK"]
-        cmds.confirmDialog(
-            title="Context Manager - Context Not Exists",
-            icon="warning",
-            messageAlign="center",
-            message=("Can't set project for new context because the workspace "
-                     "of context <{asset} - {task}> not exists yet.\nPlease "
-                     "use Avalon Launcher to enter."
-                     "".format(asset=asset, task=task)),
-        )

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -570,6 +570,7 @@ def _on_task_changed(*args):
 
         _set_project()
 
+        # Set Maya fileDialog's start-dir to /scenes
         frule_scene = cmds.workspace(fileRuleEntry="scene")
         cmds.optionVar(stringValue=("browserLocationmayaBinaryscene",
                                     workdir + "/" + frule_scene))


### PR DESCRIPTION
### Before:
![task_before](https://user-images.githubusercontent.com/3357009/45665092-d247f680-bb41-11e8-8054-0fb06c6ecad9.gif)

FileDialog's start-dir will stay at previous opened folder path after task changed.

### After:
![task_after](https://user-images.githubusercontent.com/3357009/45665093-d3792380-bb41-11e8-814f-57902e1479cf.gif)

Now it will point to the scenes folder of that task after task changed.
And, this is not recorded in GIF, but it will prompt a confirm dialog to notify artist to use Launcher, due to the workspace of that task is un-initialized (folder not exists).

