### PR TITLE
Fix #399: Maya 2019+ hide containers in outliner

### DIFF
--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -406,6 +406,16 @@ def containerise(name,
 
     cmds.sets(container, addElement=main_container)
 
+    # Implement #399: Maya 2019+ hide containers in outliner
+    if cmds.attributeQuery("hiddenInOutliner",
+                           node=container,
+                           exists=True):
+        cmds.setAttr(container + ".hiddenInOutliner", True)
+    if cmds.attributeQuery("hiddenInOutliner",
+                           node=main_container,
+                           exists=True):
+        cmds.setAttr(main_container + ".hiddenInOutliner", True)
+
     return container
 
 

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -401,6 +401,12 @@ def containerise(name,
     main_container = cmds.ls(AVALON_CONTAINERS, type="objectSet")
     if not main_container:
         main_container = cmds.sets(empty=True, name=AVALON_CONTAINERS)
+
+        # Implement #399: Maya 2019+ hide AVALON_CONTAINERS on creation..
+        if cmds.attributeQuery("hiddenInOutliner",
+                               node=main_container,
+                               exists=True):
+            cmds.setAttr(main_container + ".hiddenInOutliner", True)
     else:
         main_container = main_container[0]
 
@@ -411,10 +417,6 @@ def containerise(name,
                            node=container,
                            exists=True):
         cmds.setAttr(container + ".hiddenInOutliner", True)
-    if cmds.attributeQuery("hiddenInOutliner",
-                           node=main_container,
-                           exists=True):
-        cmds.setAttr(main_container + ".hiddenInOutliner", True)
 
     return container
 


### PR DESCRIPTION
This implements #399 - simple as that.

- Backwards compatible, it first checks whether the attribute exists.
- Will only set the value on newly created containers/sets.