### PR TITLE
Loader GUI subset grouping

### DIFF
--- a/avalon/inventory.py
+++ b/avalon/inventory.py
@@ -326,6 +326,7 @@ def _save_config_1_0(project_name, data):
     config["tasks"] = data.get("tasks", [])
     config["template"].update(data.get("template", {}))
     config["families"] = data.get("families", [])
+    config["groups"] = data.get("groups", [])
 
     schema.validate(document)
 

--- a/avalon/schema/config-1.0.json
+++ b/avalon/schema/config-1.0.json
@@ -65,6 +65,19 @@
                 "required": ["name"]
             }
         },
+        "groups": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "icon": {"type": "string"},
+                    "color": {"type": "string"},
+                    "order": {"type": ["integer", "number"]}
+                },
+                "required": ["name"]
+            }
+        },
         "copy": {
             "type": "object"
         }

--- a/avalon/tests/test_inventory.py
+++ b/avalon/tests/test_inventory.py
@@ -137,6 +137,14 @@ def test_save():
         "families": [
             {"name": "avalon.model", "label": "Model", "icon": "cube"}
         ],
+        "groups": [
+            {
+                "name": "charCaches",
+                "icon": "diamond",
+                "color": "#C4CEDC",
+                "order": -99
+            },
+        ],
         "copy": {}
     }
 

--- a/avalon/tools/cbloader/app.py
+++ b/avalon/tools/cbloader/app.py
@@ -184,8 +184,8 @@ class Window(QtWidgets.QDialog):
         subsets_model.set_asset(document['_id'])
 
         # Enforce the columns to fit the data (purely cosmetic)
-        rows = subsets_model.rowCount(QtCore.QModelIndex())
-        for i in range(rows):
+        columns = subsets_model.columnCount(QtCore.QModelIndex())
+        for i in range(columns):
             subsets.view.resizeColumnToContents(i)
 
         # Clear the version information on asset change

--- a/avalon/tools/cbloader/app.py
+++ b/avalon/tools/cbloader/app.py
@@ -342,6 +342,8 @@ class SubsetGroupingDialog(QtWidgets.QDialog):
         layout.addWidget(group_btn)
 
         group_btn.clicked.connect(self.on_group)
+        group_btn.setAutoDefault(True)
+        group_btn.setDefault(True)
 
         self.name = name
         self.name_menu = name_menu

--- a/avalon/tools/cbloader/app.py
+++ b/avalon/tools/cbloader/app.py
@@ -183,11 +183,6 @@ class Window(QtWidgets.QDialog):
         document = asset_item.data(DocumentRole)
         subsets_model.set_asset(document['_id'])
 
-        # Enforce the columns to fit the data (purely cosmetic)
-        columns = subsets_model.columnCount(QtCore.QModelIndex())
-        for i in range(columns):
-            subsets.view.resizeColumnToContents(i)
-
         # Clear the version information on asset change
         self.data['model']['version'].set_version(None)
 

--- a/avalon/tools/cbloader/app.py
+++ b/avalon/tools/cbloader/app.py
@@ -198,10 +198,8 @@ class Window(QtWidgets.QDialog):
             rows = selection.selectedRows(column=active.column())
             if active in rows:
                 node = active.data(subsets.model.NodeRole)
-                if node.get("isGroup"):
-                    return
-
-                version = node['version_document']['_id']
+                if not node.get("isGroup"):
+                    version = node['version_document']['_id']
 
         self.data['model']['version'].set_version(version)
 

--- a/avalon/tools/cbloader/app.py
+++ b/avalon/tools/cbloader/app.py
@@ -204,7 +204,7 @@ class Window(QtWidgets.QDialog):
             rows = selection.selectedRows(column=active.column())
             if active in rows:
                 node = active.data(subsets.model.NodeRole)
-                if not node.get("isGroup"):
+                if node is not None and not node.get("isGroup"):
                     version = node['version_document']['_id']
 
         self.data['model']['version'].set_version(version)

--- a/avalon/tools/cbloader/app.py
+++ b/avalon/tools/cbloader/app.py
@@ -312,6 +312,7 @@ class SubsetGroupingDialog(QtWidgets.QDialog):
     def __init__(self, items, parent=None):
         super(SubsetGroupingDialog, self).__init__(parent=parent)
         self.setWindowTitle("Grouping Subsets")
+        self.setMinimumWidth(250)
         self.setModal(True)
 
         self.items = items
@@ -319,6 +320,7 @@ class SubsetGroupingDialog(QtWidgets.QDialog):
         self.asset_id = parent.data["state"]["context"]["assetId"]
 
         name = QtWidgets.QLineEdit()
+        name.setPlaceholderText("Remain blank to ungroup..")
 
         # Menu for pre-defined subset groups
         name_button = QtWidgets.QPushButton()

--- a/avalon/tools/cbloader/app.py
+++ b/avalon/tools/cbloader/app.py
@@ -281,17 +281,17 @@ class Window(QtWidgets.QDialog):
         print("Good bye")
         return super(Window, self).closeEvent(event)
 
-    def keyReleaseEvent(self, event):
+    def keyPressEvent(self, event):
         modifiers = event.modifiers()
         ctrl_pressed = QtCore.Qt.ControlModifier & modifiers
 
-        # Grouping subsets on releasing Ctrl + G
+        # Grouping subsets on pressing Ctrl + G
         if (ctrl_pressed and event.key() == QtCore.Qt.Key_G and
                 not event.isAutoRepeat()):
             self.show_grouping_dialog()
-            event.accept()
+            return
 
-        return super(Window, self).keyReleaseEvent(event)
+        return super(Window, self).keyPressEvent(event)
 
     def show_grouping_dialog(self):
         subsets = self.data["model"]["subsets"]

--- a/avalon/tools/cbloader/app.py
+++ b/avalon/tools/cbloader/app.py
@@ -198,6 +198,9 @@ class Window(QtWidgets.QDialog):
             rows = selection.selectedRows(column=active.column())
             if active in rows:
                 node = active.data(subsets.model.NodeRole)
+                if node.get("isGroup"):
+                    return
+
                 version = node['version_document']['_id']
 
         self.data['model']['version'].set_version(version)

--- a/avalon/tools/cbloader/app.py
+++ b/avalon/tools/cbloader/app.py
@@ -270,6 +270,18 @@ class Window(QtWidgets.QDialog):
         print("Good bye")
         return super(Window, self).closeEvent(event)
 
+    def keyReleaseEvent(self, event):
+        modifiers = event.modifiers()
+        ctrl_pressed = QtCore.Qt.ControlModifier & modifiers
+
+        # Grouping subsets on releasing Ctrl + G
+        if (ctrl_pressed and event.key() == QtCore.Qt.Key_G and
+                not event.isAutoRepeat()):
+            print("GROUP...")
+            event.accept()
+
+        return super(Window, self).keyReleaseEvent(event)
+
 
 def show(debug=False, parent=None, use_context=False):
     """Display Loader GUI

--- a/avalon/tools/cbloader/app.py
+++ b/avalon/tools/cbloader/app.py
@@ -7,7 +7,7 @@ from ...vendor.Qt import QtWidgets, QtCore
 from ... import api, io, style
 from .. import lib
 
-from .lib import refresh_family_config
+from .lib import refresh_family_config, refresh_group_config
 from .widgets import SubsetWidget, VersionWidget, FamilyListWidget
 
 module = sys.modules[__name__]
@@ -105,6 +105,7 @@ class Window(QtWidgets.QDialog):
         subsets.version_changed.connect(self.on_versionschanged)
 
         refresh_family_config()
+        refresh_group_config()
 
         # Defaults
         self.resize(1330, 700)

--- a/avalon/tools/cbloader/app.py
+++ b/avalon/tools/cbloader/app.py
@@ -290,6 +290,10 @@ class Window(QtWidgets.QDialog):
 
     def show_grouping_dialog(self):
         subsets = self.data["model"]["subsets"]
+        if not subsets.is_groupable():
+            self.echo("Grouping not enabled.")
+            return
+
         selected = subsets.selected_subsets()
         if not selected:
             self.echo("No selected subset.")

--- a/avalon/tools/cbloader/delegates.py
+++ b/avalon/tools/cbloader/delegates.py
@@ -120,6 +120,10 @@ class VersionDelegate(QtWidgets.QStyledItemDelegate):
         return self._format_version(value)
 
     def createEditor(self, parent, option, index):
+        node = index.data(SubsetsModel.NodeRole)
+        if node.get("isGroup"):
+            return
+
         editor = QtWidgets.QComboBox(parent)
 
         def commit_data():

--- a/avalon/tools/cbloader/lib.py
+++ b/avalon/tools/cbloader/lib.py
@@ -115,7 +115,7 @@ def refresh_group_config():
     return groups
 
 
-def get_active_group_config(asset_id):
+def get_active_group_config(asset_id, include_predefined=False):
     """Collect all active groups from each subset
     """
     predefineds = GROUP_CONFIG.copy()
@@ -131,8 +131,13 @@ def get_active_group_config(asset_id):
     # Collect groups from subsets
     active_groups = list()
 
-    for group_name in set(io.distinct("data.subsetGroup",
-                                      {"type": "subset", "parent": asset_id})):
+    existed = set(io.distinct("data.subsetGroup",
+                              {"type": "subset", "parent": asset_id}))
+    if include_predefined:
+        # Ensure all predefined group configs will be included
+        existed.update(predefineds.keys())
+
+    for group_name in existed:
         # Get group config
         config = predefineds.get(group_name, default_group_config)
         # Calculate order

--- a/avalon/tools/cbloader/lib.py
+++ b/avalon/tools/cbloader/lib.py
@@ -1,4 +1,4 @@
-from ...vendor import qtawesome
+from ...vendor import qtawesome, Qt
 from ... import io, api, style
 
 FAMILY_ICON_COLOR = "#0091B2"
@@ -10,6 +10,16 @@ def get(config, name):
     """Get value from config with fallback to default"""
     # We assume the default fallback key in the config is `__default__`
     return config.get(name, config.get("__default__", None))
+
+
+def is_filtering_recursible():
+    """Does Qt binding support recursive filtering for QSortFilterProxyModel ?
+
+    (NOTE) Recursive filtering was introduced in Qt 5.10.
+
+    """
+    return hasattr(Qt.QtCore.QSortFilterProxyModel,
+                   "setRecursiveFilteringEnabled")
 
 
 def refresh_family_config():

--- a/avalon/tools/cbloader/model.py
+++ b/avalon/tools/cbloader/model.py
@@ -109,14 +109,14 @@ class SubsetsModel(TreeModel):
                                "parent": self._asset_id}):
 
             last_version = io.find_one({"type": "version",
-                                        "parent": subset['_id']},
+                                        "parent": subset["_id"]},
                                        sort=[("name", -1)])
             if not last_version:
                 # No published version for the subset
                 continue
 
             data = subset.copy()
-            data['subset'] = data['name']
+            data["subset"] = data["name"]
 
             node = Node()
             node.update(data)
@@ -146,7 +146,7 @@ class SubsetsModel(TreeModel):
 
             # Add icon to subset column
             if index.column() == 0:
-                return self._icons['subset']
+                return self._icons["subset"]
 
             # Add icon to family column
             if index.column() == 1:

--- a/avalon/tools/cbloader/model.py
+++ b/avalon/tools/cbloader/model.py
@@ -21,15 +21,21 @@ class SubsetsModel(TreeModel):
                "handles",
                "step"]
 
+    SortRole = QtCore.Qt.UserRole + 2
+
     def __init__(self, parent=None):
         super(SubsetsModel, self).__init__(parent=parent)
         self._asset_id = None
+        self._sorter = None
         self._icons = {"subset": qta.icon("fa.file-o",
                                           color=style.colors.default),
                        "group": qta.icon("fa.object-group",
                                          color=style.colors.default),
                        "grouped": qta.icon("fa.file",
                                            color=style.colors.default)}
+
+    def set_sorter(self, sorter):
+        self._sorter = sorter
 
     def set_asset(self, asset_id):
         self._asset_id = asset_id
@@ -189,6 +195,18 @@ class SubsetsModel(TreeModel):
             if index.column() == 1:
                 node = index.internalPointer()
                 return node.get("familyIcon", None)
+
+        if role == self.SortRole:
+            node = index.internalPointer()
+            order = self._sorter.sortOrder()
+            column = self.COLUMNS[self._sorter.sortColumn()]
+            # This would make group items always be on top
+            if node.get("isGroup"):
+                prefix = "1" if order else "0"
+            else:
+                prefix = "0" if order else "1"
+
+            return prefix + str(node.get(column))
 
         return super(SubsetsModel, self).data(index, role)
 

--- a/avalon/tools/cbloader/model.py
+++ b/avalon/tools/cbloader/model.py
@@ -272,6 +272,10 @@ class FamiliesFilterProxyModel(QtCore.QSortFilterProxyModel):
 
         # Get the node data and validate
         node = model.data(index, TreeModel.NodeRole)
+
+        if node.get("isGroup"):
+            return False
+
         family = node.get("family", None)
 
         if not family:

--- a/avalon/tools/cbloader/model.py
+++ b/avalon/tools/cbloader/model.py
@@ -244,9 +244,9 @@ class GroupMemberFilterProxyModel(QtCore.QSortFilterProxyModel):
         # Patch future function
         setRecursiveFilteringEnabled = (lambda *args: None)
 
-        def _is_group_acceptable(self, index, node):
+        def _is_group_acceptable(self, index, model):
             # (NOTE) This is not recursive.
-            for child_row in range(node["childRow"]):
+            for child_row in range(model.rowCount(index)):
                 if self.filterAcceptsRow(child_row, index):
                     return True
             return False
@@ -267,7 +267,7 @@ class SubsetFilterProxyModel(GroupMemberFilterProxyModel):
                             parent)
         node = index.internalPointer()
         if node.get("isGroup"):
-            return self.filter_accepts_group(index, node)
+            return self.filter_accepts_group(index, model)
         else:
             return super(SubsetFilterProxyModel,
                          self).filterAcceptsRow(row, parent)
@@ -305,7 +305,7 @@ class FamiliesFilterProxyModel(GroupMemberFilterProxyModel):
         node = model.data(index, TreeModel.NodeRole)
 
         if node.get("isGroup"):
-            return self.filter_accepts_group(index, node)
+            return self.filter_accepts_group(index, model)
 
         family = node.get("family", None)
 

--- a/avalon/tools/cbloader/model.py
+++ b/avalon/tools/cbloader/model.py
@@ -22,7 +22,7 @@ class SubsetsModel(TreeModel):
                "step"]
 
     SortAscendingRole = QtCore.Qt.UserRole + 2
-    sortDescendingRole = QtCore.Qt.UserRole + 3
+    SortDescendingRole = QtCore.Qt.UserRole + 3
 
     def __init__(self, grouping=True, parent=None):
         super(SubsetsModel, self).__init__(parent=parent)
@@ -196,7 +196,7 @@ class SubsetsModel(TreeModel):
                 node = index.internalPointer()
                 return node.get("familyIcon", None)
 
-        if role == self.sortDescendingRole:
+        if role == self.SortDescendingRole:
             node = index.internalPointer()
             if node.get("isGroup"):
                 # Ensure groups be on top when sorting by descending order
@@ -329,6 +329,6 @@ class FamiliesFilterProxyModel(GroupMemberFilterProxyModel):
         if order == QtCore.Qt.AscendingOrder:
             self.setSortRole(model.SortAscendingRole)
         else:
-            self.setSortRole(model.sortDescendingRole)
+            self.setSortRole(model.SortDescendingRole)
 
         super(FamiliesFilterProxyModel, self).sort(column, order)

--- a/avalon/tools/cbloader/model.py
+++ b/avalon/tools/cbloader/model.py
@@ -24,15 +24,20 @@ class SubsetsModel(TreeModel):
     SortAscendingRole = QtCore.Qt.UserRole + 2
     sortDescendingRole = QtCore.Qt.UserRole + 3
 
-    def __init__(self, parent=None):
+    def __init__(self, grouping=True, parent=None):
         super(SubsetsModel, self).__init__(parent=parent)
         self._asset_id = None
         self._sorter = None
+        self._grouping = grouping
         self._icons = {"subset": qta.icon("fa.file-o",
                                           color=style.colors.default)}
 
     def set_asset(self, asset_id):
         self._asset_id = asset_id
+        self.refresh()
+
+    def set_grouping(self, state):
+        self._grouping = state
         self.refresh()
 
     def setData(self, index, value, role=QtCore.Qt.EditRole):
@@ -114,14 +119,16 @@ class SubsetsModel(TreeModel):
 
         # Generate subset group nodes
         group_nodes = dict()
-        for data in active_groups:
-            name = data.pop("name")
-            group = Node()
-            group.update({"subset": name, "isGroup": True, "childRow": 0})
-            group.update(data)
 
-            group_nodes[name] = group
-            self.add_child(group)
+        if self._grouping:
+            for data in active_groups:
+                name = data.pop("name")
+                group = Node()
+                group.update({"subset": name, "isGroup": True, "childRow": 0})
+                group.update(data)
+
+                group_nodes[name] = group
+                self.add_child(group)
 
         filter = {"type": "subset", "parent": asset_id}
 
@@ -140,7 +147,7 @@ class SubsetsModel(TreeModel):
             data["subset"] = data["name"]
 
             group_name = subset["data"].get("subsetGroup")
-            if group_name:
+            if self._grouping and group_name:
                 group = group_nodes[group_name]
                 parent = group
                 parent_index = self.createIndex(0, 0, group)

--- a/avalon/tools/cbloader/model.py
+++ b/avalon/tools/cbloader/model.py
@@ -220,6 +220,23 @@ class SubsetsModel(TreeModel):
         return flags
 
 
+class SubsetFilterProxyModel(QtCore.QSortFilterProxyModel):
+
+    def filterAcceptsRow(self, row, parent):
+
+        model = self.sourceModel()
+        index = model.index(row,
+                            self.filterKeyColumn(),
+                            parent)
+        node = index.internalPointer()
+        if node.get("isGroup"):
+            # Keep group in view
+            return True
+        else:
+            return super(SubsetFilterProxyModel,
+                         self).filterAcceptsRow(row, parent)
+
+
 class FamiliesFilterProxyModel(QtCore.QSortFilterProxyModel):
     """Filters to specified families"""
 

--- a/avalon/tools/cbloader/widgets.py
+++ b/avalon/tools/cbloader/widgets.py
@@ -101,11 +101,15 @@ class SubsetWidget(QtWidgets.QWidget):
         if not point_index.isValid():
             return
 
+        node = point_index.data(self.model.NodeRole)
+        if node.get("isGroup"):
+            return
+
         # Get all representation->loader combinations available for the
         # index under the cursor, so we can list the user the options.
         available_loaders = api.discover(api.Loader)
         loaders = list()
-        node = point_index.data(self.model.NodeRole)
+
         version_id = node['version_document']['_id']
         representations = io.find({"type": "representation",
                                    "parent": version_id})
@@ -190,6 +194,9 @@ class SubsetWidget(QtWidgets.QWidget):
         # Trigger
         for row in rows:
             node = row.data(self.model.NodeRole)
+            if node.get("isGroup"):
+                continue
+
             version_id = node["version_document"]["_id"]
             representation = io.find_one({"type": "representation",
                                           "name": representation_name,

--- a/avalon/tools/cbloader/widgets.py
+++ b/avalon/tools/cbloader/widgets.py
@@ -82,9 +82,6 @@ class SubsetWidget(QtWidgets.QWidget):
         self.proxy.setDynamicSortFilter(True)
         self.proxy.setFilterCaseSensitivity(QtCore.Qt.CaseInsensitive)
 
-        self.proxy.setRecursiveFilteringEnabled(True)
-        self.family_proxy.setRecursiveFilteringEnabled(True)
-
         self.view.setModel(self.family_proxy)
         self.view.customContextMenuRequested.connect(self.on_context_menu)
 

--- a/avalon/tools/cbloader/widgets.py
+++ b/avalon/tools/cbloader/widgets.py
@@ -85,6 +85,10 @@ class SubsetWidget(QtWidgets.QWidget):
         self.view.setModel(self.family_proxy)
         self.view.customContextMenuRequested.connect(self.on_context_menu)
 
+        header = self.view.header()
+        # Enforce the columns to fit the data (purely cosmetic)
+        header.setSectionResizeMode(QtWidgets.QHeaderView.ResizeToContents)
+
         selection = view.selectionModel()
         selection.selectionChanged.connect(self.active_changed)
 

--- a/avalon/tools/cbloader/widgets.py
+++ b/avalon/tools/cbloader/widgets.py
@@ -95,6 +95,7 @@ class SubsetWidget(QtWidgets.QWidget):
         version_delegate.version_changed.connect(self.version_changed)
 
         self.filter.textChanged.connect(self.proxy.setFilterRegExp)
+        self.filter.textChanged.connect(self.view.expandAll)
 
         self.model.refresh()
 

--- a/avalon/tools/cbloader/widgets.py
+++ b/avalon/tools/cbloader/widgets.py
@@ -92,8 +92,6 @@ class SubsetWidget(QtWidgets.QWidget):
 
         self.filter.textChanged.connect(self.proxy.setFilterRegExp)
 
-        self.family_proxy.setSortRole(self.model.SortRole)
-        self.model.set_sorter(self.family_proxy)
         self.model.refresh()
 
         # Expose this from the widget as a method

--- a/avalon/tools/cbloader/widgets.py
+++ b/avalon/tools/cbloader/widgets.py
@@ -8,7 +8,11 @@ from ... import io
 from ... import api
 from ... import pipeline
 
-from .model import SubsetsModel, FamiliesFilterProxyModel
+from .model import (
+    SubsetsModel,
+    SubsetFilterProxyModel,
+    FamiliesFilterProxyModel,
+)
 from .delegates import PrettyTimeDelegate, VersionDelegate
 from . import lib
 
@@ -23,7 +27,7 @@ class SubsetWidget(QtWidgets.QWidget):
         super(SubsetWidget, self).__init__(parent=parent)
 
         model = SubsetsModel()
-        proxy = QtCore.QSortFilterProxyModel()
+        proxy = SubsetFilterProxyModel()
         family_proxy = FamiliesFilterProxyModel()
         family_proxy.setSourceModel(proxy)
 

--- a/avalon/tools/cbloader/widgets.py
+++ b/avalon/tools/cbloader/widgets.py
@@ -31,7 +31,7 @@ class SubsetWidget(QtWidgets.QWidget):
         filter.setPlaceholderText("Filter subsets..")
 
         view = QtWidgets.QTreeView()
-        view.setIndentation(5)
+        view.setIndentation(20)
         view.setStyleSheet("""
             QTreeView::item{
                 padding: 5px 1px;

--- a/avalon/tools/cbloader/widgets.py
+++ b/avalon/tools/cbloader/widgets.py
@@ -216,6 +216,39 @@ class SubsetWidget(QtWidgets.QWidget):
                 self.echo(exc)
                 continue
 
+    def selected_subsets(self):
+        selection = self.view.selectionModel()
+        rows = selection.selectedRows(column=0)
+
+        subsets = list()
+        for row in rows:
+            node = row.data(self.model.NodeRole)
+            if not node.get("isGroup"):
+                subsets.append(node)
+
+        return subsets
+
+    def group_subsets(self, name, asset_id, nodes):
+        field = "data.subsetGroup"
+
+        if name:
+            update = {"$set": {field: name}}
+            self.echo("Group subsets to '%s'.." % name)
+        else:
+            update = {"$unset": {field: ""}}
+            self.echo("Ungroup subsets..")
+
+        subsets = list()
+        for node in nodes:
+            subsets.append(node["subset"])
+
+        filter = {
+            "type": "subset",
+            "parent": asset_id,
+            "name": {"$in": subsets},
+        }
+        io.update_many(filter, update)
+
     def echo(self, message):
         print(message)
 

--- a/avalon/tools/cbloader/widgets.py
+++ b/avalon/tools/cbloader/widgets.py
@@ -88,6 +88,8 @@ class SubsetWidget(QtWidgets.QWidget):
 
         self.filter.textChanged.connect(self.proxy.setFilterRegExp)
 
+        self.family_proxy.setSortRole(self.model.SortRole)
+        self.model.set_sorter(self.family_proxy)
         self.model.refresh()
 
         # Expose this from the widget as a method

--- a/avalon/tools/cbloader/widgets.py
+++ b/avalon/tools/cbloader/widgets.py
@@ -82,6 +82,9 @@ class SubsetWidget(QtWidgets.QWidget):
         self.proxy.setDynamicSortFilter(True)
         self.proxy.setFilterCaseSensitivity(QtCore.Qt.CaseInsensitive)
 
+        self.proxy.setRecursiveFilteringEnabled(True)
+        self.family_proxy.setRecursiveFilteringEnabled(True)
+
         self.view.setModel(self.family_proxy)
         self.view.customContextMenuRequested.connect(self.on_context_menu)
 


### PR DESCRIPTION
### Feature - Visually grouping subsets in Loader GUI

![loader-subset](https://user-images.githubusercontent.com/3357009/59367533-e0444400-8d6e-11e9-871f-3f342e4a52e2.gif)

This grouping feature is on subset level, and the group name is from the subset document's `data.subsetGroup` field.
So to trigger subset grouping, you need to inject `subsetGroup` entry to the subset document data during publish. Or maybe another little tool for it ?

Welcome to give any inputs :)

### Update

See comment [below](https://github.com/getavalon/core/pull/391#issuecomment-501718754)
