### PR TITLE
Fix #325

### DIFF
--- a/avalon/inventory.py
+++ b/avalon/inventory.py
@@ -224,6 +224,8 @@ def load(name):
             silo = asset["silo"]
             data = asset["data"]
 
+            data.pop("visualParent", None)  # Hide from manual editing
+
             if silo not in inventory:
                 inventory[silo] = list()
 


### PR DESCRIPTION
### Concept
Avoid `visualParent` get loaded to `.inventory.toml`, hide from user editing.

### Implementation
Pop-out the key `"visualParent"` from the asset data of the project document, once it loaded from database and before saving as `.toml`.