### PR TITLE
Workfiles save: Allow enter key to accept the save.

### DIFF
--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -77,6 +77,10 @@ class NameWindow(QtWidgets.QDialog):
         # Allow "Enter" key to accept the save.
         self.ok_button.setDefault(True)
 
+        # Force default focus to comment, some hosts didn't automatically
+        # apply focus to this line edit (e.g. Houdini)
+        self.comment_lineedit.setFocus()
+
         self.refresh()
 
     def on_version_spinbox_changed(self, value):

--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -74,6 +74,9 @@ class NameWindow(QtWidgets.QDialog):
         self.ok_button.pressed.connect(self.on_ok_pressed)
         self.cancel_button.pressed.connect(self.on_cancel_pressed)
 
+        # Allow "Enter" key to accept the save.
+        self.ok_button.setDefault(True)
+
         self.refresh()
 
     def on_version_spinbox_changed(self, value):


### PR DESCRIPTION
You can now accept file save by hitting Enter in the Workfiles app.

---

Based on request by @davidlatwe [here](https://github.com/getavalon/core/issues/401#issuecomment-510115040):

> Accept file save by hitting Enter, currently you need to press Ok button to save file.