### PR TITLE
Add property 'families' into config schema 1.0

### DIFF
--- a/avalon/inventory.py
+++ b/avalon/inventory.py
@@ -323,6 +323,7 @@ def _save_config_1_0(project_name, data):
     config["apps"] = data.get("apps", [])
     config["tasks"] = data.get("tasks", [])
     config["template"].update(data.get("template", {}))
+    config["families"] = data.get("families", [])
 
     schema.validate(document)
 

--- a/avalon/schema/config-1.0.json
+++ b/avalon/schema/config-1.0.json
@@ -53,6 +53,18 @@
                 "required": ["name"]
             }
         },
+        "families": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "icon": {"type": "string"},
+                    "label": {"type": "string"}
+                },
+                "required": ["name"]
+            }
+        },
         "copy": {
             "type": "object"
         }

--- a/avalon/tests/test_inventory.py
+++ b/avalon/tests/test_inventory.py
@@ -134,6 +134,9 @@ def test_save():
                 "{root}/{project}/{silo}/{asset}/publish/"
                 "{subset}/v{version:0>3}/{subset}.{representation}"
         },
+        "families": [
+            {"name": "avalon.model", "label": "Model", "icon": "cube"}
+        ],
         "copy": {}
     }
 


### PR DESCRIPTION
This PR will make the inventory able to save the *family configurations* via `$ avalon --save`,
which is required for `cbloader`.

https://github.com/getavalon/core/blob/c5dda32149e636a32d82ac06c09e279499a76402/avalon/tools/cbloader/lib.py#L14-L27

The property `families` won't be a *required* attribute, so instead of creating a new version of config schema, I chose to update current version.