### PR TITLE
Only pop warning when module path not found

### DIFF
--- a/avalon/lib.py
+++ b/avalon/lib.py
@@ -243,7 +243,9 @@ def modules_from_path(path):
 
     path = os.path.normpath(path)
 
-    assert os.path.isdir(path), "%s is not a directory" % path
+    if not os.path.isdir(path):
+        log_.warning("%s is not a directory" % path)
+        return []
 
     modules = []
     for fname in os.listdir(path):


### PR DESCRIPTION
### Problem

I have some loader plugins that is only for me to diagnose the pipeline health or testing, like printing representation ID.
But those plugins are in a place that only I can have access, which will raise error to others when the Avalon is registering plugin path that could not be found.

### Solution

Instead of raising error, just pop up warning.

