### PR TITLE
Fix#246 : Store and lock the "family" on a "subset"

### DIFF
--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -1294,7 +1294,11 @@ def is_compatible_loader(Loader, context):
         bool
 
     """
-    families = context["version"]["data"]["families"]
+    if context["subset"]["schema"] == "avalon-core:subset-3.0":
+        families = context["subset"]["data"]["families"]
+    else:
+        families = context["version"]["data"]["families"]
+
     representation = context["representation"]
     has_family = ("*" in Loader.families or
                   any(family in Loader.families for family in families))

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -1297,7 +1297,7 @@ def is_compatible_loader(Loader, context):
     if context["subset"]["schema"] == "avalon-core:subset-3.0":
         families = context["subset"]["data"]["families"]
     else:
-        families = context["version"]["data"]["families"]
+        families = context["version"]["data"].get("families", [])
 
     representation = context["representation"]
     has_family = ("*" in Loader.families or

--- a/avalon/schema/subset-3.0.json
+++ b/avalon/schema/subset-3.0.json
@@ -1,0 +1,62 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "avalon-core:subset-3.0",
+    "description": "A container of instances",
+
+    "type": "object",
+
+    "additionalProperties": true,
+
+    "required": [
+        "schema",
+        "type",
+        "parent",
+        "name",
+        "data"
+    ],
+
+    "properties": {
+        "schema": {
+            "description": "The schema associated with this document",
+            "type": "string",
+            "enum": ["avalon-core:subset-3.0"],
+            "example": "avalon-core:subset-3.0"
+        },
+        "type": {
+            "description": "The type of document",
+            "type": "string",
+            "enum": ["subset"],
+            "example": "subset"
+        },
+        "parent": {
+            "description": "Unique identifier to parent document",
+            "example": "592c33475f8c1b064c4d1696"
+        },
+        "name": {
+            "description": "Name of directory",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.]*$",
+            "example": "shot01"
+        },
+        "data": {
+            "description": "Document metadata",
+            "type": "object",
+            "required": ["families"],
+            "properties": {
+                "families": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "One or more families associated with this subset"
+                }
+            },
+            "example": {
+                "families" : [ 
+                    "avalon.camera"
+                ],
+                "frameStart": 1000,
+                "frameEnd": 1201
+            }
+        }
+    }
+}

--- a/avalon/schema/version-3.0.json
+++ b/avalon/schema/version-3.0.json
@@ -1,0 +1,84 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "avalon-core:version-3.0",
+    "description": "An individual version",
+
+    "type": "object",
+
+    "additionalProperties": true,
+
+    "required": [
+        "schema",
+        "type",
+        "parent",
+        "name",
+        "data"
+    ],
+
+    "properties": {
+        "schema": {
+            "description": "The schema associated with this document",
+            "type": "string",
+            "enum": ["avalon-core:version-3.0"],
+            "example": "avalon-core:version-3.0"
+        },
+        "type": {
+            "description": "The type of document",
+            "type": "string",
+            "enum": ["version"],
+            "example": "version"
+        },
+        "parent": {
+            "description": "Unique identifier to parent document",
+            "example": "592c33475f8c1b064c4d1696"
+        },
+        "name": {
+            "description": "Number of version",
+            "type": "number",
+            "example": 12
+        },
+        "locations": {
+            "description": "Where on the planet this version can be found.",
+            "type": "array",
+            "items": {"type": "string"},
+            "example": ["data.avalon.com"]
+        },
+        "data": {
+            "description": "Document metadata",
+            "type": "object",
+            "required": ["author", "source", "time"],
+            "properties": {
+                "time": {
+                    "description": "ISO formatted, file-system compatible time",
+                    "type": "string"
+                },
+                "timeFormat": {
+                    "description": "ISO format of time",
+                    "type": "string"
+                },
+                "author": {
+                    "description": "User logged on to the machine at time of publish",
+                    "type": "string"
+                },
+                "version": {
+                    "description": "Number of this version",
+                    "type": "number"
+                },
+                "path": {
+                    "description": "Unformatted path, e.g. '{root}/assets/Bruce/publish/lookdevDefault/v001",
+                    "type": "string"
+                },
+                "source": {
+                    "description": "Original file from which this version was made.",
+                    "type": "string"
+                }
+            },
+            "example": {
+                "source" : "{root}/f02_prod/assets/BubbleWitch/work/modeling/marcus/maya/scenes/model_v001.ma",
+                "author" : "marcus",
+                "time" : "20170510T090203Z" 
+            }
+        }
+    }
+}

--- a/avalon/tools/loader/model.py
+++ b/avalon/tools/loader/model.py
@@ -110,7 +110,11 @@ class SubsetsModel(TreeModel):
             frames = None
             duration = None
 
-        families = version_data.get("families", [None])
+        if item["schema"] == "avalon-core:subset-3.0":
+            families = item["data"]["families"]
+        else:
+            families = version_data.get("families", [None])
+
         family = families[0]
         family_config = lib.get_family_cached_config(family)
 

--- a/avalon/tools/sceneinventory/model.py
+++ b/avalon/tools/sceneinventory/model.py
@@ -228,7 +228,11 @@ class InventoryModel(TreeModel):
             # Get the primary family
             family = version["data"].get("family", "")
             if not family:
-                families = version["data"].get("families", [])
+                if subset["schema"] == "avalon-core:subset-3.0":
+                    families = subset["data"]["families"]
+                else:
+                    families = version["data"].get("families", [])
+
                 if families:
                     family = families[0]
 


### PR DESCRIPTION
This PR aim to resolve #246, the implementation I am proposing is to involve new schema for subset and version, so that we could have a standard to maintain backwards compatibility.

**What's changed?**
* New schema files, `subset-3.0` and `version-3.0`
* In Loader App and Scene Inventory, get `data.families` from **subset** document if the `schema` is `subset-3.0`