### PR TITLE
Fix #350, specify JSON schema draft version

### DIFF
--- a/avalon/schema/application-1.0.json
+++ b/avalon/schema/application-1.0.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
 
     "title": "avalon-core:application-1.0",
     "description": "An application definition.",

--- a/avalon/schema/asset-1.0.json
+++ b/avalon/schema/asset-1.0.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
 
     "title": "avalon-core:asset-1.0",
     "description": "A unit of data",

--- a/avalon/schema/asset-2.0.json
+++ b/avalon/schema/asset-2.0.json
@@ -20,13 +20,13 @@
         "schema": {
             "description": "Schema identifier for payload",
             "type": "string",
-            "const": "avalon-core:asset-2.0",
+            "enum": ["avalon-core:asset-2.0"],
             "example": "avalon-core:asset-2.0"
         },
         "type": {
             "description": "The type of document",
             "type": "string",
-            "const": "asset",
+            "enum": ["asset"],
             "example": "asset"
         },
         "parent": {

--- a/avalon/schema/asset-2.0.json
+++ b/avalon/schema/asset-2.0.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
 
     "title": "avalon-core:asset-2.0",
     "description": "A unit of data",

--- a/avalon/schema/config-1.0.json
+++ b/avalon/schema/config-1.0.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
 
     "title": "avalon-core:config-1.0",
     "description": "A project configuration.",

--- a/avalon/schema/container-1.0.json
+++ b/avalon/schema/container-1.0.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
 
     "title": "avalon-core:container-1.0",
     "description": "A loaded asset",

--- a/avalon/schema/container-1.0.json
+++ b/avalon/schema/container-1.0.json
@@ -28,7 +28,7 @@
         "id": {
             "description": "Identifier for finding object in host",
             "type": "string",
-            "const": "pyblish.mindbender.container",
+            "enum": ["pyblish.mindbender.container"],
             "example": "pyblish.mindbender.container"
         },
         "objectName": {

--- a/avalon/schema/container-2.0.json
+++ b/avalon/schema/container-2.0.json
@@ -21,13 +21,13 @@
         "schema": {
             "description": "Schema identifier for payload",
             "type": "string",
-            "const": "avalon-core:container-2.0",
+            "enum": ["avalon-core:container-2.0"],
             "example": "avalon-core:container-2.0"
         },
           "id": {
             "description": "Identifier for finding object in host",
             "type": "string",
-            "const": "pyblish.avalon.container",
+            "enum": ["pyblish.avalon.container"],
             "example": "pyblish.avalon.container"
         },
         "objectName": {

--- a/avalon/schema/container-2.0.json
+++ b/avalon/schema/container-2.0.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
 
     "title": "avalon-core:container-2.0",
     "description": "A loaded asset",

--- a/avalon/schema/inventory-1.0.json
+++ b/avalon/schema/inventory-1.0.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
 
     "title": "avalon-core:config-1.0",
     "description": "A project configuration.",

--- a/avalon/schema/project-2.0.json
+++ b/avalon/schema/project-2.0.json
@@ -20,13 +20,13 @@
         "schema": {
             "description": "Schema identifier for payload",
             "type": "string",
-            "const": "avalon-core:project-2.0",
+            "enum": ["avalon-core:project-2.0"],
             "example": "avalon-core:project-2.0"
         },
         "type": {
             "description": "The type of document",
             "type": "string",
-            "const": "project",
+            "enum": ["project"],
             "example": "project"
         },
         "parent": {

--- a/avalon/schema/project-2.0.json
+++ b/avalon/schema/project-2.0.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
 
     "title": "avalon-core:project-2.0",
     "description": "A unit of data",

--- a/avalon/schema/representation-1.0.json
+++ b/avalon/schema/representation-1.0.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
 
     "title": "avalon-core:representation-1.0",
     "description": "The inverse of an instance",

--- a/avalon/schema/representation-2.0.json
+++ b/avalon/schema/representation-2.0.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
 
     "title": "avalon-core:representation-2.0",
     "description": "The inverse of an instance",

--- a/avalon/schema/representation-2.0.json
+++ b/avalon/schema/representation-2.0.json
@@ -20,13 +20,13 @@
         "schema": {
             "description": "Schema identifier for payload",
             "type": "string",
-            "const": "avalon-core:representation-2.0",
+            "enum": ["avalon-core:representation-2.0"],
             "example": "avalon-core:representation-2.0"
         },
         "type": {
             "description": "The type of document",
             "type": "string",
-            "const": "representation",
+            "enum": ["representation"],
             "example": "representation"
         },
         "parent": {

--- a/avalon/schema/session-1.0.json
+++ b/avalon/schema/session-1.0.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
 
     "title": "avalon-core:session-1.0",
     "description": "The Avalon environment",

--- a/avalon/schema/shaders-1.0.json
+++ b/avalon/schema/shaders-1.0.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
 
     "title": "avalon-core:shaders-1.0",
     "description": "Relationships between shaders and Avalon IDs",

--- a/avalon/schema/subset-1.0.json
+++ b/avalon/schema/subset-1.0.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
 
     "title": "avalon-core:subset-1.0",
     "description": "A container of instances",

--- a/avalon/schema/subset-2.0.json
+++ b/avalon/schema/subset-2.0.json
@@ -20,13 +20,13 @@
         "schema": {
             "description": "The schema associated with this document",
             "type": "string",
-            "const": "avalon-core:subset-2.0",
+            "enum": ["avalon-core:subset-2.0"],
             "example": "avalon-core:subset-2.0"
         },
         "type": {
             "description": "The type of document",
             "type": "string",
-            "const": "subset",
+            "enum": ["subset"],
             "example": "subset"
         },
         "parent": {

--- a/avalon/schema/subset-2.0.json
+++ b/avalon/schema/subset-2.0.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
 
     "title": "avalon-core:subset-2.0",
     "description": "A container of instances",

--- a/avalon/schema/version-1.0.json
+++ b/avalon/schema/version-1.0.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
 
     "title": "avalon-core:version-1.0",
     "description": "An individual version",

--- a/avalon/schema/version-2.0.json
+++ b/avalon/schema/version-2.0.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
 
     "title": "avalon-core:version-2.0",
     "description": "An individual version",

--- a/avalon/schema/version-2.0.json
+++ b/avalon/schema/version-2.0.json
@@ -20,13 +20,13 @@
         "schema": {
             "description": "The schema associated with this document",
             "type": "string",
-            "const": "avalon-core:version-2.0",
+            "enum": ["avalon-core:version-2.0"],
             "example": "avalon-core:version-2.0"
         },
         "type": {
             "description": "The type of document",
             "type": "string",
-            "const": "version",
+            "enum": ["version"],
             "example": "version"
         },
         "parent": {


### PR DESCRIPTION
### Changes

* Specifying our schema draft version to version 4, because the module `jsonschema` we vendorized was only supported up to version 4.

* Change keyword `const` to `enum`, because `const` was introduced in JSON schema Draft 6.

You may see #350 for detail :)