### PR TITLE
General Improvement

### DIFF
--- a/avalon/fusion/pipeline.py
+++ b/avalon/fusion/pipeline.py
@@ -4,6 +4,8 @@ import importlib
 import logging
 from pyblish import api as pyblish
 
+from ..pipeline import AVALON_CONTAINER_ID
+
 
 class CompLogHandler(logging.Handler):
     def emit(self, record):
@@ -91,7 +93,7 @@ def imprint_container(tool,
 
     data = [
         ("schema", "avalon-core:container-2.0"),
-        ("id", "pyblish.avalon.container"),
+        ("id", AVALON_CONTAINER_ID),
         ("name", str(name)),
         ("namespace", str(namespace)),
         ("loader", str(loader)),

--- a/avalon/houdini/pipeline.py
+++ b/avalon/houdini/pipeline.py
@@ -239,6 +239,13 @@ def ls():
 
     for container in sorted(containers):
         data = parse_container(container)
+
+        # Collect custom data if attribute is present
+        config = find_host_config(api.registered_config())
+        if hasattr(config, "collect_container_metadata"):
+            metadata = config.collect_container_metadata(container)
+            data.update(metadata)
+
         yield data
 
 

--- a/avalon/houdini/pipeline.py
+++ b/avalon/houdini/pipeline.py
@@ -13,6 +13,7 @@ from . import lib
 from ..lib import logger
 from avalon import api, schema
 
+from ..pipeline import AVALON_CONTAINER_ID
 
 self = sys.modules[__name__]
 self._has_been_setup = False
@@ -186,7 +187,7 @@ def containerise(name,
     container = obj_network.node(name)
     data = {
         "schema": "avalon-core:container-2.0",
-        "id": "pyblish.avalon.container",
+        "id": AVALON_CONTAINER_ID,
         "name": name,
         "namespace": namespace,
         "loader": str(loader),
@@ -232,7 +233,7 @@ def parse_container(container, validate=True):
 
 def ls():
     containers = []
-    for identifier in ("pyblish.avalon.container",
+    for identifier in (AVALON_CONTAINER_ID,
                        "pyblish.mindbender.container"):
         containers += lib.lsattr("id", identifier)
 

--- a/avalon/maya/lib.py
+++ b/avalon/maya/lib.py
@@ -83,6 +83,16 @@ def read(node):
     for attr in cmds.listAttr(node, userDefined=True) or list():
         try:
             value = cmds.getAttr(node + "." + attr, asString=True)
+
+        except RuntimeError:
+            # For Message type attribute or others that have connections,
+            # take source node name as value.
+            source = cmds.listConnections(node + "." + attr,
+                                          source=True,
+                                          destination=False)
+            source = cmds.ls(source, long=True) or [None]
+            value = source[0]
+
         except ValueError:
             # Some attributes cannot be read directly,
             # such as mesh and color attributes. These

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -449,6 +449,13 @@ def ls():
 
     for container in sorted(containers):
         data = parse_container(container)
+
+        # Collect custom data if attribute is present
+        config = find_host_config(api.registered_config())
+        if hasattr(config, "collect_container_metadata"):
+            metadata = config.collect_container_metadata(container)
+            data.update(metadata)
+
         yield data
 
 

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -13,6 +13,8 @@ from .. import api, schema
 from ..tools import workfiles
 from ..vendor.Qt import QtCore, QtWidgets
 
+from ..pipeline import AVALON_CONTAINER_ID
+
 # Backwards compatibility
 load = compat.load
 update = compat.update
@@ -377,7 +379,7 @@ def containerise(name,
 
     data = [
         ("schema", "avalon-core:container-2.0"),
-        ("id", "pyblish.avalon.container"),
+        ("id", AVALON_CONTAINER_ID),
         ("name", name),
         ("namespace", namespace),
         ("loader", str(loader)),
@@ -441,7 +443,7 @@ def ls():
     """
 
     containers = list()
-    for identifier in ("pyblish.avalon.container",
+    for identifier in (AVALON_CONTAINER_ID,
                        "pyblish.mindbender.container"):
         containers += lib.lsattr("id", identifier)
 

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -226,7 +226,7 @@ class Creator(object):
         self.data["id"] = "pyblish.avalon.instance"
         self.data["family"] = self.family
         self.data["asset"] = asset
-        self.data["subset"] = name
+        self.data["subset"] = self.name
         self.data["active"] = True
 
         self.data.update(data or {})
@@ -806,6 +806,12 @@ def create(name, asset, family, options=None, data=None):
 
         if not has_family:
             continue
+
+        if not name:
+            name = Plugin.name
+            Plugin.log.info(
+                "Using default name '%s' from '%s'" % (name, Plugin.__name__)
+            )
 
         Plugin.log.info(
             "Creating '%s' with '%s'" % (name, Plugin.__name__)

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -39,6 +39,9 @@ self.data = {}
 log = logging.getLogger(__name__)
 
 
+AVALON_CONTAINER_ID = "pyblish.avalon.container"
+
+
 class IncompatibleLoaderError(ValueError):
     """Error when Loader is incompatible with a representation."""
     pass

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -412,7 +412,7 @@ def discover(superclass):
         for module in lib.modules_from_path(path):
             for plugin in plugin_from_module(superclass, module):
                 if plugin.__name__ in plugins:
-                    print("Duplicate plug-in found: %s", plugin)
+                    print("Duplicate plug-in found: %s" % plugin)
                     continue
 
                 plugins[plugin.__name__] = plugin

--- a/avalon/tools/cbsceneinventory/model.py
+++ b/avalon/tools/cbsceneinventory/model.py
@@ -69,20 +69,11 @@ class InventoryModel(TreeModel):
         """Refresh the model"""
 
         host = api.registered_host()
-        config = api.registered_config()
 
         items = []
         containers = host.ls()
         for container in containers:
-            item = container
-            # Collect custom data if attribute is present
-            if hasattr(config, "collect_container_metadata"):
-                data = config.collect_container_metadata(container)
-                # Protect the container by merging it into the data
-                data.update(container)
-                item = data
-
-            items.append(item)
+            items.append(container)
 
         self.clear()
         self.add_items(items)

--- a/avalon/tools/cbsceneinventory/model.py
+++ b/avalon/tools/cbsceneinventory/model.py
@@ -167,10 +167,6 @@ class InventoryModel(TreeModel):
                 item_node = Node()
                 item_node.update(item)
 
-                # set name from namespace (unique identifier for the `item`
-                # todo(marcus): should this remapping be necessary?
-                item_node["name"] = item["namespace"]
-
                 # store the current version on the item
                 item_node["version"] = version['name']
 


### PR DESCRIPTION
### Changed

1. If `RuntimeError` raised while reading custom attributes in `avalon.maya.lib.read()`, parse source node name if has input connection. Useful for message type connection.

2. Use creator plugin's `name` value as default, if `avalon.pipeline.create()`'s arg `name` receive `""` or `None`.

3. Remove unnecessary value remap in `cbsceneinventory` app, which causing wrong container data `name` passed to `loader.update`.

4. Remove hard-coded container id `"pyblish.avalon.container"` in each host.

5. Move `collect_container_metadata` from `cbsceneinventory` app to each `host.ls`, thought putting this logic to each host would making more sense.


Hoping these changes are making sense to you, please let me know what you think :)
