### PR TITLE
Remerge app.py

### DIFF
--- a/avalon/tools/loader/app.py
+++ b/avalon/tools/loader/app.py
@@ -1,13 +1,21 @@
 import sys
 import time
 
-from ..projectmanager.widget import AssetWidget, AssetModel
+from ..projectmanager.widget import (
+    AssetWidget,
+    AssetModel,
+    preserve_selection,
+)
 
 from ...vendor.Qt import QtWidgets, QtCore
 from ... import api, io, style
 from .. import lib
 
-from .lib import refresh_family_config, refresh_group_config
+from .lib import (
+    refresh_family_config,
+    refresh_group_config,
+    get_active_group_config,
+)
 from .widgets import SubsetWidget, VersionWidget, FamilyListWidget
 
 module = sys.modules[__name__]
@@ -57,6 +65,10 @@ class Window(QtWidgets.QDialog):
         split.addWidget(subsets)
         split.addWidget(version)
         split.setSizes([180, 950, 200])
+
+        # Remove QSplitter border
+        split.setStyleSheet("QSplitter { border: 0px; }")
+
         container_layout.addWidget(split)
 
         body_layout = QtWidgets.QHBoxLayout(body)
@@ -91,6 +103,7 @@ class Window(QtWidgets.QDialog):
                     "root": None,
                     "project": None,
                     "asset": None,
+                    "assetId": None,
                     "silo": None,
                     "subset": None,
                     "version": None,
@@ -171,15 +184,11 @@ class Window(QtWidgets.QDialog):
         document = asset_item.data(DocumentRole)
         subsets_model.set_asset(document['_id'])
 
-        # Enforce the columns to fit the data (purely cosmetic)
-        rows = subsets_model.rowCount(QtCore.QModelIndex())
-        for i in range(rows):
-            subsets.view.resizeColumnToContents(i)
-
         # Clear the version information on asset change
         self.data['model']['version'].set_version(None)
 
         self.data["state"]["context"]["asset"] = document["name"]
+        self.data["state"]["context"]["assetId"] = document["_id"]
         self.data["state"]["context"]["silo"] = document["silo"]
         self.echo("Duration: %.3fs" % (time.time() - t1))
 
@@ -196,7 +205,8 @@ class Window(QtWidgets.QDialog):
             rows = selection.selectedRows(column=active.column())
             if active in rows:
                 node = active.data(subsets.model.NodeRole)
-                version = node['version_document']['_id']
+                if node is not None and not node.get("isGroup"):
+                    version = node['version_document']['_id']
 
         self.data['model']['version'].set_version(version)
 
@@ -266,6 +276,114 @@ class Window(QtWidgets.QDialog):
 
         print("Good bye")
         return super(Window, self).closeEvent(event)
+
+    def keyPressEvent(self, event):
+        modifiers = event.modifiers()
+        ctrl_pressed = QtCore.Qt.ControlModifier & modifiers
+
+        # Grouping subsets on pressing Ctrl + G
+        if (ctrl_pressed and event.key() == QtCore.Qt.Key_G and
+                not event.isAutoRepeat()):
+            self.show_grouping_dialog()
+            return
+
+        return super(Window, self).keyPressEvent(event)
+
+    def show_grouping_dialog(self):
+        subsets = self.data["model"]["subsets"]
+        if not subsets.is_groupable():
+            self.echo("Grouping not enabled.")
+            return
+
+        selected = subsets.selected_subsets()
+        if not selected:
+            self.echo("No selected subset.")
+            return
+
+        dialog = SubsetGroupingDialog(items=selected, parent=self)
+        dialog.grouped.connect(self._assetschanged)
+        dialog.show()
+
+
+class SubsetGroupingDialog(QtWidgets.QDialog):
+
+    grouped = QtCore.Signal()
+
+    def __init__(self, items, parent=None):
+        super(SubsetGroupingDialog, self).__init__(parent=parent)
+        self.setWindowTitle("Grouping Subsets")
+        self.setMinimumWidth(250)
+        self.setModal(True)
+
+        self.items = items
+        self.subsets = parent.data["model"]["subsets"]
+        self.asset_id = parent.data["state"]["context"]["assetId"]
+
+        name = QtWidgets.QLineEdit()
+        name.setPlaceholderText("Remain blank to ungroup..")
+
+        # Menu for pre-defined subset groups
+        name_button = QtWidgets.QPushButton()
+        name_button.setFixedWidth(18)
+        name_button.setFixedHeight(20)
+        name_menu = QtWidgets.QMenu(name_button)
+        name_button.setMenu(name_menu)
+
+        name_layout = QtWidgets.QHBoxLayout()
+        name_layout.addWidget(name)
+        name_layout.addWidget(name_button)
+        name_layout.setContentsMargins(0, 0, 0, 0)
+
+        group_btn = QtWidgets.QPushButton("Apply")
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(QtWidgets.QLabel("Group Name"))
+        layout.addLayout(name_layout)
+        layout.addWidget(group_btn)
+
+        group_btn.clicked.connect(self.on_group)
+        group_btn.setAutoDefault(True)
+        group_btn.setDefault(True)
+
+        self.name = name
+        self.name_menu = name_menu
+
+        self._build_menu()
+
+    def _build_menu(self):
+        menu = self.name_menu
+        button = menu.parent()
+        # Get and destroy the action group
+        group = button.findChild(QtWidgets.QActionGroup)
+        if group:
+            group.deleteLater()
+
+        active_groups = get_active_group_config(self.asset_id,
+                                                include_predefined=True)
+        # Build new action group
+        group = QtWidgets.QActionGroup(button)
+        for data in sorted(active_groups, key=lambda x: x["order"]):
+            name = data["name"]
+            icon = data["icon"]
+
+            action = group.addAction(name)
+            action.setIcon(icon)
+            menu.addAction(action)
+
+        group.triggered.connect(self._on_action_clicked)
+        button.setEnabled(not menu.isEmpty())
+
+    def _on_action_clicked(self, action):
+        self.name.setText(action.text())
+
+    def on_group(self):
+        name = self.name.text().strip()
+        self.subsets.group_subsets(name, self.asset_id, self.items)
+
+        with preserve_selection(tree_view=self.subsets.view,
+                                current_index=False):
+            self.grouped.emit()
+            self.close()
 
 
 def show(debug=False, parent=None, use_context=False):

--- a/avalon/tools/loader/widgets.py
+++ b/avalon/tools/loader/widgets.py
@@ -2,7 +2,7 @@ import datetime
 import pprint
 import inspect
 
-from ...vendor.Qt import QtWidgets, QtCore
+from ...vendor.Qt import QtWidgets, QtCore, QtCompat
 from ...vendor import qtawesome
 from ... import io
 from ... import api
@@ -99,7 +99,8 @@ class SubsetWidget(QtWidgets.QWidget):
 
         header = self.view.header()
         # Enforce the columns to fit the data (purely cosmetic)
-        header.setSectionResizeMode(QtWidgets.QHeaderView.ResizeToContents)
+        QtCompat.setSectionResizeMode(
+            header, QtWidgets.QHeaderView.ResizeToContents)
 
         selection = view.selectionModel()
         selection.selectionChanged.connect(self.active_changed)


### PR DESCRIPTION
#388 mistakenly merged the wrong `app.py` for the new loader. See https://github.com/getavalon/core/pull/426#issuecomment-523377949

@davidlatwe At first glance, this appears to be working, however the style doesn't appear to work, and I'm not sure why? :S

**Before**

![image](https://user-images.githubusercontent.com/2152766/63423140-911c2e80-c403-11e9-888d-87d320ca81d2.png)

**After**

![image](https://user-images.githubusercontent.com/2152766/63423107-81044f00-c403-11e9-96df-5e9f31f20884.png)
