### PR TITLE
Update Qt.py

### DIFF
--- a/avalon/vendor/Qt.py
+++ b/avalon/vendor/Qt.py
@@ -43,7 +43,8 @@ import types
 import shutil
 import importlib
 
-__version__ = "1.1.0.b2"
+
+__version__ = "1.2.0.b3"
 
 # Enable support for `from Qt import *`
 __all__ = []
@@ -63,17 +64,153 @@ except NameError:
     # Python 3 compatibility
     long = int
 
+
 """Common members of all bindings
 
 This is where each member of Qt.py is explicitly defined.
 It is based on a "lowest common denominator" of all bindings;
 including members found in each of the 4 bindings.
 
-Find or add excluded members in build_membership.py
+The "_common_members" dictionary is generated using the
+build_membership.sh script.
 
 """
 
 _common_members = {
+    "QtCore": [
+        "QAbstractAnimation",
+        "QAbstractEventDispatcher",
+        "QAbstractItemModel",
+        "QAbstractListModel",
+        "QAbstractState",
+        "QAbstractTableModel",
+        "QAbstractTransition",
+        "QAnimationGroup",
+        "QBasicTimer",
+        "QBitArray",
+        "QBuffer",
+        "QByteArray",
+        "QByteArrayMatcher",
+        "QChildEvent",
+        "QCoreApplication",
+        "QCryptographicHash",
+        "QDataStream",
+        "QDate",
+        "QDateTime",
+        "QDir",
+        "QDirIterator",
+        "QDynamicPropertyChangeEvent",
+        "QEasingCurve",
+        "QElapsedTimer",
+        "QEvent",
+        "QEventLoop",
+        "QEventTransition",
+        "QFile",
+        "QFileInfo",
+        "QFileSystemWatcher",
+        "QFinalState",
+        "QGenericArgument",
+        "QGenericReturnArgument",
+        "QHistoryState",
+        "QItemSelectionRange",
+        "QIODevice",
+        "QLibraryInfo",
+        "QLine",
+        "QLineF",
+        "QLocale",
+        "QMargins",
+        "QMetaClassInfo",
+        "QMetaEnum",
+        "QMetaMethod",
+        "QMetaObject",
+        "QMetaProperty",
+        "QMimeData",
+        "QModelIndex",
+        "QMutex",
+        "QMutexLocker",
+        "QObject",
+        "QParallelAnimationGroup",
+        "QPauseAnimation",
+        "QPersistentModelIndex",
+        "QPluginLoader",
+        "QPoint",
+        "QPointF",
+        "QProcess",
+        "QProcessEnvironment",
+        "QPropertyAnimation",
+        "QReadLocker",
+        "QReadWriteLock",
+        "QRect",
+        "QRectF",
+        "QRegExp",
+        "QResource",
+        "QRunnable",
+        "QSemaphore",
+        "QSequentialAnimationGroup",
+        "QSettings",
+        "QSignalMapper",
+        "QSignalTransition",
+        "QSize",
+        "QSizeF",
+        "QSocketNotifier",
+        "QState",
+        "QStateMachine",
+        "QSysInfo",
+        "QSystemSemaphore",
+        "QT_TRANSLATE_NOOP",
+        "QT_TR_NOOP",
+        "QT_TR_NOOP_UTF8",
+        "QTemporaryFile",
+        "QTextBoundaryFinder",
+        "QTextCodec",
+        "QTextDecoder",
+        "QTextEncoder",
+        "QTextStream",
+        "QTextStreamManipulator",
+        "QThread",
+        "QThreadPool",
+        "QTime",
+        "QTimeLine",
+        "QTimer",
+        "QTimerEvent",
+        "QTranslator",
+        "QUrl",
+        "QVariantAnimation",
+        "QWaitCondition",
+        "QWriteLocker",
+        "QXmlStreamAttribute",
+        "QXmlStreamAttributes",
+        "QXmlStreamEntityDeclaration",
+        "QXmlStreamEntityResolver",
+        "QXmlStreamNamespaceDeclaration",
+        "QXmlStreamNotationDeclaration",
+        "QXmlStreamReader",
+        "QXmlStreamWriter",
+        "Qt",
+        "QtCriticalMsg",
+        "QtDebugMsg",
+        "QtFatalMsg",
+        "QtMsgType",
+        "QtSystemMsg",
+        "QtWarningMsg",
+        "qAbs",
+        "qAddPostRoutine",
+        "qChecksum",
+        "qCritical",
+        "qDebug",
+        "qFatal",
+        "qFuzzyCompare",
+        "qIsFinite",
+        "qIsInf",
+        "qIsNaN",
+        "qIsNull",
+        "qRegisterResourceData",
+        "qUnregisterResourceData",
+        "qVersion",
+        "qWarning",
+        "qrand",
+        "qsrand"
+    ],
     "QtGui": [
         "QAbstractTextDocumentLayout",
         "QActionEvent",
@@ -85,6 +222,7 @@ _common_members = {
         "QConicalGradient",
         "QContextMenuEvent",
         "QCursor",
+        "QDesktopServices",
         "QDoubleValidator",
         "QDrag",
         "QDragEnterEvent",
@@ -182,6 +320,7 @@ _common_members = {
         "QTextTableCell",
         "QTextTableCellFormat",
         "QTextTableFormat",
+        "QTouchEvent",
         "QTransform",
         "QValidator",
         "QVector2D",
@@ -197,7 +336,101 @@ _common_members = {
         "qIsGray",
         "qRed",
         "qRgb",
-        "qRgb",
+        "qRgba"
+    ],
+    "QtHelp": [
+        "QHelpContentItem",
+        "QHelpContentModel",
+        "QHelpContentWidget",
+        "QHelpEngine",
+        "QHelpEngineCore",
+        "QHelpIndexModel",
+        "QHelpIndexWidget",
+        "QHelpSearchEngine",
+        "QHelpSearchQuery",
+        "QHelpSearchQueryWidget",
+        "QHelpSearchResultWidget"
+    ],
+    "QtMultimedia": [
+        "QAbstractVideoBuffer",
+        "QAbstractVideoSurface",
+        "QAudio",
+        "QAudioDeviceInfo",
+        "QAudioFormat",
+        "QAudioInput",
+        "QAudioOutput",
+        "QVideoFrame",
+        "QVideoSurfaceFormat"
+    ],
+    "QtNetwork": [
+        "QAbstractNetworkCache",
+        "QAbstractSocket",
+        "QAuthenticator",
+        "QHostAddress",
+        "QHostInfo",
+        "QLocalServer",
+        "QLocalSocket",
+        "QNetworkAccessManager",
+        "QNetworkAddressEntry",
+        "QNetworkCacheMetaData",
+        "QNetworkConfiguration",
+        "QNetworkConfigurationManager",
+        "QNetworkCookie",
+        "QNetworkCookieJar",
+        "QNetworkDiskCache",
+        "QNetworkInterface",
+        "QNetworkProxy",
+        "QNetworkProxyFactory",
+        "QNetworkProxyQuery",
+        "QNetworkReply",
+        "QNetworkRequest",
+        "QNetworkSession",
+        "QSsl",
+        "QTcpServer",
+        "QTcpSocket",
+        "QUdpSocket"
+    ],
+    "QtOpenGL": [
+        "QGL",
+        "QGLContext",
+        "QGLFormat",
+        "QGLWidget"
+    ],
+    "QtPrintSupport": [
+        "QAbstractPrintDialog",
+        "QPageSetupDialog",
+        "QPrintDialog",
+        "QPrintEngine",
+        "QPrintPreviewDialog",
+        "QPrintPreviewWidget",
+        "QPrinter",
+        "QPrinterInfo"
+    ],
+    "QtSql": [
+        "QSql",
+        "QSqlDatabase",
+        "QSqlDriver",
+        "QSqlDriverCreatorBase",
+        "QSqlError",
+        "QSqlField",
+        "QSqlIndex",
+        "QSqlQuery",
+        "QSqlQueryModel",
+        "QSqlRecord",
+        "QSqlRelation",
+        "QSqlRelationalDelegate",
+        "QSqlRelationalTableModel",
+        "QSqlResult",
+        "QSqlTableModel"
+    ],
+    "QtSvg": [
+        "QGraphicsSvgItem",
+        "QSvgGenerator",
+        "QSvgRenderer",
+        "QSvgWidget"
+    ],
+    "QtTest": [
+        "QTest"
     ],
     "QtWidgets": [
         "QAbstractButton",
@@ -389,138 +622,10 @@ _common_members = {
         "QWidgetAction",
         "QWidgetItem",
         "QWizard",
-        "QWizardPage",
+        "QWizardPage"
     ],
-    "QtCore": [
-        "QAbstractAnimation",
-        "QAbstractEventDispatcher",
-        "QAbstractItemModel",
-        "QAbstractListModel",
-        "QAbstractState",
-        "QAbstractTableModel",
-        "QAbstractTransition",
-        "QAnimationGroup",
-        "QBasicTimer",
-        "QBitArray",
-        "QBuffer",
-        "QByteArray",
-        "QByteArrayMatcher",
-        "QChildEvent",
-        "QCoreApplication",
-        "QCryptographicHash",
-        "QDataStream",
-        "QDate",
-        "QDateTime",
-        "QDir",
-        "QDirIterator",
-        "QDynamicPropertyChangeEvent",
-        "QEasingCurve",
-        "QElapsedTimer",
-        "QEvent",
-        "QEventLoop",
-        "QEventTransition",
-        "QFile",
-        "QFileInfo",
-        "QFileSystemWatcher",
-        "QFinalState",
-        "QGenericArgument",
-        "QGenericReturnArgument",
-        "QHistoryState",
-        "QIODevice",
-        "QLibraryInfo",
-        "QLine",
-        "QLineF",
-        "QLocale",
-        "QMargins",
-        "QMetaClassInfo",
-        "QMetaEnum",
-        "QMetaMethod",
-        "QMetaObject",
-        "QMetaProperty",
-        "QMetaType",
-        "QMimeData",
-        "QModelIndex",
-        "QMutex",
-        "QMutexLocker",
-        "QObject",
-        "QParallelAnimationGroup",
-        "QPauseAnimation",
-        "QPersistentModelIndex",
-        "QPluginLoader",
-        "QPoint",
-        "QPointF",
-        "QProcess",
-        "QProcessEnvironment",
-        "QPropertyAnimation",
-        "QReadLocker",
-        "QReadWriteLock",
-        "QRect",
-        "QRectF",
-        "QRegExp",
-        "QResource",
-        "QRunnable",
-        "QSemaphore",
-        "QSequentialAnimationGroup",
-        "QSettings",
-        "QSignalMapper",
-        "QSignalTransition",
-        "QSize",
-        "QSizeF",
-        "QSocketNotifier",
-        "QState",
-        "QStateMachine",
-        "QSysInfo",
-        "QSystemSemaphore",
-        "QTemporaryFile",
-        "QTextBoundaryFinder",
-        "QTextCodec",
-        "QTextDecoder",
-        "QTextEncoder",
-        "QTextStream",
-        "QTextStreamManipulator",
-        "QThread",
-        "QThreadPool",
-        "QTime",
-        "QTimeLine",
-        "QTimer",
-        "QTimerEvent",
-        "QTranslator",
-        "QUrl",
-        "QVariantAnimation",
-        "QWaitCondition",
-        "QWriteLocker",
-        "QXmlStreamAttribute",
-        "QXmlStreamAttributes",
-        "QXmlStreamEntityDeclaration",
-        "QXmlStreamEntityResolver",
-        "QXmlStreamNamespaceDeclaration",
-        "QXmlStreamNotationDeclaration",
-        "QXmlStreamReader",
-        "QXmlStreamWriter",
-        "Qt",
-        "QtCriticalMsg",
-        "QtDebugMsg",
-        "QtFatalMsg",
-        "QtMsgType",
-        "QtSystemMsg",
-        "QtWarningMsg",
-        "qAbs",
-        "qAddPostRoutine",
-        "qChecksum",
-        "qCritical",
-        "qDebug",
-        "qFatal",
-        "qFuzzyCompare",
-        "qIsFinite",
-        "qIsInf",
-        "qIsNaN",
-        "qIsNull",
-        "qRegisterResourceData",
-        "qUnregisterResourceData",
-        "qVersion",
-        "qWarning",
-        "qrand",
-        "qsrand",
+    "QtX11Extras": [
+        "QX11Info"
     ],
     "QtXml": [
         "QDomAttr",
@@ -555,144 +660,73 @@ _common_members = {
         "QXmlReader",
         "QXmlSimpleReader"
     ],
-    "QtHelp": [
-        "QHelpContentItem",
-        "QHelpContentModel",
-        "QHelpContentWidget",
-        "QHelpEngine",
-        "QHelpEngineCore",
-        "QHelpIndexModel",
-        "QHelpIndexWidget",
-        "QHelpSearchEngine",
-        "QHelpSearchQuery",
-        "QHelpSearchQueryWidget",
-        "QHelpSearchResultWidget"
-    ],
-    "QtNetwork": [
-        "QAbstractNetworkCache",
-        "QAbstractSocket",
-        "QAuthenticator",
-        "QHostAddress",
-        "QHostInfo",
-        "QLocalServer",
-        "QLocalSocket",
-        "QNetworkAccessManager",
-        "QNetworkAddressEntry",
-        "QNetworkCacheMetaData",
-        "QNetworkConfiguration",
-        "QNetworkConfigurationManager",
-        "QNetworkCookie",
-        "QNetworkCookieJar",
-        "QNetworkDiskCache",
-        "QNetworkInterface",
-        "QNetworkProxy",
-        "QNetworkProxyFactory",
-        "QNetworkProxyQuery",
-        "QNetworkReply",
-        "QNetworkRequest",
-        "QNetworkSession",
-        "QSsl",
-        "QTcpServer",
-        "QTcpSocket",
-        "QUdpSocket"
-    ],
-    "QtOpenGL": [
-        "QGL",
-        "QGLContext",
-        "QGLFormat",
-        "QGLWidget"
+    "QtXmlPatterns": [
+        "QAbstractMessageHandler",
+        "QAbstractUriResolver",
+        "QAbstractXmlNodeModel",
+        "QAbstractXmlReceiver",
+        "QSourceLocation",
+        "QXmlFormatter",
+        "QXmlItem",
+        "QXmlName",
+        "QXmlNamePool",
+        "QXmlNodeModelIndex",
+        "QXmlQuery",
+        "QXmlResultItems",
+        "QXmlSchema",
+        "QXmlSchemaValidator",
+        "QXmlSerializer"
     ]
 }
 
 
-"""Misplaced members
+def _qInstallMessageHandler(handler):
+    """Install a message handler that works in all bindings
 
-These members from the original submodule are misplaced relative PySide2
+    Args:
+        handler: A function that takes 3 arguments, or None
+    """
+    def messageOutputHandler(*args):
+        # In Qt4 bindings, message handlers are passed 2 arguments
+        # In Qt5 bindings, message handlers are passed 3 arguments
+        # The first argument is a QtMsgType
+        # The last argument is the message to be printed
+        # The Middle argument (if passed) is a QMessageLogContext
+        if len(args) == 3:
+            msgType, logContext, msg = args
+        elif len(args) == 2:
+            msgType, msg = args
+            logContext = None
+        else:
+            raise TypeError(
+                "handler expected 2 or 3 arguments, got {0}".format(len(args)))
 
-"""
-_misplaced_members = {
-    "pyside2": {
-        "QtGui.QStringListModel": "QtCore.QStringListModel",
-        "QtCore.Property": "QtCore.Property",
-        "QtCore.Signal": "QtCore.Signal",
-        "QtCore.Slot": "QtCore.Slot",
-        "QtCore.QAbstractProxyModel": "QtCore.QAbstractProxyModel",
-        "QtCore.QSortFilterProxyModel": "QtCore.QSortFilterProxyModel",
-        "QtCore.QItemSelection": "QtCore.QItemSelection",
-        "QtCore.QItemSelectionModel": "QtCore.QItemSelectionModel",
-    },
-    "pyqt5": {
-        "QtCore.pyqtProperty": "QtCore.Property",
-        "QtCore.pyqtSignal": "QtCore.Signal",
-        "QtCore.pyqtSlot": "QtCore.Slot",
-        "QtCore.QAbstractProxyModel": "QtCore.QAbstractProxyModel",
-        "QtCore.QSortFilterProxyModel": "QtCore.QSortFilterProxyModel",
-        "QtCore.QStringListModel": "QtCore.QStringListModel",
-        "QtCore.QItemSelection": "QtCore.QItemSelection",
-        "QtCore.QItemSelectionModel": "QtCore.QItemSelectionModel",
-    },
-    "pyside": {
-        "QtGui.QAbstractProxyModel": "QtCore.QAbstractProxyModel",
-        "QtGui.QSortFilterProxyModel": "QtCore.QSortFilterProxyModel",
-        "QtGui.QStringListModel": "QtCore.QStringListModel",
-        "QtGui.QItemSelection": "QtCore.QItemSelection",
-        "QtGui.QItemSelectionModel": "QtCore.QItemSelectionModel",
-        "QtCore.Property": "QtCore.Property",
-        "QtCore.Signal": "QtCore.Signal",
-        "QtCore.Slot": "QtCore.Slot",
+        if isinstance(msg, bytes):
+            # In python 3, some bindings pass a bytestring, which cannot be
+            # used elsewhere. Decoding a python 2 or 3 bytestring object will
+            # consistently return a unicode object.
+            msg = msg.decode()
 
-    },
-    "pyqt4": {
-        "QtGui.QAbstractProxyModel": "QtCore.QAbstractProxyModel",
-        "QtGui.QSortFilterProxyModel": "QtCore.QSortFilterProxyModel",
-        "QtGui.QItemSelection": "QtCore.QItemSelection",
-        "QtGui.QStringListModel": "QtCore.QStringListModel",
-        "QtGui.QItemSelectionModel": "QtCore.QItemSelectionModel",
-        "QtCore.pyqtProperty": "QtCore.Property",
-        "QtCore.pyqtSignal": "QtCore.Signal",
-        "QtCore.pyqtSlot": "QtCore.Slot",
-    }
-}
+        handler(msgType, logContext, msg)
+
+    passObject = messageOutputHandler if handler else handler
+    if Qt.IsPySide or Qt.IsPyQt4:
+        return Qt._QtCore.qInstallMsgHandler(passObject)
+    elif Qt.IsPySide2 or Qt.IsPyQt5:
+        return Qt._QtCore.qInstallMessageHandler(passObject)
 
 
-def _apply_site_config():
-    try:
-        import QtSiteConfig
-    except ImportError:
-        # If no QtSiteConfig module found, no modifications
-        # to _common_members are needed.
-        pass
-    else:
-        # Update _common_members with any changes made by QtSiteConfig
-        QtSiteConfig.update_members(_common_members)
+def _getcpppointer(object):
+    if hasattr(Qt, "_shiboken2"):
+        return getattr(Qt, "_shiboken2").getCppPointer(object)[0]
+    elif hasattr(Qt, "_shiboken"):
+        return getattr(Qt, "_shiboken").getCppPointer(object)[0]
+    elif hasattr(Qt, "_sip"):
+        return getattr(Qt, "_sip").unwrapinstance(object)
+    raise AttributeError("'module' has no attribute 'getCppPointer'")
 
 
-def _new_module(name):
-    return types.ModuleType(__name__ + "." + name)
-
-
-def _setup(module, extras):
-    """Install common submodules"""
-
-    Qt.__binding__ = module.__name__
-
-    for name in list(_common_members) + extras:
-        try:
-            submodule = importlib.import_module(
-                module.__name__ + "." + name)
-        except ImportError:
-            continue
-
-        setattr(Qt, "_" + name, submodule)
-
-        if name not in extras:
-            # Store reference to original binding,
-            # but don't store speciality modules
-            # such as uic or QtUiTools
-            setattr(Qt, name, _new_module(name))
-
-
-def _wrapinstance(func, ptr, base=None):
+def _wrapinstance(ptr, base=None):
     """Enable implicit cast of pointer to most suitable class
 
     This behaviour is available in sip per default.
@@ -707,7 +741,6 @@ def _wrapinstance(func, ptr, base=None):
         See :func:`QtCompat.wrapInstance()`
 
     Arguments:
-        func (function): Original function
         ptr (long): Pointer to QObject in memory
         base (QObject, optional): Base class to wrap with. Defaults to QObject,
             which should handle anything.
@@ -717,6 +750,15 @@ def _wrapinstance(func, ptr, base=None):
     assert isinstance(ptr, long), "Argument 'ptr' must be of type <long>"
     assert (base is None) or issubclass(base, Qt.QtCore.QObject), (
         "Argument 'base' must be of type <QObject>")
+
+    if Qt.IsPyQt4 or Qt.IsPyQt5:
+        func = getattr(Qt, "_sip").wrapinstance
+    elif Qt.IsPySide2:
+        func = getattr(Qt, "_shiboken2").wrapInstance
+    elif Qt.IsPySide:
+        func = getattr(Qt, "_shiboken").wrapInstance
+    else:
+        raise AttributeError("'module' has no attribute 'wrapInstance'")
 
     if base is None:
         q_object = func(long(ptr), Qt.QtCore.QObject)
@@ -736,34 +778,581 @@ def _wrapinstance(func, ptr, base=None):
     return func(long(ptr), base)
 
 
-def _reassign_misplaced_members(binding):
-    """Parse `_misplaced_members` dict and remap
-    values based on the underlying binding.
+def _translate(context, sourceText, *args):
+    # In Qt4 bindings, translate can be passed 2 or 3 arguments
+    # In Qt5 bindings, translate can be passed 2 arguments
+    # The first argument is disambiguation[str]
+    # The last argument is n[int]
+    # The middle argument can be encoding[QtCore.QCoreApplication.Encoding]
+    if len(args) == 3:
+        disambiguation, encoding, n = args
+    elif len(args) == 2:
+        disambiguation, n = args
+        encoding = None
+    else:
+        raise TypeError(
+            "Expected 4 or 5 arguments, got {0}.".format(len(args) + 2))
 
-    :param str binding: Top level binding in _misplaced_members.
+    if hasattr(Qt.QtCore, "QCoreApplication"):
+        app = getattr(Qt.QtCore, "QCoreApplication")
+    else:
+        raise NotImplementedError(
+            "Missing QCoreApplication implementation for {binding}".format(
+                binding=Qt.__binding__,
+            )
+        )
+    if Qt.__binding__ in ("PySide2", "PyQt5"):
+        sanitized_args = [context, sourceText, disambiguation, n]
+    else:
+        sanitized_args = [
+            context,
+            sourceText,
+            disambiguation,
+            encoding or app.CodecForTr,
+            n
+        ]
+    return app.translate(*sanitized_args)
+
+
+def _loadUi(uifile, baseinstance=None):
+    """Dynamically load a user interface from the given `uifile`
+
+    This function calls `uic.loadUi` if using PyQt bindings,
+    else it implements a comparable binding for PySide.
+
+    Documentation:
+        http://pyqt.sourceforge.net/Docs/PyQt5/designer.html#PyQt5.uic.loadUi
+
+    Arguments:
+        uifile (str): Absolute path to Qt Designer file.
+        baseinstance (QWidget): Instantiated QWidget or subclass thereof
+
+    Return:
+        baseinstance if `baseinstance` is not `None`. Otherwise
+        return the newly created instance of the user interface.
+
+    """
+    if hasattr(Qt, "_uic"):
+        return Qt._uic.loadUi(uifile, baseinstance)
+
+    elif hasattr(Qt, "_QtUiTools"):
+        # Implement `PyQt5.uic.loadUi` for PySide(2)
+
+        class _UiLoader(Qt._QtUiTools.QUiLoader):
+            """Create the user interface in a base instance.
+
+            Unlike `Qt._QtUiTools.QUiLoader` itself this class does not
+            create a new instance of the top-level widget, but creates the user
+            interface in an existing instance of the top-level class if needed.
+
+            This mimics the behaviour of `PyQt5.uic.loadUi`.
+
+            """
+
+            def __init__(self, baseinstance):
+                super(_UiLoader, self).__init__(baseinstance)
+                self.baseinstance = baseinstance
+                self.custom_widgets = {}
+
+            def _loadCustomWidgets(self, etree):
+                """
+                Workaround to pyside-77 bug.
+
+                From QUiLoader doc we should use registerCustomWidget method.
+                But this causes a segfault on some platforms.
+
+                Instead we fetch from customwidgets DOM node the python class
+                objects. Then we can directly use them in createWidget method.
+                """
+
+                def headerToModule(header):
+                    """
+                    Translate a header file to python module path
+                    foo/bar.h => foo.bar
+                    """
+                    # Remove header extension
+                    module = os.path.splitext(header)[0]
+
+                    # Replace os separator by python module separator
+                    return module.replace("/", ".").replace("\\", ".")
+
+                custom_widgets = etree.find("customwidgets")
+
+                if custom_widgets is None:
+                    return
+
+                for custom_widget in custom_widgets:
+                    class_name = custom_widget.find("class").text
+                    header = custom_widget.find("header").text
+                    module = importlib.import_module(headerToModule(header))
+                    self.custom_widgets[class_name] = getattr(module,
+                                                              class_name)
+
+            def load(self, uifile, *args, **kwargs):
+                from xml.etree.ElementTree import ElementTree
+
+                # For whatever reason, if this doesn't happen then
+                # reading an invalid or non-existing .ui file throws
+                # a RuntimeError.
+                etree = ElementTree()
+                etree.parse(uifile)
+                self._loadCustomWidgets(etree)
+
+                widget = Qt._QtUiTools.QUiLoader.load(
+                    self, uifile, *args, **kwargs)
+
+                # Workaround for PySide 1.0.9, see issue #208
+                widget.parentWidget()
+
+                return widget
+
+            def createWidget(self, class_name, parent=None, name=""):
+                """Called for each widget defined in ui file
+
+                Overridden here to populate `baseinstance` instead.
+
+                """
+
+                if parent is None and self.baseinstance:
+                    # Supposed to create the top-level widget,
+                    # return the base instance instead
+                    return self.baseinstance
+
+                # For some reason, Line is not in the list of available
+                # widgets, but works fine, so we have to special case it here.
+                if class_name in self.availableWidgets() + ["Line"]:
+                    # Create a new widget for child widgets
+                    widget = Qt._QtUiTools.QUiLoader.createWidget(self,
+                                                                  class_name,
+                                                                  parent,
+                                                                  name)
+                elif class_name in self.custom_widgets:
+                    widget = self.custom_widgets[class_name](parent)
+                else:
+                    raise Exception("Custom widget '%s' not supported"
+                                    % class_name)
+
+                if self.baseinstance:
+                    # Set an attribute for the new child widget on the base
+                    # instance, just like PyQt5.uic.loadUi does.
+                    setattr(self.baseinstance, name, widget)
+
+                return widget
+
+        widget = _UiLoader(baseinstance).load(uifile)
+        Qt.QtCore.QMetaObject.connectSlotsByName(widget)
+
+        return widget
+
+    else:
+        raise NotImplementedError("No implementation available for loadUi")
+
+
+"""Misplaced members
+
+These members from the original submodule are misplaced relative PySide2
+
+"""
+_misplaced_members = {
+    "PySide2": {
+        "QtCore.QStringListModel": "QtCore.QStringListModel",
+        "QtGui.QStringListModel": "QtCore.QStringListModel",
+        "QtCore.Property": "QtCore.Property",
+        "QtCore.Signal": "QtCore.Signal",
+        "QtCore.Slot": "QtCore.Slot",
+        "QtCore.QAbstractProxyModel": "QtCore.QAbstractProxyModel",
+        "QtCore.QSortFilterProxyModel": "QtCore.QSortFilterProxyModel",
+        "QtCore.QItemSelection": "QtCore.QItemSelection",
+        "QtCore.QItemSelectionModel": "QtCore.QItemSelectionModel",
+        "QtCore.QItemSelectionRange": "QtCore.QItemSelectionRange",
+        "QtUiTools.QUiLoader": ["QtCompat.loadUi", _loadUi],
+        "shiboken2.wrapInstance": ["QtCompat.wrapInstance", _wrapinstance],
+        "shiboken2.getCppPointer": ["QtCompat.getCppPointer", _getcpppointer],
+        "QtWidgets.qApp": "QtWidgets.QApplication.instance()",
+        "QtCore.QCoreApplication.translate": [
+            "QtCompat.translate", _translate
+        ],
+        "QtWidgets.QApplication.translate": [
+            "QtCompat.translate", _translate
+        ],
+        "QtCore.qInstallMessageHandler": [
+            "QtCompat.qInstallMessageHandler", _qInstallMessageHandler
+        ],
+    },
+    "PyQt5": {
+        "QtCore.pyqtProperty": "QtCore.Property",
+        "QtCore.pyqtSignal": "QtCore.Signal",
+        "QtCore.pyqtSlot": "QtCore.Slot",
+        "QtCore.QAbstractProxyModel": "QtCore.QAbstractProxyModel",
+        "QtCore.QSortFilterProxyModel": "QtCore.QSortFilterProxyModel",
+        "QtCore.QStringListModel": "QtCore.QStringListModel",
+        "QtCore.QItemSelection": "QtCore.QItemSelection",
+        "QtCore.QItemSelectionModel": "QtCore.QItemSelectionModel",
+        "QtCore.QItemSelectionRange": "QtCore.QItemSelectionRange",
+        "uic.loadUi": ["QtCompat.loadUi", _loadUi],
+        "sip.wrapinstance": ["QtCompat.wrapInstance", _wrapinstance],
+        "sip.unwrapinstance": ["QtCompat.getCppPointer", _getcpppointer],
+        "QtWidgets.qApp": "QtWidgets.QApplication.instance()",
+        "QtCore.QCoreApplication.translate": [
+            "QtCompat.translate", _translate
+        ],
+        "QtWidgets.QApplication.translate": [
+            "QtCompat.translate", _translate
+        ],
+        "QtCore.qInstallMessageHandler": [
+            "QtCompat.qInstallMessageHandler", _qInstallMessageHandler
+        ],
+    },
+    "PySide": {
+        "QtGui.QAbstractProxyModel": "QtCore.QAbstractProxyModel",
+        "QtGui.QSortFilterProxyModel": "QtCore.QSortFilterProxyModel",
+        "QtGui.QStringListModel": "QtCore.QStringListModel",
+        "QtGui.QItemSelection": "QtCore.QItemSelection",
+        "QtGui.QItemSelectionModel": "QtCore.QItemSelectionModel",
+        "QtCore.Property": "QtCore.Property",
+        "QtCore.Signal": "QtCore.Signal",
+        "QtCore.Slot": "QtCore.Slot",
+        "QtGui.QItemSelectionRange": "QtCore.QItemSelectionRange",
+        "QtGui.QAbstractPrintDialog": "QtPrintSupport.QAbstractPrintDialog",
+        "QtGui.QPageSetupDialog": "QtPrintSupport.QPageSetupDialog",
+        "QtGui.QPrintDialog": "QtPrintSupport.QPrintDialog",
+        "QtGui.QPrintEngine": "QtPrintSupport.QPrintEngine",
+        "QtGui.QPrintPreviewDialog": "QtPrintSupport.QPrintPreviewDialog",
+        "QtGui.QPrintPreviewWidget": "QtPrintSupport.QPrintPreviewWidget",
+        "QtGui.QPrinter": "QtPrintSupport.QPrinter",
+        "QtGui.QPrinterInfo": "QtPrintSupport.QPrinterInfo",
+        "QtUiTools.QUiLoader": ["QtCompat.loadUi", _loadUi],
+        "shiboken.wrapInstance": ["QtCompat.wrapInstance", _wrapinstance],
+        "shiboken.unwrapInstance": ["QtCompat.getCppPointer", _getcpppointer],
+        "QtGui.qApp": "QtWidgets.QApplication.instance()",
+        "QtCore.QCoreApplication.translate": [
+            "QtCompat.translate", _translate
+        ],
+        "QtGui.QApplication.translate": [
+            "QtCompat.translate", _translate
+        ],
+        "QtCore.qInstallMsgHandler": [
+            "QtCompat.qInstallMessageHandler", _qInstallMessageHandler
+        ],
+    },
+    "PyQt4": {
+        "QtGui.QAbstractProxyModel": "QtCore.QAbstractProxyModel",
+        "QtGui.QSortFilterProxyModel": "QtCore.QSortFilterProxyModel",
+        "QtGui.QItemSelection": "QtCore.QItemSelection",
+        "QtGui.QStringListModel": "QtCore.QStringListModel",
+        "QtGui.QItemSelectionModel": "QtCore.QItemSelectionModel",
+        "QtCore.pyqtProperty": "QtCore.Property",
+        "QtCore.pyqtSignal": "QtCore.Signal",
+        "QtCore.pyqtSlot": "QtCore.Slot",
+        "QtGui.QItemSelectionRange": "QtCore.QItemSelectionRange",
+        "QtGui.QAbstractPrintDialog": "QtPrintSupport.QAbstractPrintDialog",
+        "QtGui.QPageSetupDialog": "QtPrintSupport.QPageSetupDialog",
+        "QtGui.QPrintDialog": "QtPrintSupport.QPrintDialog",
+        "QtGui.QPrintEngine": "QtPrintSupport.QPrintEngine",
+        "QtGui.QPrintPreviewDialog": "QtPrintSupport.QPrintPreviewDialog",
+        "QtGui.QPrintPreviewWidget": "QtPrintSupport.QPrintPreviewWidget",
+        "QtGui.QPrinter": "QtPrintSupport.QPrinter",
+        "QtGui.QPrinterInfo": "QtPrintSupport.QPrinterInfo",
+        # "QtCore.pyqtSignature": "QtCore.Slot",
+        "uic.loadUi": ["QtCompat.loadUi", _loadUi],
+        "sip.wrapinstance": ["QtCompat.wrapInstance", _wrapinstance],
+        "sip.unwrapinstance": ["QtCompat.getCppPointer", _getcpppointer],
+        "QtCore.QString": "str",
+        "QtGui.qApp": "QtWidgets.QApplication.instance()",
+        "QtCore.QCoreApplication.translate": [
+            "QtCompat.translate", _translate
+        ],
+        "QtGui.QApplication.translate": [
+            "QtCompat.translate", _translate
+        ],
+        "QtCore.qInstallMsgHandler": [
+            "QtCompat.qInstallMessageHandler", _qInstallMessageHandler
+        ],
+    }
+}
+
+""" Compatibility Members
+
+This dictionary is used to build Qt.QtCompat objects that provide a consistent
+interface for obsolete members, and differences in binding return values.
+
+{
+    "binding": {
+        "classname": {
+            "targetname": "binding_namespace",
+        }
+    }
+}
+"""
+_compatibility_members = {
+    "PySide2": {
+        "QWidget": {
+            "grab": "QtWidgets.QWidget.grab",
+        },
+        "QHeaderView": {
+            "sectionsClickable": "QtWidgets.QHeaderView.sectionsClickable",
+            "setSectionsClickable":
+                "QtWidgets.QHeaderView.setSectionsClickable",
+            "sectionResizeMode": "QtWidgets.QHeaderView.sectionResizeMode",
+            "setSectionResizeMode":
+                "QtWidgets.QHeaderView.setSectionResizeMode",
+            "sectionsMovable": "QtWidgets.QHeaderView.sectionsMovable",
+            "setSectionsMovable": "QtWidgets.QHeaderView.setSectionsMovable",
+        },
+        "QFileDialog": {
+            "getOpenFileName": "QtWidgets.QFileDialog.getOpenFileName",
+            "getOpenFileNames": "QtWidgets.QFileDialog.getOpenFileNames",
+            "getSaveFileName": "QtWidgets.QFileDialog.getSaveFileName",
+        },
+    },
+    "PyQt5": {
+        "QWidget": {
+            "grab": "QtWidgets.QWidget.grab",
+        },
+        "QHeaderView": {
+            "sectionsClickable": "QtWidgets.QHeaderView.sectionsClickable",
+            "setSectionsClickable":
+                "QtWidgets.QHeaderView.setSectionsClickable",
+            "sectionResizeMode": "QtWidgets.QHeaderView.sectionResizeMode",
+            "setSectionResizeMode":
+                "QtWidgets.QHeaderView.setSectionResizeMode",
+            "sectionsMovable": "QtWidgets.QHeaderView.sectionsMovable",
+            "setSectionsMovable": "QtWidgets.QHeaderView.setSectionsMovable",
+        },
+        "QFileDialog": {
+            "getOpenFileName": "QtWidgets.QFileDialog.getOpenFileName",
+            "getOpenFileNames": "QtWidgets.QFileDialog.getOpenFileNames",
+            "getSaveFileName": "QtWidgets.QFileDialog.getSaveFileName",
+        },
+    },
+    "PySide": {
+        "QWidget": {
+            "grab": "QtWidgets.QPixmap.grabWidget",
+        },
+        "QHeaderView": {
+            "sectionsClickable": "QtWidgets.QHeaderView.isClickable",
+            "setSectionsClickable": "QtWidgets.QHeaderView.setClickable",
+            "sectionResizeMode": "QtWidgets.QHeaderView.resizeMode",
+            "setSectionResizeMode": "QtWidgets.QHeaderView.setResizeMode",
+            "sectionsMovable": "QtWidgets.QHeaderView.isMovable",
+            "setSectionsMovable": "QtWidgets.QHeaderView.setMovable",
+        },
+        "QFileDialog": {
+            "getOpenFileName": "QtWidgets.QFileDialog.getOpenFileName",
+            "getOpenFileNames": "QtWidgets.QFileDialog.getOpenFileNames",
+            "getSaveFileName": "QtWidgets.QFileDialog.getSaveFileName",
+        },
+    },
+    "PyQt4": {
+        "QWidget": {
+            "grab": "QtWidgets.QPixmap.grabWidget",
+        },
+        "QHeaderView": {
+            "sectionsClickable": "QtWidgets.QHeaderView.isClickable",
+            "setSectionsClickable": "QtWidgets.QHeaderView.setClickable",
+            "sectionResizeMode": "QtWidgets.QHeaderView.resizeMode",
+            "setSectionResizeMode": "QtWidgets.QHeaderView.setResizeMode",
+            "sectionsMovable": "QtWidgets.QHeaderView.isMovable",
+            "setSectionsMovable": "QtWidgets.QHeaderView.setMovable",
+        },
+        "QFileDialog": {
+            "getOpenFileName": "QtWidgets.QFileDialog.getOpenFileName",
+            "getOpenFileNames": "QtWidgets.QFileDialog.getOpenFileNames",
+            "getSaveFileName": "QtWidgets.QFileDialog.getSaveFileName",
+        },
+    },
+}
+
+
+def _apply_site_config():
+    try:
+        import QtSiteConfig
+    except ImportError:
+        # If no QtSiteConfig module found, no modifications
+        # to _common_members are needed.
+        pass
+    else:
+        # Provide the ability to modify the dicts used to build Qt.py
+        if hasattr(QtSiteConfig, 'update_members'):
+            QtSiteConfig.update_members(_common_members)
+
+        if hasattr(QtSiteConfig, 'update_misplaced_members'):
+            QtSiteConfig.update_misplaced_members(members=_misplaced_members)
+
+        if hasattr(QtSiteConfig, 'update_compatibility_members'):
+            QtSiteConfig.update_compatibility_members(
+                members=_compatibility_members)
+
+
+def _new_module(name):
+    return types.ModuleType(__name__ + "." + name)
+
+
+def _import_sub_module(module, name):
+    """import_sub_module will mimic the function of importlib.import_module"""
+    module = __import__(module.__name__ + "." + name)
+    for level in name.split("."):
+        module = getattr(module, level)
+    return module
+
+
+def _setup(module, extras):
+    """Install common submodules"""
+
+    Qt.__binding__ = module.__name__
+
+    for name in list(_common_members) + extras:
+        try:
+            submodule = _import_sub_module(
+                module, name)
+        except ImportError:
+            try:
+                # For extra modules like sip and shiboken that may not be
+                # children of the binding.
+                submodule = __import__(name)
+            except ImportError:
+                continue
+
+        setattr(Qt, "_" + name, submodule)
+
+        if name not in extras:
+            # Store reference to original binding,
+            # but don't store speciality modules
+            # such as uic or QtUiTools
+            setattr(Qt, name, _new_module(name))
+
+
+def _reassign_misplaced_members(binding):
+    """Apply misplaced members from `binding` to Qt.py
+
+    Arguments:
+        binding (dict): Misplaced members
 
     """
 
     for src, dst in _misplaced_members[binding].items():
-        src_module, src_member = src.split(".")
-        dst_module, dst_member = dst.split(".")
+        dst_value = None
+
+        src_parts = src.split(".")
+        src_module = src_parts[0]
+        src_member = None
+        if len(src_parts) > 1:
+            src_member = src_parts[1:]
+
+        if isinstance(dst, (list, tuple)):
+            dst, dst_value = dst
+
+        dst_parts = dst.split(".")
+        dst_module = dst_parts[0]
+        dst_member = None
+        if len(dst_parts) > 1:
+            dst_member = dst_parts[1]
+
+        # Get the member we want to store in the namesapce.
+        if not dst_value:
+            try:
+                _part = getattr(Qt, "_" + src_module)
+                while src_member:
+                    member = src_member.pop(0)
+                    _part = getattr(_part, member)
+                dst_value = _part
+            except AttributeError:
+                # If the member we want to store in the namespace does not
+                # exist, there is no need to continue. This can happen if a
+                # request was made to rename a member that didn't exist, for
+                # example if QtWidgets isn't available on the target platform.
+                _log("Misplaced member has no source: {0}".format(src))
+                continue
 
         try:
             src_object = getattr(Qt, dst_module)
         except AttributeError:
-            # Skip reassignment of non-existing members.
-            # This can happen if a request was made to
-            # rename a member that didn't exist, for example
-            # if QtWidgets isn't available on the target platform.
-            continue
+            if dst_module not in _common_members:
+                # Only create the Qt parent module if its listed in
+                # _common_members. Without this check, if you remove QtCore
+                # from _common_members, the default _misplaced_members will add
+                # Qt.QtCore so it can add Signal, Slot, etc.
+                msg = 'Not creating missing member module "{m}" for "{c}"'
+                _log(msg.format(m=dst_module, c=dst_member))
+                continue
+            # If the dst is valid but the Qt parent module does not exist
+            # then go ahead and create a new module to contain the member.
+            setattr(Qt, dst_module, _new_module(dst_module))
+            src_object = getattr(Qt, dst_module)
+            # Enable direct import of the new module
+            sys.modules[__name__ + "." + dst_module] = src_object
 
-        dst_value = getattr(getattr(Qt, "_" + src_module), src_member)
+        if not dst_value:
+            dst_value = getattr(Qt, "_" + src_module)
+            if src_member:
+                dst_value = getattr(dst_value, src_member)
 
         setattr(
             src_object,
-            dst_member,
+            dst_member or dst_module,
             dst_value
         )
+
+
+def _build_compatibility_members(binding, decorators=None):
+    """Apply `binding` to QtCompat
+
+    Arguments:
+        binding (str): Top level binding in _compatibility_members.
+        decorators (dict, optional): Provides the ability to decorate the
+            original Qt methods when needed by a binding. This can be used
+            to change the returned value to a standard value. The key should
+            be the classname, the value is a dict where the keys are the
+            target method names, and the values are the decorator functions.
+
+    """
+
+    decorators = decorators or dict()
+
+    # Allow optional site-level customization of the compatibility members.
+    # This method does not need to be implemented in QtSiteConfig.
+    try:
+        import QtSiteConfig
+    except ImportError:
+        pass
+    else:
+        if hasattr(QtSiteConfig, 'update_compatibility_decorators'):
+            QtSiteConfig.update_compatibility_decorators(binding, decorators)
+
+    _QtCompat = type("QtCompat", (object,), {})
+
+    for classname, bindings in _compatibility_members[binding].items():
+        attrs = {}
+        for target, binding in bindings.items():
+            namespaces = binding.split('.')
+            try:
+                src_object = getattr(Qt, "_" + namespaces[0])
+            except AttributeError as e:
+                _log("QtCompat: AttributeError: %s" % e)
+                # Skip reassignment of non-existing members.
+                # This can happen if a request was made to
+                # rename a member that didn't exist, for example
+                # if QtWidgets isn't available on the target platform.
+                continue
+
+            # Walk down any remaining namespace getting the object assuming
+            # that if the first namespace exists the rest will exist.
+            for namespace in namespaces[1:]:
+                src_object = getattr(src_object, namespace)
+
+            # decorate the Qt method if a decorator was provided.
+            if target in decorators.get(classname, []):
+                # staticmethod must be called on the decorated method to
+                # prevent a TypeError being raised when the decorated method
+                # is called.
+                src_object = staticmethod(
+                    decorators[classname][target](src_object))
+
+            attrs[target] = src_object
+
+        # Create the QtCompat class and install it into the namespace
+        compat_class = type(classname, (_QtCompat,), attrs)
+        setattr(Qt.QtCompat, classname, compat_class)
 
 
 def _pyside2():
@@ -777,55 +1366,63 @@ def _pyside2():
     """
 
     import PySide2 as module
-    _setup(module, ["QtUiTools"])
+    extras = ["QtUiTools"]
+    try:
+        try:
+            # Before merge of PySide and shiboken
+            import shiboken2
+        except ImportError:
+            # After merge of PySide and shiboken, May 2017
+            from PySide2 import shiboken2
+        extras.append("shiboken2")
+    except ImportError:
+        pass
 
+    _setup(module, extras)
     Qt.__binding_version__ = module.__version__
 
-    try:
-        import shiboken2
-        Qt.QtCompat.wrapInstance = (
-            lambda ptr, base=None: _wrapinstance(
-                shiboken2.wrapInstance, ptr, base)
-        )
-        Qt.QtCompat.getCppPointer = lambda object: \
-            shiboken2.getCppPointer(object)[0]
-
-    except ImportError:
-        pass  # Optional
+    if hasattr(Qt, "_shiboken2"):
+        Qt.QtCompat.wrapInstance = _wrapinstance
+        Qt.QtCompat.getCppPointer = _getcpppointer
+        Qt.QtCompat.delete = shiboken2.delete
 
     if hasattr(Qt, "_QtUiTools"):
         Qt.QtCompat.loadUi = _loadUi
 
     if hasattr(Qt, "_QtCore"):
         Qt.__qt_version__ = Qt._QtCore.qVersion()
-        Qt.QtCompat.translate = Qt._QtCore.QCoreApplication.translate
 
     if hasattr(Qt, "_QtWidgets"):
         Qt.QtCompat.setSectionResizeMode = \
             Qt._QtWidgets.QHeaderView.setSectionResizeMode
 
-    _reassign_misplaced_members("pyside2")
+    _reassign_misplaced_members("PySide2")
+    _build_compatibility_members("PySide2")
 
 
 def _pyside():
     """Initialise PySide"""
 
     import PySide as module
-    _setup(module, ["QtUiTools"])
+    extras = ["QtUiTools"]
+    try:
+        try:
+            # Before merge of PySide and shiboken
+            import shiboken
+        except ImportError:
+            # After merge of PySide and shiboken, May 2017
+            from PySide import shiboken
+        extras.append("shiboken")
+    except ImportError:
+        pass
 
+    _setup(module, extras)
     Qt.__binding_version__ = module.__version__
 
-    try:
-        import shiboken
-        Qt.QtCompat.wrapInstance = (
-            lambda ptr, base=None: _wrapinstance(
-                shiboken.wrapInstance, ptr, base)
-        )
-        Qt.QtCompat.getCppPointer = lambda object: \
-            shiboken.getCppPointer(object)[0]
-
-    except ImportError:
-        pass  # Optional
+    if hasattr(Qt, "_shiboken"):
+        Qt.QtCompat.wrapInstance = _wrapinstance
+        Qt.QtCompat.getCppPointer = _getcpppointer
+        Qt.QtCompat.delete = shiboken.delete
 
     if hasattr(Qt, "_QtUiTools"):
         Qt.QtCompat.loadUi = _loadUi
@@ -833,43 +1430,35 @@ def _pyside():
     if hasattr(Qt, "_QtGui"):
         setattr(Qt, "QtWidgets", _new_module("QtWidgets"))
         setattr(Qt, "_QtWidgets", Qt._QtGui)
+        if hasattr(Qt._QtGui, "QX11Info"):
+            setattr(Qt, "QtX11Extras", _new_module("QtX11Extras"))
+            Qt.QtX11Extras.QX11Info = Qt._QtGui.QX11Info
 
         Qt.QtCompat.setSectionResizeMode = Qt._QtGui.QHeaderView.setResizeMode
 
     if hasattr(Qt, "_QtCore"):
         Qt.__qt_version__ = Qt._QtCore.qVersion()
-        QCoreApplication = Qt._QtCore.QCoreApplication
-        Qt.QtCompat.translate = (
-            lambda context, sourceText, disambiguation, n:
-            QCoreApplication.translate(
-                context,
-                sourceText,
-                disambiguation,
-                QCoreApplication.CodecForTr,
-                n
-            )
-        )
 
-    _reassign_misplaced_members("pyside")
+    _reassign_misplaced_members("PySide")
+    _build_compatibility_members("PySide")
 
 
 def _pyqt5():
     """Initialise PyQt5"""
 
     import PyQt5 as module
-    _setup(module, ["uic"])
-
+    extras = ["uic"]
     try:
         import sip
-        Qt.QtCompat.wrapInstance = (
-            lambda ptr, base=None: _wrapinstance(
-                sip.wrapinstance, ptr, base)
-        )
-        Qt.QtCompat.getCppPointer = lambda object: \
-            sip.unwrapinstance(object)
-
+        extras.append(sip.__name__)
     except ImportError:
-        pass  # Optional
+        sip = None
+
+    _setup(module, extras)
+    if hasattr(Qt, "_sip"):
+        Qt.QtCompat.wrapInstance = _wrapinstance
+        Qt.QtCompat.getCppPointer = _getcpppointer
+        Qt.QtCompat.delete = sip.delete
 
     if hasattr(Qt, "_uic"):
         Qt.QtCompat.loadUi = _loadUi
@@ -877,13 +1466,13 @@ def _pyqt5():
     if hasattr(Qt, "_QtCore"):
         Qt.__binding_version__ = Qt._QtCore.PYQT_VERSION_STR
         Qt.__qt_version__ = Qt._QtCore.QT_VERSION_STR
-        Qt.QtCompat.translate = Qt._QtCore.QCoreApplication.translate
 
     if hasattr(Qt, "_QtWidgets"):
         Qt.QtCompat.setSectionResizeMode = \
             Qt._QtWidgets.QHeaderView.setSectionResizeMode
 
-    _reassign_misplaced_members("pyqt5")
+    _reassign_misplaced_members("PyQt5")
+    _build_compatibility_members('PyQt5')
 
 
 def _pyqt4():
@@ -924,19 +1513,18 @@ def _pyqt4():
                 )
 
     import PyQt4 as module
-    _setup(module, ["uic"])
-
+    extras = ["uic"]
     try:
         import sip
-        Qt.QtCompat.wrapInstance = (
-            lambda ptr, base=None: _wrapinstance(
-                sip.wrapinstance, ptr, base)
-        )
-        Qt.QtCompat.getCppPointer = lambda object: \
-            sip.unwrapinstance(object)
-
+        extras.append(sip.__name__)
     except ImportError:
-        pass  # Optional
+        sip = None
+
+    _setup(module, extras)
+    if hasattr(Qt, "_sip"):
+        Qt.QtCompat.wrapInstance = _wrapinstance
+        Qt.QtCompat.getCppPointer = _getcpppointer
+        Qt.QtCompat.delete = sip.delete
 
     if hasattr(Qt, "_uic"):
         Qt.QtCompat.loadUi = _loadUi
@@ -944,6 +1532,9 @@ def _pyqt4():
     if hasattr(Qt, "_QtGui"):
         setattr(Qt, "QtWidgets", _new_module("QtWidgets"))
         setattr(Qt, "_QtWidgets", Qt._QtGui)
+        if hasattr(Qt._QtGui, "QX11Info"):
+            setattr(Qt, "QtX11Extras", _new_module("QtX11Extras"))
+            Qt.QtX11Extras.QX11Info = Qt._QtGui.QX11Info
 
         Qt.QtCompat.setSectionResizeMode = \
             Qt._QtGui.QHeaderView.setResizeMode
@@ -952,18 +1543,32 @@ def _pyqt4():
         Qt.__binding_version__ = Qt._QtCore.PYQT_VERSION_STR
         Qt.__qt_version__ = Qt._QtCore.QT_VERSION_STR
 
-        QCoreApplication = Qt._QtCore.QCoreApplication
-        Qt.QtCompat.translate = (
-            lambda context, sourceText, disambiguation, n:
-            QCoreApplication.translate(
-                context,
-                sourceText,
-                disambiguation,
-                QCoreApplication.CodecForTr,
-                n)
-        )
+    _reassign_misplaced_members("PyQt4")
 
-    _reassign_misplaced_members("pyqt4")
+    # QFileDialog QtCompat decorator
+    def _standardizeQFileDialog(some_function):
+        """Decorator that makes PyQt4 return conform to other bindings"""
+        def wrapper(*args, **kwargs):
+            ret = (some_function(*args, **kwargs))
+
+            # PyQt4 only returns the selected filename, force it to a
+            # standard return of the selected filename, and a empty string
+            # for the selected filter
+            return ret, ''
+
+        wrapper.__doc__ = some_function.__doc__
+        wrapper.__name__ = some_function.__name__
+
+        return wrapper
+
+    decorators = {
+        "QFileDialog": {
+            "getOpenFileName": _standardizeQFileDialog,
+            "getOpenFileNames": _standardizeQFileDialog,
+            "getSaveFileName": _standardizeQFileDialog,
+        }
+    }
+    _build_compatibility_members('PyQt4', decorators)
 
 
 def _none():
@@ -987,108 +1592,6 @@ def _log(text):
         sys.stdout.write(text + "\n")
 
 
-def _loadUi(uifile, baseinstance=None):
-    """Dynamically load a user interface from the given `uifile`
-
-    This function calls `uic.loadUi` if using PyQt bindings,
-    else it implements a comparable binding for PySide.
-
-    Documentation:
-        http://pyqt.sourceforge.net/Docs/PyQt5/designer.html#PyQt5.uic.loadUi
-
-    Arguments:
-        uifile (str): Absolute path to Qt Designer file.
-        baseinstance (QWidget): Instantiated QWidget or subclass thereof
-
-    Return:
-        baseinstance if `baseinstance` is not `None`. Otherwise
-        return the newly created instance of the user interface.
-
-    """
-    if hasattr(baseinstance, "layout") and baseinstance.layout():
-        message = ("QLayout: Attempting to add Layout to %s which "
-                   "already has a layout")
-        raise RuntimeError(message % (baseinstance))
-
-    if hasattr(Qt, "_uic"):
-        return Qt._uic.loadUi(uifile, baseinstance)
-
-    elif hasattr(Qt, "_QtUiTools"):
-        # Implement `PyQt5.uic.loadUi` for PySide(2)
-
-        class _UiLoader(Qt._QtUiTools.QUiLoader):
-            """Create the user interface in a base instance.
-
-            Unlike `Qt._QtUiTools.QUiLoader` itself this class does not
-            create a new instance of the top-level widget, but creates the user
-            interface in an existing instance of the top-level class if needed.
-
-            This mimics the behaviour of `PyQt5.uic.loadUi`.
-
-            """
-
-            def __init__(self, baseinstance):
-                super(_UiLoader, self).__init__(baseinstance)
-                self.baseinstance = baseinstance
-
-            def load(self, uifile, *args, **kwargs):
-                from xml.etree.ElementTree import ElementTree
-
-                # For whatever reason, if this doesn't happen then
-                # reading an invalid or non-existing .ui file throws
-                # a RuntimeError.
-                etree = ElementTree()
-                etree.parse(uifile)
-
-                widget = Qt._QtUiTools.QUiLoader.load(
-                    self, uifile, *args, **kwargs)
-
-                # Workaround for PySide 1.0.9, see issue #208
-                widget.parentWidget()
-
-                return widget
-
-            def createWidget(self, class_name, parent=None, name=""):
-                """Called for each widget defined in ui file
-
-                Overridden here to populate `baseinstance` instead.
-
-                """
-
-                if parent is None and self.baseinstance:
-                    # Supposed to create the top-level widget,
-                    # return the base instance instead
-                    return self.baseinstance
-
-                # For some reason, Line is not in the list of available
-                # widgets, but works fine, so we have to special case it here.
-                if class_name in self.availableWidgets() + ["Line"]:
-                    # Create a new widget for child widgets
-                    widget = Qt._QtUiTools.QUiLoader.createWidget(self,
-                                                                  class_name,
-                                                                  parent,
-                                                                  name)
-
-                else:
-                    raise Exception("Custom widget '%s' not supported"
-                                    % class_name)
-
-                if self.baseinstance:
-                    # Set an attribute for the new child widget on the base
-                    # instance, just like PyQt5.uic.loadUi does.
-                    setattr(self.baseinstance, name, widget)
-
-                return widget
-
-        widget = _UiLoader(baseinstance).load(uifile)
-        Qt.QtCore.QMetaObject.connectSlotsByName(widget)
-
-        return widget
-
-    else:
-        raise NotImplementedError("No implementation available for loadUi")
-
-
 def _convert(lines):
     """Convert compiled .ui file from PySide2 to Qt.py
 
@@ -1105,6 +1608,11 @@ def _convert(lines):
         line = line.replace("from PySide2 import", "from Qt import QtCompat,")
         line = line.replace("QtWidgets.QApplication.translate",
                             "QtCompat.translate")
+        if "QtCore.SIGNAL" in line:
+            raise NotImplementedError("QtCore.SIGNAL is missing from PyQt5 "
+                                      "and so Qt.py does not support it: you "
+                                      "should avoid defining signals inside "
+                                      "your ui files.")
         return line
 
     parsed = list()
@@ -1236,8 +1744,12 @@ def _install():
 
             setattr(our_submodule, member, their_member)
 
+    # Enable direct import of QtCompat
+    sys.modules['Qt.QtCompat'] = Qt.QtCompat
+
     # Backwards compatibility
-    Qt.QtCompat.load_ui = Qt.QtCompat.loadUi
+    if hasattr(Qt.QtCompat, 'loadUi'):
+        Qt.QtCompat.load_ui = Qt.QtCompat.loadUi
 
 
 _install()


### PR DESCRIPTION
### Problem

After installing `PySide2` in my Avalon environment, when I try to open Avalon Loader from the Launcher action, it gave me this error :
```python
AttributeError: module 'PySide2.QtGui' has no attribute 'QStringListModel'
```

### Solution

Updating vendorized `Qt.py` to the latest version (`1.2.0.b3`) solved this.

---

In Gitter
:point_up: [March 21, 2019 3:33 PM](https://gitter.im/getavalon/Lobby?at=5c933e389d9cc8114af7031b)