### PR TITLE
Fix #411, change io.save to io.replace_one

### DIFF
--- a/avalon/inventory.py
+++ b/avalon/inventory.py
@@ -258,7 +258,9 @@ def _save_inventory_1_0(project_name, data):
             print("Separating project metadata: %s" % key)
             metadata[key] = data.pop(key)
 
-    document = io.find_one({"type": "project"})
+    _filter = {"type": "project"}
+
+    document = io.find_one(_filter)
     if document is None:
         print("'%s' not found, creating.." % project_name)
         _id = create_project(project_name)
@@ -269,7 +271,7 @@ def _save_inventory_1_0(project_name, data):
     for key, value in metadata.items():
         document["data"][key] = value
 
-    io.save(document)
+    io.replace_one(_filter, document)
 
     print("Updating assets..")
     added = list()
@@ -277,10 +279,13 @@ def _save_inventory_1_0(project_name, data):
     missing = list()
     for silo, assets in data.items():
         for asset in assets:
-            asset_doc = io.find_one({
+
+            _filter = {
                 "name": asset["name"],
                 "type": "asset",
-            })
+            }
+
+            asset_doc = io.find_one(_filter)
 
             if asset_doc is None:
                 asset["silo"] = silo
@@ -299,7 +304,7 @@ def _save_inventory_1_0(project_name, data):
                                                         asset_doc["data"][key],
                                                         value))
 
-            io.save(asset_doc)
+            io.replace_one(_filter, asset_doc)
 
     for data in missing:
         print("+ added %s" % data["name"])
@@ -318,7 +323,9 @@ def _save_inventory_1_0(project_name, data):
 
 
 def _save_config_1_0(project_name, data):
-    document = io.find_one({"type": "project"})
+    _filter = {"type": "project"}
+
+    document = io.find_one(_filter)
 
     config = document["config"]
 
@@ -330,7 +337,7 @@ def _save_config_1_0(project_name, data):
 
     schema.validate(document)
 
-    io.save(document)
+    io.replace_one(_filter, document)
 
 
 def _report(added, updated):

--- a/avalon/io.py
+++ b/avalon/io.py
@@ -366,6 +366,7 @@ def find_one(filter, projection=None, sort=None):
 
 @auto_reconnect
 def save(*args, **kwargs):
+    """Deprecated, please use `replace_one`"""
     return self._database[Session["AVALON_PROJECT"]].save(
         *args, **kwargs)
 

--- a/avalon/tools/projectmanager/app.py
+++ b/avalon/tools/projectmanager/app.py
@@ -175,7 +175,8 @@ class Window(QtWidgets.QDialog):
         model = self.data["model"]["assets"]
         selected = model.get_selected_assets()
         for asset_id in selected:
-            asset = io.find_one({"_id": asset_id})
+            _filter = {"_id": asset_id}
+            asset = io.find_one(_filter)
             asset_tasks = asset.get("data", {}).get("tasks", [])
             for task in tasks:
                 if task not in asset_tasks:
@@ -185,7 +186,7 @@ class Window(QtWidgets.QDialog):
             asset['data']['tasks'] = asset_tasks
 
             schema.validate(asset)
-            io.save(asset)
+            io.replace_one(_filter, asset)
 
         # Refresh the tasks model
         self.on_asset_changed()


### PR DESCRIPTION
Pymongo [`collections.save()`](https://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.save) is deprecated since [version 3.0](https://api.mongodb.com/python/current/changelog.html#collection-changes). According to the document, we should change to use `insert_one` or `replace_one`.

* Changed to use `replace_one` since we use `io.save` to overwrite full document.
* Add a deprecation note in `io.save` doc string.

#411 