### PR TITLE
Improve Asset Switcher GUI

### DIFF
--- a/avalon/tools/cbsceneinventory/app.py
+++ b/avalon/tools/cbsceneinventory/app.py
@@ -481,7 +481,15 @@ class SwitchAssetDialog(QtWidgets.QDialog):
         self._representations_box = SearchComboBox(
             placeholder="<representation>")
 
-        input_layout = QtWidgets.QHBoxLayout()
+        self._asset_label = QtWidgets.QLabel('')
+        self._subset_label = QtWidgets.QLabel('')
+        self._repre_label = QtWidgets.QLabel('')
+
+        main_layout = QtWidgets.QVBoxLayout()
+        context_layout = QtWidgets.QHBoxLayout()
+        asset_layout = QtWidgets.QVBoxLayout()
+        subset_layout = QtWidgets.QVBoxLayout()
+        repre_layout = QtWidgets.QVBoxLayout()
 
         accept_icon = qta.icon("fa.check", color="white")
         accept_btn = QtWidgets.QPushButton()
@@ -489,15 +497,23 @@ class SwitchAssetDialog(QtWidgets.QDialog):
         accept_btn.setFixedWidth(24)
         accept_btn.setFixedHeight(24)
 
-        input_layout.addWidget(self._assets_box)
-        input_layout.addWidget(self._subsets_box)
-        input_layout.addWidget(self._representations_box)
-        input_layout.addWidget(accept_btn)
+        asset_layout.addWidget(self._assets_box)
+        asset_layout.addWidget(self._asset_label)
+        subset_layout.addWidget(self._subsets_box)
+        subset_layout.addWidget(self._subset_label)
+        repre_layout.addWidget(self._representations_box)
+        repre_layout.addWidget(self._repre_label)
 
-        self._input_layout = input_layout
+        context_layout.addLayout(asset_layout)
+        context_layout.addLayout(subset_layout)
+        context_layout.addLayout(repre_layout)
+        context_layout.addWidget(accept_btn)
+
         self._accept_btn = accept_btn
 
-        self.setLayout(input_layout)
+
+        main_layout.addLayout(context_layout)
+        self.setLayout(main_layout)
         self.setWindowTitle("Switch selected items ...")
 
         self.connections()
@@ -522,8 +538,23 @@ class SwitchAssetDialog(QtWidgets.QDialog):
         subsets = sorted(self._get_subsets())
         self._subsets_box.populate(subsets)
 
-        representations = sorted(self._get_representations())
-        self._representations_box.populate(representations)
+    def set_labels(self):
+        default = "*No changes"
+        asset_label = default
+        subset_label = default
+        repre_label = default
+
+        if self._assets_box.currentText() != '':
+            asset_label = self._assets_box.currentText()
+        if self._subsets_box.currentText() != '':
+            subset_label = self._subsets_box.currentText()
+        if self._representations_box.currentText() != '':
+            repre_label = self._representations_box.currentText()
+
+        self._asset_label.setText(asset_label)
+        self._subset_label.setText(subset_label)
+        self._repre_label.setText(repre_label)
+
 
     def _get_assets(self):
         filtered_assets = []

--- a/avalon/tools/cbsceneinventory/app.py
+++ b/avalon/tools/cbsceneinventory/app.py
@@ -529,14 +529,45 @@ class SwitchAssetDialog(QtWidgets.QDialog):
     def connections(self):
         self._accept_btn.clicked.connect(self._on_accept)
 
-    def refresh(self):
+
+    def refresh(self, refresh_type=0):
         """Build the need comboboxes with content"""
+        if refresh_type < 1:
+            assets = sorted(self._get_assets())
+            self._assets_box.populate(assets)
 
-        assets = sorted(self._get_assets())
-        self._assets_box.populate(assets)
+        if refresh_type < 2:
+            last_subset = self._subsets_box.currentText()
 
-        subsets = sorted(self._get_subsets())
-        self._subsets_box.populate(subsets)
+            subsets = sorted(self._get_subsets())
+            self._subsets_box.populate(subsets)
+
+            if (last_subset != "" and last_subset in list(subsets)):
+                index = None
+                for i in range(self._subsets_box.count()):
+                    if last_subset == str(self._subsets_box.itemText(i)):
+                        index = i
+                        break
+                if index is not None:
+                    self._subsets_box.setCurrentIndex(index)
+
+        if refresh_type < 3:
+            last_repre = self._representations_box.currentText()
+
+            representations = sorted(self._get_representations())
+            self._representations_box.populate(representations)
+
+            if (last_repre != "" and last_repre in list(representations)):
+                index = None
+                for i in range(self._representations_box.count()):
+                    if last_repre == self._representations_box.itemText(i):
+                        index = i
+                        break
+                if index is not None:
+                    self._representations_box.setCurrentIndex(index)
+
+        self.set_labels()
+        self.validate()
 
     def set_labels(self):
         default = "*No changes"

--- a/avalon/tools/cbsceneinventory/app.py
+++ b/avalon/tools/cbsceneinventory/app.py
@@ -526,7 +526,17 @@ class SwitchAssetDialog(QtWidgets.QDialog):
         self._representations_box.populate(representations)
 
     def _get_assets(self):
-        return self._get_document_names("asset")
+        filtered_assets = []
+        for asset in io.find({'type': 'asset'}):
+            subsets = io.find({
+                'type': 'subset',
+                'parent': asset['_id']
+            })
+            for subs in subsets:
+                filtered_assets.append(asset['name'])
+                break
+
+        return filtered_assets
 
     def _get_subsets(self):
         return self._get_document_names("subset")

--- a/avalon/tools/cbsceneinventory/app.py
+++ b/avalon/tools/cbsceneinventory/app.py
@@ -575,11 +575,21 @@ class SwitchAssetDialog(QtWidgets.QDialog):
     def _get_representations(self):
         return self._get_document_names("representation")
 
-    def _get_document_names(self, document_type, parent=None):
+        return list(possible_repres)
+
+    def _get_document_names(self, document_type, parents=[]):
 
         query = {"type": document_type}
-        if parent:
-            query["parent"] = parent["_id"]
+
+        if len(parents) == 1:
+            query["parent"] = parents[0]["_id"]
+        elif len(parents) > 1:
+            or_exprs = []
+            for parent in parents:
+                expr = {"parent": parent["_id"]}
+                or_exprs.append(expr)
+
+            query["$or"] = or_exprs
 
         return io.find(query).distinct("name")
 

--- a/avalon/tools/cbsceneinventory/app.py
+++ b/avalon/tools/cbsceneinventory/app.py
@@ -555,6 +555,86 @@ class SwitchAssetDialog(QtWidgets.QDialog):
         self._subset_label.setText(subset_label)
         self._repre_label.setText(repre_label)
 
+    def validate(self):
+        asset_name = self._assets_box.get_valid_value() or None
+        subset_name = self._subsets_box.get_valid_value() or None
+        repre_name = self._representations_box.get_valid_value() or None
+
+        asset_ok = True
+        subset_ok = True
+        repre_ok = True
+        for item in self._items:
+            if any(not x for x in [asset_name, subset_name, repre_name]):
+                _id = io.ObjectId(item["representation"])
+                representation = io.find_one({
+                    "type": "representation",
+                    "_id": _id
+                })
+                version, subset, asset, project = io.parenthood(representation)
+
+                if asset_name is None:
+                    asset_name = asset["name"]
+
+                if subset_name is None:
+                    subset_name = subset["name"]
+
+                if repre_name is None:
+                    repre_name = representation["name"]
+
+            asset = io.find_one({"name": asset_name, "type": "asset"})
+            if asset is None:
+                asset_ok = False
+                continue
+            subset = io.find_one({
+                "name": subset_name,
+                "type": "subset",
+                "parent": asset["_id"]
+            })
+            if subset is None:
+                subset_ok = False
+                continue
+            version = io.find_one(
+                {
+                    "type": "version",
+                    "parent": subset["_id"]
+                },
+                sort=[('name', -1)]
+            )
+            if version is None:
+                repre_ok = False
+                continue
+
+            repre = io.find_one({
+                "name": repre_name,
+                "type": "representation",
+                "parent": version["_id"]
+            })
+            if repre is None:
+                repre_ok = False
+
+        asset_sheet = ''
+        subset_sheet = ''
+        repre_sheet = ''
+        accept_sheet = ''
+        error_msg = '*Please select'
+        if asset_ok is False:
+            asset_sheet = 'border: 1px solid red;'
+            self._asset_label.setText(error_msg)
+        if subset_ok is False:
+            subset_sheet = 'border: 1px solid red;'
+            self._subset_label.setText(error_msg)
+        if repre_ok is False:
+            repre_sheet = 'border: 1px solid red;'
+            self._repre_label.setText(error_msg)
+        if asset_ok and subset_ok and repre_ok:
+            accept_sheet = 'border: 1px solid green;'
+
+        self._assets_box.setStyleSheet(asset_sheet)
+        self._subsets_box.setStyleSheet(subset_sheet)
+        self._representations_box.setStyleSheet(repre_sheet)
+
+        self._accept_btn.setEnabled(asset_ok and subset_ok and repre_ok)
+        self._accept_btn.setStyleSheet(accept_sheet)
 
     def _get_assets(self):
         filtered_assets = []

--- a/avalon/tools/cbsceneinventory/app.py
+++ b/avalon/tools/cbsceneinventory/app.py
@@ -511,6 +511,11 @@ class SwitchAssetDialog(QtWidgets.QDialog):
 
         self._accept_btn = accept_btn
 
+        self._assets_box.currentIndexChanged.connect(self.on_assets_change)
+        self._subsets_box.currentIndexChanged.connect(self.on_subset_change)
+        self._representations_box.currentIndexChanged.connect(
+            self.on_repre_change
+        )
 
         main_layout.addLayout(context_layout)
         self.setLayout(main_layout)
@@ -529,6 +534,14 @@ class SwitchAssetDialog(QtWidgets.QDialog):
     def connections(self):
         self._accept_btn.clicked.connect(self._on_accept)
 
+    def on_assets_change(self):
+        self.refresh(1)
+
+    def on_subset_change(self):
+        self.refresh(2)
+
+    def on_repre_change(self):
+        self.refresh(3)
 
     def refresh(self, refresh_type=0):
         """Build the need comboboxes with content"""


### PR DESCRIPTION
This PR add new functionality to asset switcher GUI in cbsceneinventory and improves in user experience in general.

Changes:
- Dropdown are filtered left to right. If I select an asset on the left, I only see subsets from that particular asset. Same goes for representations. When no new asset is selected, only subsets from currently loaded asset are visible
- Added visual cues indicating whether currently selected combination of asset, subset and representation exists and is therefore importable. For example if my loaded subset is called `modelMain` but the asset I selected in the switcher doesn't have this subset, I won't be able to switch it and the subset dropdown will be coloured in red indicating I have to choose a new subset name. 
- When trying to switch more assets at the same time, the GUI shows an intersection of their available subsets by default. So if too assets don't share any subset name, we cannot change them in one go, unless we're replacing them with a new asset.



everything else should work identically so searching and the actual switch mechanism wasn't touched. 

Here's the look of it
![Mar 14 2019 8_12 PM - Edited](https://user-images.githubusercontent.com/3333008/54385729-9e383300-4697-11e9-8108-fa69df84cf1f.gif)

