### PR TITLE
Fix #358

### DIFF
--- a/avalon/lib.py
+++ b/avalon/lib.py
@@ -141,8 +141,16 @@ def which_app(app):
     return None
 
 
-def get_application(name, environment=None):
-    environment = environment or os.environ
+def get_application(name):
+    """Find the application .toml and parse it.
+
+    Arguments:
+        name (str): The name of the application to search.
+
+    Returns:
+        dict: The parsed application from the .toml settings.
+
+    """
     application_definition = which_app(name)
 
     if application_definition is None:
@@ -160,48 +168,6 @@ def get_application(name, environment=None):
             toml.TomlDecodeError) as e:
         log_.error("%s was invalid." % application_definition)
         raise
-
-    executable = which(app.get("executable", name))
-
-    if executable is None:
-        raise ValueError(
-            "'%s' not found on your PATH\n%s"
-            % (app["executable"], os.getenv("PATH"))
-        )
-
-    try:
-        app = dict_format(app, **environment)
-    except KeyError as e:
-        log_.error(
-            "One of the {variables} defined in the application "
-            "definition wasn't found in this session.\n"
-            "The variable was %s " % e
-        )
-        log_.error(json.dumps(environment, indent=4, sort_keys=True))
-
-        raise ValueError(
-            "This is typically a bug in the pipeline, "
-            "ask your developer.")
-
-    # Ingest application environment
-    environment = app.get("environment", {})
-    for key, value in environment.copy().items():
-        if isinstance(value, list):
-            # Treat list values as paths, e.g. PYTHONPATH=[]
-            environment[key] = os.pathsep.join(value)
-
-        elif isinstance(value, six.string_types):
-            if PY2:
-                # Protect against unicode in the environment
-                encoding = sys.getfilesystemencoding()
-                environment[key] = value.encode(encoding)
-            else:
-                environment[key] = value
-        else:
-            log_.error(
-                "%s: Unsupported environment reference in %s for %s"
-                % (value, name, key)
-            )
 
     return app
 

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -370,9 +370,9 @@ class Application(Action):
                 else:
                     app_environment[key] = value
             else:
-                log_.error(
+                log.error(
                     "%s: Unsupported environment reference in %s for %s"
-                    % (value, name, key)
+                    % (value, self.name, key)
                 )
 
         # Build environment
@@ -453,12 +453,12 @@ class Application(Action):
         try:
             return lib.dict_format(original, **kwargs)
         except KeyError as e:
-            log_.error(
+            log.error(
                 "One of the {variables} defined in the application "
                 "definition wasn't found in this session.\n"
                 "The variable was %s " % e
             )
-            log_.error(json.dumps(kwargs, indent=4, sort_keys=True))
+            log.error(json.dumps(kwargs, indent=4, sort_keys=True))
 
             raise ValueError(
                 "This is typically a bug in the pipeline, "

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -324,7 +324,7 @@ class Application(Action):
     """Default application launcher
 
     This is a convenience application Action that when "config" refers to a
-    loaded application `.toml` this can launch the application.
+    parsed application `.toml` this can launch the application.
 
     """
 
@@ -355,10 +355,31 @@ class Application(Action):
         workdir = _format_work_template(template, session)
         session["AVALON_WORKDIR"] = workdir
 
+        # Construct application environment from .toml config
+        app_environment = self.config.get("environment", {})
+        for key, value in app_environment.copy().items():
+            if isinstance(value, list):
+                # Treat list values as paths, e.g. PYTHONPATH=[]
+                app_environment[key] = os.pathsep.join(value)
+
+            elif isinstance(value, six.string_types):
+                if lib.PY2:
+                    # Protect against unicode in the environment
+                    encoding = sys.getfilesystemencoding()
+                    app_environment[key] = value.encode(encoding)
+                else:
+                    app_environment[key] = value
+            else:
+                log_.error(
+                    "%s: Unsupported environment reference in %s for %s"
+                    % (value, name, key)
+                )
+
         # Build environment
         env = os.environ.copy()
-        env.update(self.config.get("environment", {}))
         env.update(session)
+        app_environment = self._format(app_environment, **env)
+        env.update(app_environment)
 
         return env
 
@@ -373,6 +394,7 @@ class Application(Action):
 
             # Create default directories from app configuration
             default_dirs = self.config.get("default_dirs", [])
+            default_dirs = self._format(default_dirs, **environment)
             if default_dirs:
                 self.log.debug("Creating default directories..")
                 for dirname in default_dirs:
@@ -398,7 +420,14 @@ class Application(Action):
                 self.log.error(" - %s -> %s" % (src, dst))
 
     def launch(self, environment):
+
         executable = lib.which(self.config["executable"])
+        if executable is None:
+            raise ValueError(
+                "'%s' not found on your PATH\n%s"
+                % (self.config["executable"], os.getenv("PATH"))
+            )
+
         args = self.config.get("args", [])
         return lib.launch(
             executable=executable,
@@ -417,6 +446,23 @@ class Application(Action):
 
         if kwargs.get("launch", True):
             return self.launch(environment)
+
+    def _format(self, original, **kwargs):
+        """Utility recursive dict formatting that logs the error clearly."""
+
+        try:
+            return lib.dict_format(original, **kwargs)
+        except KeyError as e:
+            log_.error(
+                "One of the {variables} defined in the application "
+                "definition wasn't found in this session.\n"
+                "The variable was %s " % e
+            )
+            log_.error(json.dumps(kwargs, indent=4, sort_keys=True))
+
+            raise ValueError(
+                "This is typically a bug in the pipeline, "
+                "ask your developer.")
 
 
 def discover(superclass):

--- a/avalon/session.py
+++ b/avalon/session.py
@@ -102,13 +102,8 @@ class _Session(dict):
         config = project["config"]
         template = config["template"]["work"]
 
-        environment = dict(os.environ, **self)
-
         # Application READS from environment..
-        application = lib.get_application(
-            name=self["AVALON_APP"],
-            environment=environment
-        )
+        application = lib.get_application(name=self["AVALON_APP"])
 
         self["AVALON_WORKDIR"] = template.format(
             root=self["AVALON_PROJECTS"],


### PR DESCRIPTION
This avoids `get_application` directly merging the environment but solely parses the `.toml` for #358. Whether this is the best solution I'm not too sure, but in my case this is exactly functional for our produtions and fixes the issue.

I've implemented in the way I described in the issue:

> My proposal would be to change: avalon.lib.get_application to only read out the toml, but not perform the environment management and leave that up to the action. We will need to read the .toml at least before "running" it to load the icon and color to be displayed in the Launcher

So visually it functions the same, it just now merges the environment at the end upon the call to `environ()` of the `Application` class.
