### PR TITLE
fix #406: Unified attributes names

### DIFF
--- a/avalon/inventory.py
+++ b/avalon/inventory.py
@@ -80,13 +80,13 @@ DEFAULTS = {
         "film": [
             {
                 "name": "shot1",
-                "edit_in": 1000,
-                "edit_out": 1143
+                "frameStart": 1000,
+                "frameEnd": 1143
             },
             {
                 "name": "shot2",
-                "edit_in": 1000,
-                "edit_out": 1081
+                "frameStart": 1000,
+                "frameEnd": 1081
             },
         ]
     }

--- a/avalon/maya/commands.py
+++ b/avalon/maya/commands.py
@@ -21,10 +21,12 @@ def reset_frame_range():
 
         frame_start = shot["data"].get(
             "frameStart",
+            # backwards compatibility
             shot["data"].get("edit_in")
         )
         frame_end = shot["data"].get(
             "frameEnd",
+            # backwards compatibility
             shot["data"].get("edit_out")
         )
     except KeyError:
@@ -59,16 +61,14 @@ def reset_resolution():
 
     try:
         resolution_width = project["data"].get(
-            "resolutionWidth", project["data"].get(
-                "resolution_width",
-                1920
-            )
+            "resolutionWidth",
+            # backwards compatibility
+            project["data"].get("resolution_width", 1920)
         )
         resolution_height = project["data"].get(
-            "resolutionHeight", project["data"].get(
-                "resolution_height",
-                1080
-            )
+            "resolutionHeight",
+            # backwards compatibility
+            project["data"].get("resolution_height", 1080)
         )
     except KeyError:
         cmds.warning("No resolution information found for %s"

--- a/avalon/maya/commands.py
+++ b/avalon/maya/commands.py
@@ -53,8 +53,18 @@ def reset_resolution():
     project = io.find_one({"type": "project"})
 
     try:
-        resolution_width = project["data"].get("resolution_width", 1920)
-        resolution_height = project["data"].get("resolution_height", 1080)
+        resolution_width = project["data"].get(
+            "resolutionWidth", project["data"].get(
+                "resolution_width",
+                1920
+            )
+        )
+        resolution_height = project["data"].get(
+            "resolutionHeight", project["data"].get(
+                "resolution_height",
+                1080
+            )
+        )
     except KeyError:
         cmds.warning("No resolution information found for %s"
                      % project["name"])

--- a/avalon/maya/commands.py
+++ b/avalon/maya/commands.py
@@ -17,9 +17,11 @@ def reset_frame_range():
     shot = api.Session["AVALON_ASSET"]
     shot = io.find_one({"name": shot, "type": "asset"})
 
+    shot_data = shot["data"]
     try:
-        edit_in = shot["data"]["edit_in"]
-        edit_out = shot["data"]["edit_out"]
+
+        frame_start = shot["data"].get("frameStart", shot["data"]["edit_in"])
+        frame_end = shot["data"].get("frameEnd", shot["data"]["edit_out"])
     except KeyError:
         cmds.warning("No edit information found for %s" % shot["name"])
         return
@@ -38,13 +40,13 @@ def reset_frame_range():
 
     cmds.currentUnit(time=fps)
 
-    cmds.playbackOptions(minTime=edit_in)
-    cmds.playbackOptions(maxTime=edit_out)
-    cmds.playbackOptions(animationStartTime=edit_in)
-    cmds.playbackOptions(animationEndTime=edit_out)
-    cmds.playbackOptions(minTime=edit_in)
-    cmds.playbackOptions(maxTime=edit_out)
-    cmds.currentTime(edit_in)
+    cmds.playbackOptions(minTime=frame_start)
+    cmds.playbackOptions(maxTime=frame_end)
+    cmds.playbackOptions(animationStartTime=frame_start)
+    cmds.playbackOptions(animationEndTime=frame_end)
+    cmds.playbackOptions(minTime=frame_start)
+    cmds.playbackOptions(maxTime=frame_end)
+    cmds.currentTime(frame_start)
 
 
 def reset_resolution():

--- a/avalon/maya/commands.py
+++ b/avalon/maya/commands.py
@@ -19,8 +19,14 @@ def reset_frame_range():
 
     try:
 
-        frame_start = shot["data"].get("frameStart", shot["data"]["edit_in"])
-        frame_end = shot["data"].get("frameEnd", shot["data"]["edit_out"])
+        frame_start = shot["data"].get(
+            "frameStart",
+            shot["data"].get("edit_in")
+        )
+        frame_end = shot["data"].get(
+            "frameEnd",
+            shot["data"].get("edit_out")
+        )
     except KeyError:
         cmds.warning("No edit information found for %s" % shot["name"])
         return

--- a/avalon/maya/commands.py
+++ b/avalon/maya/commands.py
@@ -17,7 +17,6 @@ def reset_frame_range():
     shot = api.Session["AVALON_ASSET"]
     shot = io.find_one({"name": shot, "type": "asset"})
 
-    shot_data = shot["data"]
     try:
 
         frame_start = shot["data"].get("frameStart", shot["data"]["edit_in"])

--- a/avalon/schema/subset-2.0.json
+++ b/avalon/schema/subset-2.0.json
@@ -43,8 +43,8 @@
             "type": "object",
             "description": "Document metadata",
             "example": {
-                "startFrame": 1000,
-                "endFrame": 1201
+                "frameStart": 1000,
+                "frameEnd": 1201
             }
         }
     }

--- a/avalon/tools/cbloader/model.py
+++ b/avalon/tools/cbloader/model.py
@@ -72,16 +72,17 @@ class SubsetsModel(TreeModel):
         version_data = version.get("data", dict())
 
         # Compute frame ranges (if data is present)
-        start = version_data.get("startFrame", None)
-        end = version_data.get("endFrame", None)
         handles = version_data.get("handles", None)
-        if start is not None and end is not None:
+        frame_start = version_data.get("frameStart", None)
+        frame_end = version_data.get("frameEnd", None)
+
+        if frame_start is not None and frame_end is not None:
             # Remove superfluous zeros from numbers (3.0 -> 3) to improve
             # readability for most frame ranges
-            start_clean = ('%f' % start).rstrip('0').rstrip('.')
-            end_clean = ('%f' % end).rstrip('0').rstrip('.')
+            start_clean = ('%f' % frame_start).rstrip('0').rstrip('.')
+            end_clean = ('%f' % frame_end).rstrip('0').rstrip('.')
             frames = "{0}-{1}".format(start_clean, end_clean)
-            duration = end - start + 1
+            duration = frame_end - frame_start + 1
         else:
             frames = None
             duration = None
@@ -99,8 +100,8 @@ class SubsetsModel(TreeModel):
             "familyLabel": family_config.get("label", family),
             "familyIcon": family_config.get('icon', None),
             "families": set(families),
-            "startFrame": start,
-            "endFrame": end,
+            "frameStart": frame_start,
+            "frameEnd": frame_end,
             "duration": duration,
             "handles": handles,
             "frames": frames,

--- a/avalon/tools/cbloader/model.py
+++ b/avalon/tools/cbloader/model.py
@@ -74,10 +74,12 @@ class SubsetsModel(TreeModel):
         # Compute frame ranges (if data is present)
         frame_start = version_data.get(
             "frameStart",
+            # backwards compatibility
             version_data.get("startFrame", None)
         )
         frame_end = version_data.get(
             "frameEnd",
+            # backwards compatibility
             version_data.get("endFrame", None)
         )
 

--- a/avalon/tools/cbloader/model.py
+++ b/avalon/tools/cbloader/model.py
@@ -72,9 +72,15 @@ class SubsetsModel(TreeModel):
         version_data = version.get("data", dict())
 
         # Compute frame ranges (if data is present)
-        handles = version_data.get("handles", None)
         frame_start = version_data.get("frameStart", None)
         frame_end = version_data.get("frameEnd", None)
+
+        handle_start = version_data.get("handleStart", None)
+        handle_end = version_data.get("handleEnd", None)
+        if handle_start is not None and handle_end is not None:
+            handles = "{}-{}".format(str(handle_start), str(handle_end))
+        else:
+            handles = version_data.get("handles", None)
 
         if frame_start is not None and frame_end is not None:
             # Remove superfluous zeros from numbers (3.0 -> 3) to improve

--- a/avalon/tools/cbloader/model.py
+++ b/avalon/tools/cbloader/model.py
@@ -72,8 +72,14 @@ class SubsetsModel(TreeModel):
         version_data = version.get("data", dict())
 
         # Compute frame ranges (if data is present)
-        frame_start = version_data.get("frameStart", None)
-        frame_end = version_data.get("frameEnd", None)
+        frame_start = version_data.get(
+            "frameStart",
+            version_data.get("startFrame", None)
+        )
+        frame_end = version_data.get(
+            "frameEnd",
+            version_data.get("endFrame", None)
+        )
 
         handle_start = version_data.get("handleStart", None)
         handle_end = version_data.get("handleEnd", None)


### PR DESCRIPTION
Changed attribute naming:
- `edit_in`, `startFrame` changed to `frameStart`
- `edit_out`, `endFrame` changed to `frameEnd`
- `resolution_width` changed to `resolutionWidth`
- `resolution_height` changed to `resolutionHeight`
- `handles` can be stored as `handleStart` and `handleEnd`
___
Reference issue: #406 

Everything should stay backwards compatible