### PR TITLE
Fix asset task view

### DIFF
--- a/avalon/tools/contextmanager/__init__.py
+++ b/avalon/tools/contextmanager/__init__.py
@@ -1,3 +1,3 @@
-from app import show
+from .app import show
 
 __all__ = ["show"]

--- a/avalon/tools/projectmanager/model.py
+++ b/avalon/tools/projectmanager/model.py
@@ -191,8 +191,7 @@ class TasksModel(TreeModel):
         super(TasksModel, self).__init__()
         self._num_assets = 0
         self._icons = {
-            "__default__": awesome.icon("fa.folder-o",
-                                        color=style.colors.default)
+            "__default__": awesome.icon("fa.male", color=style.colors.default)
         }
 
         self._get_task_icons()

--- a/avalon/tools/projectmanager/model.py
+++ b/avalon/tools/projectmanager/model.py
@@ -228,13 +228,6 @@ class TasksModel(TreeModel):
             asset_tasks = asset.get("data", {}).get("tasks", [])
             tasks.update(asset_tasks)
 
-        # If no asset tasks are defined, use the project tasks.
-        if assets and not tasks:
-            project = io.find_one({"type": "project"})
-            tasks.update(
-                [task["name"] for task in project["config"].get("tasks", [])]
-            )
-
         self.clear()
         self.beginResetModel()
 


### PR DESCRIPTION
As discussed on [Gitter](https://gitter.im/getavalon/Lobby?at=5d3aafd2f3e76e13270c5326) this shows only the tasks that were specifically assigned to an asset in the Project Manager.

I also included 2 other (small) things:
- Make the `app` import of the Context Manager relative. Now it also import properly in Python 3.7
- Change the default task icon of the Project Manager to `fa.male`. This is to make it consistent with Avalon Launcher. If people prefer the `folder-o` then maybe we should change the Launcher.