### PR TITLE
Add note about API and additions to it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,3 +120,12 @@ As a user of Avalon, if there is something you find in any contained submodule t
 With this in mind, exposed members should be kept to a minimal and be appropriately general. Remember, once something is added to an API, there is no going back. Clients can expect members of an API to work forever and not break their code.
 
 Because Avalon and Avalon's API is both written in Python, it can sometimes be difficult to separate between what is an API, and what is internal, but think of it this way; you couldn't import the C++ files that make Qt, or DLLs that make OpenGL. Only the interface is accessible to you, that's what enables these frameworks to evolve and improve, without breaking code that depend on it.
+
+**Examples**
+
+| Bad | Good
+|:-----|:--------
+| `api.asset_or_shot_data(document)` | `api.data()`
+| `api.open_file_from_last_week()` | `api.open_file(fname)`
+| `api.install_with_delay()` | `api.install()`
+| `api.log_welcome_message()` | `api.log_message("welcome")`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,3 +98,25 @@ Less obvious, but equally important guidelines for high-level code quality.
 - **Good**: https://github.com/getavalon/core/pull/400, minimal, clear goal
 - **Bad**: https://github.com/getavalon/core/pull/413, no motivation, no goal
 - **Good**: https://github.com/getavalon/core/pull/403, minimal, clear goal
+
+<br>
+
+### API
+
+Avalon is a framework, akin to PyQt, flask or OpenGL. Code is exposed to clients via `avalon.api` and supported integrations, such as `avalon.maya`. Access to any other module, including `avalon.io`, `avalon.maya.lib` and `avalon.tools.*` are *discouraged* as they are implementation details to these public APIs. Use at your own risk.
+
+As a user of Avalon, if there is something you find in any contained submodule that *isn't* exposed via the API, here's what you do.
+
+1. [Ask for it](https://gitter.im/getavalon/Lobby) to be exposed, odds are there is already something in there to achieve the goal you seek
+2. [Submit an issue](#feature-request), clarifying what and why you want something exposed, taking into consideration the below rules.
+
+**Rules**
+
+- `api.py` and host-APIs are *additive*, meaning nothing is ever removed.
+- Members `api.py` and host-APIs are guaranteed to remain stable and unchanged *forever*, with two exceptions.
+	1. Avalon is incremented from X.0 to Y.0, as per [semantic versioning](https://semver.org)
+	2. Excruciating circumstances compels a breaking change to be made, for example someone's life is at stake
+
+With this in mind, exposed members should be kept to a minimal and be appropriately general. Remember, once something is added to an API, there is no going back. Clients can expect members of an API to work forever and not break their code.
+
+Because Avalon and Avalon's API is both written in Python, it can sometimes be difficult to separate between what is an API, and what is internal, but think of it this way; you couldn't import the C++ files that make Qt, or DLLs that make OpenGL. Only the interface is accessible to you, that's what enables these frameworks to evolve and improve, without breaking code that depend on it.


### PR DESCRIPTION
Added a section on how to make improvements to the Avalon API, and the importance of not exposing overly-specific members.