### PR TITLE
Implement Hierarchy View in Scene Inventory App

### DIFF
--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -447,6 +447,14 @@ def ls():
 
     for container in sorted(containers):
         data = parse_container(container)
+
+        # Hierarchical container support
+        parent = cmds.listSets(object=container) or []
+        for node in parent:
+            if node in containers:
+                data["parent"] = node
+                break
+
         yield data
 
 

--- a/avalon/tools/cbsceneinventory/app.py
+++ b/avalon/tools/cbsceneinventory/app.py
@@ -475,6 +475,14 @@ class Window(QtWidgets.QDialog):
         control_layout.addWidget(text_filter)
         control_layout.addWidget(outdated_only)
         control_layout.addWidget(refresh_button)
+
+        option_layout = QtWidgets.QHBoxLayout()
+        hierarchy_view = QtWidgets.QCheckBox("Hierarchy View")
+        hierarchy_view.setToolTip("Display subsets hierarchy.")
+        hierarchy_view.setChecked(False)
+
+        option_layout.addWidget(hierarchy_view)
+
         # endregion control
 
         model = InventoryModel()
@@ -488,10 +496,12 @@ class Window(QtWidgets.QDialog):
         view.setItemDelegateForColumn(column, version_delegate)
 
         layout.addLayout(control_layout)
+        layout.addLayout(option_layout)
         layout.addWidget(view)
 
         self.filter = text_filter
         self.outdated_only = outdated_only
+        self.hierarchy_view = hierarchy_view
         self.view = view
         self.refresh_button = refresh_button
         self.model = model
@@ -500,6 +510,7 @@ class Window(QtWidgets.QDialog):
         # signals
         text_filter.textChanged.connect(self.proxy.setFilterRegExp)
         outdated_only.stateChanged.connect(self.proxy.set_filter_outdated)
+        hierarchy_view.stateChanged.connect(self.model.set_hierarchy_view)
         refresh_button.clicked.connect(self.refresh)
         view.data_changed.connect(self.refresh)
 

--- a/avalon/tools/cbsceneinventory/lib.py
+++ b/avalon/tools/cbsceneinventory/lib.py
@@ -65,8 +65,8 @@ def switch_item(container,
                                   "parent": version["_id"]})
 
     assert representation, (
-            "Could not find representation in the database with"
-            " the name '%s'" % representation_name)
+        "Could not find representation in the database with"
+        " the name '%s'" % representation_name)
 
     api.switch(container, representation)
 

--- a/avalon/tools/cbsceneinventory/model.py
+++ b/avalon/tools/cbsceneinventory/model.py
@@ -58,7 +58,7 @@ class InventoryModel(TreeModel):
                 if node.get("isGroupNode"):  # group-item
                     return qta.icon("fa.folder", color=color)
                 else:
-                    return qta.icon("fa.folder-o", color=color)
+                    return qta.icon("fa.file-o", color=color)
 
             if index.column() == 3:
                 # Family icon

--- a/avalon/tools/cbsceneinventory/model.py
+++ b/avalon/tools/cbsceneinventory/model.py
@@ -55,7 +55,7 @@ class InventoryModel(TreeModel):
             if index.column() == 0:
                 # Override color
                 color = node.get("color", style.colors.default)
-                if not index.parent().isValid():  # group-item
+                if node.get("isGroupNode"):  # group-item
                     return qta.icon("fa.folder", color=color)
                 else:
                     return qta.icon("fa.folder-o", color=color)
@@ -202,6 +202,7 @@ class InventoryModel(TreeModel):
             group_node["family"] = family
             group_node["familyIcon"] = family_icon
             group_node["count"] = len(group_items)
+            group_node["isGroupNode"] = True
 
             self.add_child(group_node, parent=parent)
 


### PR DESCRIPTION
This enables a better view for hierarchical (nested) subset type like `setdress` in Scene Inventory App.
Able to switch between normal *flat* view and hierarchy view.

![hierarchy_view](https://user-images.githubusercontent.com/3357009/48304452-bc105280-e554-11e8-905f-837374d57e5d.gif)

