### PR TITLE
Default subsets from creator plugin

### DIFF
--- a/avalon/houdini/pipeline.py
+++ b/avalon/houdini/pipeline.py
@@ -305,7 +305,7 @@ class Creator(api.Creator):
 
         # Get out node
         out = hou.node("out")
-        instance = out.createNode(node_type, node_name=self.name)
+        instance = out.createNode(node_type, node_name=self.data["subset"])
         instance.moveToGoodPosition()
 
         lib.imprint(instance, self.data)

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -503,7 +503,7 @@ class Creator(api.Creator):
         if (self.options or {}).get("useSelection"):
             nodes = cmds.ls(selection=True)
 
-        instance = cmds.sets(nodes, name=self.name)
+        instance = cmds.sets(nodes, name=self.data["subset"])
         lib.imprint(instance, self.data)
 
         return instance

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -216,13 +216,11 @@ class Loader(list):
 @lib.log
 class Creator(object):
     """Determine how assets are created"""
-    name = None
     label = None
     family = None
     subsets = None
 
     def __init__(self, name, asset, options=None, data=None):
-        self.name = name or self.name
         self.options = options
 
         # Default data

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -230,7 +230,7 @@ class Creator(object):
         self.data["id"] = "pyblish.avalon.instance"
         self.data["family"] = self.family
         self.data["asset"] = asset
-        self.data["subset"] = self.name
+        self.data["subset"] = name
         self.data["active"] = True
 
         self.data.update(data or {})
@@ -873,12 +873,6 @@ def create(name, asset, family, options=None, data=None):
 
         if not has_family:
             continue
-
-        if not name:
-            name = Plugin.name
-            Plugin.log.info(
-                "Using default name '%s' from '%s'" % (name, Plugin.__name__)
-            )
 
         Plugin.log.info(
             "Creating '%s' with '%s'" % (name, Plugin.__name__)

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -218,7 +218,7 @@ class Creator(object):
     """Determine how assets are created"""
     label = None
     family = None
-    subsets = None
+    defaults = None
 
     def __init__(self, name, asset, options=None, data=None):
         self.name = name  # For backwards compatibility

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -218,7 +218,7 @@ class Creator(object):
     """Determine how assets are created"""
     label = None
     family = None
-    subsets = None
+    variants = None
 
     def __init__(self, name, asset, options=None, data=None):
         self.options = options

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -234,23 +234,6 @@ class Creator(object):
 
         self.data.update(data or {})
 
-    @classmethod
-    def family_branch(cls):
-        """Return family branch name"""
-        return cls.family.rsplit(".", 1)[-1]
-
-    @classmethod
-    def compose_subset(cls, variant):
-        """Compose subset name with variant name"""
-        if variant:
-            variant = variant[0].upper() + variant[1:]
-        return "{}{}".format(cls.family_branch(), variant)
-
-    @classmethod
-    def parse_variant(cls, subset):
-        """Parse variant name from subset name"""
-        return subset.split(cls.family_branch())[-1]
-
     def process(self):
         pass
 

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -233,6 +233,23 @@ class Creator(object):
 
         self.data.update(data or {})
 
+    @classmethod
+    def family_branch(cls):
+        """Return family branch name"""
+        return cls.family.rsplit(".", 1)[-1]
+
+    @classmethod
+    def compose_subset(cls, variant):
+        """Compose subset name with variant name"""
+        if variant:
+            variant = variant[0].upper() + variant[1:]
+        return "{}{}".format(cls.family_branch(), variant)
+
+    @classmethod
+    def parse_variant(cls, subset):
+        """Parse variant name from subset name"""
+        return subset.split(cls.family_branch())[-1]
+
     def process(self):
         pass
 

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -218,7 +218,7 @@ class Creator(object):
     """Determine how assets are created"""
     label = None
     family = None
-    variants = None
+    subsets = None
 
     def __init__(self, name, asset, options=None, data=None):
         self.name = name  # For backwards compatibility

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -221,6 +221,7 @@ class Creator(object):
     variants = None
 
     def __init__(self, name, asset, options=None, data=None):
+        self.name = name  # For backwards compatibility
         self.options = options
 
         # Default data

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -219,6 +219,7 @@ class Creator(object):
     name = None
     label = None
     family = None
+    subsets = None
 
     def __init__(self, name, asset, options=None, data=None):
         self.name = name or self.name

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -213,7 +213,9 @@ class Window(QtWidgets.QDialog):
 
             if plugin.defaults and isinstance(plugin.defaults, list):
                 defaults = plugin.defaults[:] + [Separator]
-                for sub in [s for s in existed_subsets if s not in defaults]:
+                lowered = [d.lower() for d in plugin.defaults]
+                for sub in [s for s in existed_subsets
+                            if s.lower() not in lowered]:
                     defaults.append(sub)
             else:
                 defaults = existed_subsets

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -1,4 +1,4 @@
-import os
+
 import sys
 import inspect
 
@@ -180,7 +180,6 @@ class Window(QtWidgets.QDialog):
         asset_name = self.data["Asset"]
         subset = self.data["Subset"]
         result = self.data["Result"]
-        button = self.data["Create Button"]
 
         item = listing.currentItem()
         subset_name = subset.text()

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -48,19 +48,19 @@ class Window(QtWidgets.QDialog):
         result.setStyleSheet("color: gray;")
         result.setEnabled(False)
 
-        # region Menu for default subset names
+        # region Menu for default variant names
 
-        subset_button = QtWidgets.QPushButton()
-        subset_button.setFixedWidth(18)
-        subset_button.setFixedHeight(20)
-        subset_menu = QtWidgets.QMenu(subset_button)
-        subset_button.setMenu(subset_menu)
+        variant_button = QtWidgets.QPushButton()
+        variant_button.setFixedWidth(18)
+        variant_button.setFixedHeight(20)
+        variant_menu = QtWidgets.QMenu(variant_button)
+        variant_button.setMenu(variant_menu)
 
         # endregion
 
         name_layout = QtWidgets.QHBoxLayout()
         name_layout.addWidget(name)
-        name_layout.addWidget(subset_button)
+        name_layout.addWidget(variant_button)
         name_layout.setContentsMargins(0, 0, 0, 0)
 
         layout = QtWidgets.QVBoxLayout(container)
@@ -112,8 +112,8 @@ class Window(QtWidgets.QDialog):
             "Create Button": create_btn,
             "Listing": listing,
             "Use Selection Checkbox": useselection_chk,
-            "Subset": name,
-            "Subset Menu": subset_menu,
+            "Variant": name,
+            "Variant Menu": variant_menu,
             "Result": result,
             "Asset": asset,
             "Error Message": error_msg,
@@ -141,7 +141,7 @@ class Window(QtWidgets.QDialog):
         self.data['Create Button'].setEnabled(state)
 
     def _build_menu(self, default_names):
-        """Create optional predefined subset names
+        """Create optional predefined variant names
 
         Args:
             default_names(list): all predefined names
@@ -150,7 +150,7 @@ class Window(QtWidgets.QDialog):
              None
         """
 
-        menu = self.data["Subset Menu"]
+        menu = self.data["Variant Menu"]
         button = menu.parent()
 
         # Get and destroy the action group
@@ -172,18 +172,18 @@ class Window(QtWidgets.QDialog):
         group.triggered.connect(self._on_action_clicked)
 
     def _on_action_clicked(self, action):
-        name = self.data["Subset"]
+        name = self.data["Variant"]
         name.setText(action.text())
 
     def _on_data_changed(self):
 
         listing = self.data["Listing"]
         asset_name = self.data["Asset"]
-        subset = self.data["Subset"]
+        variant = self.data["Variant"]
         result = self.data["Result"]
 
         item = listing.currentItem()
-        subset_name = subset.text()
+        variant_name = variant.text()
         asset_name = asset_name.text()
 
         # Get the assets from the database which match with the name
@@ -202,19 +202,18 @@ class Window(QtWidgets.QDialog):
                                                "$options": "i"},
                                       "parent": {"$in": asset_ids}}) or []
 
-            # Get all subsets' their description name, "Default", "High", "Low"
-            subsets = set([sub["name"].split(family)[-1] for sub in subsets])
-            plugin_subsets = getattr(plugin, "subsets", None)
-            if isinstance(plugin_subsets, list):
-                plugin_subsets.append("Default")
-                subsets.update(set(plugin_subsets))
+            # Get all subsets' their variant name, "Default", "High", "Low"
+            variants = set([sub["name"].split(family)[-1] for sub in subsets])
 
-            self._build_menu(sorted(list(subsets)))
+            if isinstance(plugin.variants, list):
+                variants.update(set(plugin.variants))
+
+            self._build_menu(sorted(list(variants)))
 
             # Update the result
-            if subset_name:
-                subset_name = subset_name[0].upper() + subset_name[1:]
-            result.setText("{}{}".format(family, subset_name))
+            if variant_name:
+                variant_name = variant_name[0].upper() + variant_name[1:]
+            result.setText("{}{}".format(family, variant_name))
 
             item.setData(ExistsRole, True)
             self.echo("Ready ..")
@@ -225,7 +224,7 @@ class Window(QtWidgets.QDialog):
 
         # Update the valid state
         valid = (
-            subset_name.strip() != "" and
+            variant_name.strip() != "" and
             asset_name.strip() != "" and
             item.data(QtCore.Qt.ItemIsEnabled) and
             item.data(ExistsRole)
@@ -242,7 +241,7 @@ class Window(QtWidgets.QDialog):
         lib.schedule(self._on_data_changed, 500, channel="gui")
 
     def on_selection_changed(self, *args):
-        name = self.data["Subset"]
+        name = self.data["Variant"]
         item = self.data["Listing"].currentItem()
 
         plugin = item.data(PluginRole)

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -50,19 +50,19 @@ class Window(QtWidgets.QDialog):
         result.setStyleSheet("color: gray;")
         result.setEnabled(False)
 
-        # region Menu for default variant names
+        # region Menu for default subset names
 
-        variant_button = QtWidgets.QPushButton()
-        variant_button.setFixedWidth(18)
-        variant_button.setFixedHeight(20)
-        variant_menu = QtWidgets.QMenu(variant_button)
-        variant_button.setMenu(variant_menu)
+        subset_button = QtWidgets.QPushButton()
+        subset_button.setFixedWidth(18)
+        subset_button.setFixedHeight(20)
+        subset_menu = QtWidgets.QMenu(subset_button)
+        subset_button.setMenu(subset_menu)
 
         # endregion
 
         name_layout = QtWidgets.QHBoxLayout()
         name_layout.addWidget(name)
-        name_layout.addWidget(variant_button)
+        name_layout.addWidget(subset_button)
         name_layout.setContentsMargins(0, 0, 0, 0)
 
         layout = QtWidgets.QVBoxLayout(container)
@@ -114,8 +114,8 @@ class Window(QtWidgets.QDialog):
             "Create Button": create_btn,
             "Listing": listing,
             "Use Selection Checkbox": useselection_chk,
-            "Variant": name,
-            "Variant Menu": variant_menu,
+            "Subset": name,
+            "Subset Menu": subset_menu,
             "Result": result,
             "Asset": asset,
             "Error Message": error_msg,
@@ -143,7 +143,7 @@ class Window(QtWidgets.QDialog):
         self.data['Create Button'].setEnabled(state)
 
     def _build_menu(self, default_names):
-        """Create optional predefined variant names
+        """Create optional predefined subset names
 
         Args:
             default_names(list): all predefined names
@@ -152,7 +152,7 @@ class Window(QtWidgets.QDialog):
              None
         """
 
-        menu = self.data["Variant Menu"]
+        menu = self.data["Subset Menu"]
         button = menu.parent()
 
         # Get and destroy the action group
@@ -177,18 +177,18 @@ class Window(QtWidgets.QDialog):
         group.triggered.connect(self._on_action_clicked)
 
     def _on_action_clicked(self, action):
-        name = self.data["Variant"]
+        name = self.data["Subset"]
         name.setText(action.text())
 
     def _on_data_changed(self):
 
         listing = self.data["Listing"]
         asset_name = self.data["Asset"]
-        variant = self.data["Variant"]
+        subset = self.data["Subset"]
         result = self.data["Result"]
 
         item = listing.currentItem()
-        variant_name = variant.text()
+        subset_name = subset.text()
         asset_name = asset_name.text()
 
         # Get the assets from the database which match with the name
@@ -207,23 +207,23 @@ class Window(QtWidgets.QDialog):
                                                "$options": "i"},
                                       "parent": {"$in": asset_ids}}) or []
 
-            # Get all subsets' their variant name, "Default", "High", "Low"
-            existed_variants = [sub["name"].split(family)[-1]
-                                for sub in subsets]
+            # Get all subsets' their subset name, "Default", "High", "Low"
+            existed_subsets = [sub["name"].split(family)[-1]
+                               for sub in subsets]
 
-            if plugin.variants and isinstance(plugin.variants, list):
-                variants = plugin.variants[:] + [Separator]
-                for var in [v for v in existed_variants if v not in variants]:
-                    variants.append(var)
+            if plugin.subsets and isinstance(plugin.subsets, list):
+                subsets = plugin.subsets[:] + [Separator]
+                for sub in [s for s in existed_subsets if s not in subsets]:
+                    subsets.append(sub)
             else:
-                variants = existed_variants
+                subsets = existed_subsets
 
-            self._build_menu(variants)
+            self._build_menu(subsets)
 
             # Update the result
-            if variant_name:
-                variant_name = variant_name[0].upper() + variant_name[1:]
-            result.setText("{}{}".format(family, variant_name))
+            if subset_name:
+                subset_name = subset_name[0].upper() + subset_name[1:]
+            result.setText("{}{}".format(family, subset_name))
 
             item.setData(ExistsRole, True)
             self.echo("Ready ..")
@@ -234,7 +234,7 @@ class Window(QtWidgets.QDialog):
 
         # Update the valid state
         valid = (
-            variant_name.strip() != "" and
+            subset_name.strip() != "" and
             asset_name.strip() != "" and
             item.data(QtCore.Qt.ItemIsEnabled) and
             item.data(ExistsRole)
@@ -251,19 +251,19 @@ class Window(QtWidgets.QDialog):
         lib.schedule(self._on_data_changed, 500, channel="gui")
 
     def on_selection_changed(self, *args):
-        name = self.data["Variant"]
+        name = self.data["Subset"]
         item = self.data["Listing"].currentItem()
 
         plugin = item.data(PluginRole)
         if plugin is None:
             return
 
-        if plugin.variants and isinstance(plugin.variants, list):
-            default_variant = plugin.variants[0]
+        if plugin.subsets and isinstance(plugin.subsets, list):
+            default_subset = plugin.subsets[0]
         else:
-            default_variant = "Default"
+            default_subset = "Default"
 
-        name.setText(default_variant)
+        name.setText(default_subset)
 
         self.on_data_changed()
 

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -208,11 +208,12 @@ class Window(QtWidgets.QDialog):
                                       "parent": {"$in": asset_ids}}) or []
 
             # Get all subsets' their subset name, "Default", "High", "Low"
-            existed_subsets = [sub["name"].split(family)[-1]
+            existed_subsets = [sub["name"].split(family)[-1].capitalize()
                                for sub in subsets]
 
             if plugin.defaults and isinstance(plugin.defaults, list):
-                defaults = plugin.defaults[:] + [Separator]
+                defaults = [d.capitalize() for d in plugin.defaults]
+                defaults.append(Separator)
                 for sub in [s for s in existed_subsets if s not in defaults]:
                     defaults.append(sub)
             else:
@@ -222,7 +223,7 @@ class Window(QtWidgets.QDialog):
 
             # Update the result
             if subset_name:
-                subset_name = subset_name[0].upper() + subset_name[1:]
+                subset_name = subset_name.capitalize()
             result.setText("{}{}".format(family, subset_name))
 
             item.setData(ExistsRole, True)
@@ -259,7 +260,7 @@ class Window(QtWidgets.QDialog):
             return
 
         if plugin.defaults and isinstance(plugin.defaults, list):
-            default = plugin.defaults[0]
+            default = plugin.defaults[0].capitalize()
         else:
             default = "Default"
 

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -203,8 +203,13 @@ class Window(QtWidgets.QDialog):
                                       "parent": {"$in": asset_ids}}) or []
 
             # Get all subsets' their description name, "Default", "High", "Low"
-            subsets = [subset["name"].split(family)[-1] for subset in subsets]
-            self._build_menu(subsets)
+            subsets = set([sub["name"].split(family)[-1] for sub in subsets])
+            plugin_subsets = getattr(plugin, "subsets", None)
+            if isinstance(plugin_subsets, list):
+                plugin_subsets.append("Default")
+                subsets.update(set(plugin_subsets))
+
+            self._build_menu(sorted(list(subsets)))
 
             # Update the result
             if subset_name:

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -45,6 +45,7 @@ class Window(QtWidgets.QDialog):
         asset = QtWidgets.QLineEdit()
         name = QtWidgets.QLineEdit()
         result = QtWidgets.QLineEdit()
+        result.setStyleSheet("color: gray;")
         result.setEnabled(False)
 
         # region Menu for default subset names

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -198,17 +198,17 @@ class Window(QtWidgets.QDialog):
         if assets:
             # Get plugin and family
             plugin = item.data(PluginRole)
-            branch = plugin.family_branch()
+            family = plugin.family.rsplit(".", 1)[-1]
 
             # Get all subsets of the current asset
             asset_ids = [asset["_id"] for asset in assets]
             subsets = io.find(filter={"type": "subset",
-                                      "name": {"$regex": "{}*".format(branch),
+                                      "name": {"$regex": "{}*".format(family),
                                                "$options": "i"},
                                       "parent": {"$in": asset_ids}}) or []
 
             # Get all subsets' their variant name, "Default", "High", "Low"
-            existed_variants = [plugin.parse_variant(sub["name"])
+            existed_variants = [sub["name"].split(family)[-1]
                                 for sub in subsets]
 
             if plugin.variants and isinstance(plugin.variants, list):
@@ -221,7 +221,9 @@ class Window(QtWidgets.QDialog):
             self._build_menu(variants)
 
             # Update the result
-            result.setText(plugin.compose_subset(variant_name))
+            if variant_name:
+                variant_name = variant_name[0].upper() + variant_name[1:]
+            result.setText("{}{}".format(family, variant_name))
 
             item.setData(ExistsRole, True)
             self.echo("Ready ..")

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -203,13 +203,17 @@ class Window(QtWidgets.QDialog):
                                       "parent": {"$in": asset_ids}}) or []
 
             # Get all subsets' their variant name, "Default", "High", "Low"
-            variants = set([plugin.parse_variant(sub["name"])
-                            for sub in subsets])
+            existed_variants = [plugin.parse_variant(sub["name"])
+                                for sub in subsets]
 
-            if isinstance(plugin.variants, list):
-                variants.update(set(plugin.variants))
+            if plugin.variants and isinstance(plugin.variants, list):
+                variants = plugin.variants[:]
+                for var in [v for v in existed_variants if v not in variants]:
+                    variants.append(var)
+            else:
+                variants = existed_variants
 
-            self._build_menu(sorted(list(variants)))
+            self._build_menu(variants)
 
             # Update the result
             result.setText(plugin.compose_subset(variant_name))
@@ -247,8 +251,12 @@ class Window(QtWidgets.QDialog):
         if plugin is None:
             return
 
-        label = "Default"
-        name.setText(label)
+        if plugin.variants and isinstance(plugin.variants, list):
+            default_variant = plugin.variants[0]
+        else:
+            default_variant = "Default"
+
+        name.setText(default_variant)
 
         self.on_data_changed()
 

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -208,12 +208,11 @@ class Window(QtWidgets.QDialog):
                                       "parent": {"$in": asset_ids}}) or []
 
             # Get all subsets' their subset name, "Default", "High", "Low"
-            existed_subsets = [sub["name"].split(family)[-1].capitalize()
+            existed_subsets = [sub["name"].split(family)[-1]
                                for sub in subsets]
 
             if plugin.defaults and isinstance(plugin.defaults, list):
-                defaults = [d.capitalize() for d in plugin.defaults]
-                defaults.append(Separator)
+                defaults = plugin.defaults[:] + [Separator]
                 for sub in [s for s in existed_subsets if s not in defaults]:
                     defaults.append(sub)
             else:
@@ -223,7 +222,7 @@ class Window(QtWidgets.QDialog):
 
             # Update the result
             if subset_name:
-                subset_name = subset_name.capitalize()
+                subset_name = subset_name[0].upper() + subset_name[1:]
             result.setText("{}{}".format(family, subset_name))
 
             item.setData(ExistsRole, True)
@@ -260,7 +259,7 @@ class Window(QtWidgets.QDialog):
             return
 
         if plugin.defaults and isinstance(plugin.defaults, list):
-            default = plugin.defaults[0].capitalize()
+            default = plugin.defaults[0]
         else:
             default = "Default"
 

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -211,14 +211,14 @@ class Window(QtWidgets.QDialog):
             existed_subsets = [sub["name"].split(family)[-1]
                                for sub in subsets]
 
-            if plugin.subsets and isinstance(plugin.subsets, list):
-                subsets = plugin.subsets[:] + [Separator]
-                for sub in [s for s in existed_subsets if s not in subsets]:
-                    subsets.append(sub)
+            if plugin.defaults and isinstance(plugin.defaults, list):
+                defaults = plugin.defaults[:] + [Separator]
+                for sub in [s for s in existed_subsets if s not in defaults]:
+                    defaults.append(sub)
             else:
-                subsets = existed_subsets
+                defaults = existed_subsets
 
-            self._build_menu(subsets)
+            self._build_menu(defaults)
 
             # Update the result
             if subset_name:
@@ -258,12 +258,12 @@ class Window(QtWidgets.QDialog):
         if plugin is None:
             return
 
-        if plugin.subsets and isinstance(plugin.subsets, list):
-            default_subset = plugin.subsets[0]
+        if plugin.defaults and isinstance(plugin.defaults, list):
+            default = plugin.defaults[0]
         else:
-            default_subset = "Default"
+            default = "Default"
 
-        name.setText(default_subset)
+        name.setText(default)
 
         self.on_data_changed()
 

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -17,6 +17,8 @@ FamilyRole = QtCore.Qt.UserRole + 3
 ExistsRole = QtCore.Qt.UserRole + 4
 PluginRole = QtCore.Qt.UserRole + 5
 
+Separator = "---separator---"
+
 
 class Window(QtWidgets.QDialog):
 
@@ -166,6 +168,9 @@ class Window(QtWidgets.QDialog):
         # Build new action group
         group = QtWidgets.QActionGroup(button)
         for name in default_names:
+            if name == Separator:
+                menu.addSeparator()
+                continue
             action = group.addAction(name)
             menu.addAction(action)
 
@@ -207,7 +212,7 @@ class Window(QtWidgets.QDialog):
                                 for sub in subsets]
 
             if plugin.variants and isinstance(plugin.variants, list):
-                variants = plugin.variants[:]
+                variants = plugin.variants[:] + [Separator]
                 for var in [v for v in existed_variants if v not in variants]:
                     variants.append(var)
             else:


### PR DESCRIPTION
## Feature Propose

Make TDs able to predefine some commonly used subset names in the creator plugin.

Example creator:
```python
import avalon.maya

class ModelCreator(avalon.maya.Creator):
    name = "modelDefault"
    label = "model"
    family = "pipeline.model"
    subsets = [
        "HighPoly",
        "LowPoly",
    ]
```

Those predefined subset names will be listed in the Creator App's subset menu for artists to pick up, along with previous published subset names.
