### PR TITLE
Remove silo create tab from Loader and Context Manager GUI

### DIFF
--- a/avalon/tools/cbloader/app.py
+++ b/avalon/tools/cbloader/app.py
@@ -37,7 +37,7 @@ class Window(QtWidgets.QDialog):
 
         container = QtWidgets.QWidget()
 
-        assets = AssetWidget()
+        assets = AssetWidget(silo_creatable=False)
         families = FamilyListWidget()
         subsets = SubsetWidget()
         version = VersionWidget()

--- a/avalon/tools/contextmanager/app.py
+++ b/avalon/tools/contextmanager/app.py
@@ -33,7 +33,7 @@ class App(QtWidgets.QDialog):
         accept_btn = QtWidgets.QPushButton("Accept")
 
         # Asset picker
-        assets = AssetWidget()
+        assets = AssetWidget(silo_creatable=False)
 
         # Task picker
         tasks_widgets = QtWidgets.QWidget()

--- a/avalon/tools/projectmanager/widget.py
+++ b/avalon/tools/projectmanager/widget.py
@@ -318,8 +318,9 @@ class SiloTabWidget(QtWidgets.QTabBar):
     silo_changed = QtCore.Signal(str)
     silo_added = QtCore.Signal(str)
 
-    def __init__(self, parent=None):
+    def __init__(self, silo_creatable=True, parent=None):
         super(SiloTabWidget, self).__init__(parent=parent)
+        self.silo_creatable = silo_creatable
         self._previous_tab_index = -1
         self.set_silos([])
 
@@ -338,7 +339,7 @@ class SiloTabWidget(QtWidgets.QTabBar):
 
         # If it's the last tab
         num = self.count()
-        if index == num - 1:
+        if self.silo_creatable and index == num - 1:
             self.on_add_silo()
             self.setCurrentIndex(self._previous_tab_index)
             return
@@ -358,7 +359,7 @@ class SiloTabWidget(QtWidgets.QTabBar):
         for i in range(self.count()):
             self.removeTab(0)
 
-    def set_silos(self, silos, creatable=True):
+    def set_silos(self, silos):
 
         current_silo = self.get_current_silo()
 
@@ -372,7 +373,7 @@ class SiloTabWidget(QtWidgets.QTabBar):
         for silo in sorted(silos):
             self.addTab(silo)
 
-        if creatable:
+        if self.silo_creatable:
             # Add the "+" tab
             self.addTab("+")
 
@@ -472,7 +473,7 @@ class AssetWidget(QtWidgets.QWidget):
         # Header
         header = QtWidgets.QHBoxLayout()
 
-        silo = SiloTabWidget()
+        silo = SiloTabWidget(silo_creatable=silo_creatable)
 
         icon = awesome.icon("fa.refresh", color=style.colors.light)
         refresh = QtWidgets.QPushButton(icon, "")
@@ -506,7 +507,6 @@ class AssetWidget(QtWidgets.QWidget):
         silo.silo_changed.connect(self._on_silo_changed)
         refresh.clicked.connect(self.refresh)
 
-        self.silo_creatable = silo_creatable
         self.refreshButton = refresh
         self.silo = silo
         self.model = model
@@ -537,7 +537,7 @@ class AssetWidget(QtWidgets.QWidget):
     def refresh(self):
 
         silos = _list_project_silos()
-        self.silo.set_silos(silos, self.silo_creatable)
+        self.silo.set_silos(silos)
 
         self._refresh_model()
 

--- a/avalon/tools/projectmanager/widget.py
+++ b/avalon/tools/projectmanager/widget.py
@@ -358,7 +358,7 @@ class SiloTabWidget(QtWidgets.QTabBar):
         for i in range(self.count()):
             self.removeTab(0)
 
-    def set_silos(self, silos):
+    def set_silos(self, silos, creatable=True):
 
         current_silo = self.get_current_silo()
 
@@ -372,8 +372,9 @@ class SiloTabWidget(QtWidgets.QTabBar):
         for silo in sorted(silos):
             self.addTab(silo)
 
-        # Add the "+" tab
-        self.addTab("+")
+        if creatable:
+            # Add the "+" tab
+            self.addTab("+")
 
         self.set_current_silo(current_silo)
         self.blockSignals(False)
@@ -460,7 +461,7 @@ class AssetWidget(QtWidgets.QWidget):
     selection_changed = QtCore.Signal()  # on view selection change
     current_changed = QtCore.Signal()    # on view current index change
 
-    def __init__(self, parent=None):
+    def __init__(self, silo_creatable=True, parent=None):
         super(AssetWidget, self).__init__(parent=parent)
         self.setContentsMargins(0, 0, 0, 0)
 
@@ -505,6 +506,7 @@ class AssetWidget(QtWidgets.QWidget):
         silo.silo_changed.connect(self._on_silo_changed)
         refresh.clicked.connect(self.refresh)
 
+        self.silo_creatable = silo_creatable
         self.refreshButton = refresh
         self.silo = silo
         self.model = model
@@ -535,7 +537,7 @@ class AssetWidget(QtWidgets.QWidget):
     def refresh(self):
 
         silos = _list_project_silos()
-        self.silo.set_silos(silos)
+        self.silo.set_silos(silos, self.silo_creatable)
 
         self._refresh_model()
 


### PR DESCRIPTION
Remove the `+` tab which will pop-up a silo create dialog even you are in the GUI that was not meant to create silo.

![image](https://user-images.githubusercontent.com/3357009/59371246-108fe080-8d77-11e9-8838-c48a48945912.png)
