### PR TITLE
Fix app copy fail when path contain env var

### DIFF
--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -411,6 +411,8 @@ class Application(Action):
         # Perform application copy
         for src, dst in self.config.get("copy", {}).items():
             dst = os.path.join(workdir, dst)
+            # Expand env vars
+            src, dst = self._format([src, dst], **environment)
 
             try:
                 self.log.info("Copying %s -> %s" % (src, dst))


### PR DESCRIPTION
### Problem

The files in `copy` section of app `.toml` did not get copied due to the file path contain envvar did not expand.
e.g. `"{AVALON_CORE}/res/workspace.mel"`

The app still be able to launch from Launcher even the copy fails, but will get error when you switching context in app.

### Fix

This PR ensure the paths from `config["copy"]` get expanded before doing `shutil.copy`.
