### PR TITLE
Implement#179

### DIFF
--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -227,6 +227,7 @@ class Window(QtWidgets.QDialog):
                 subset_name = subset_name[0].upper() + subset_name[1:]
             result.setText("{}{}".format(family, subset_name))
 
+            # Indicate subset existence
             if not subset_name:
                 subset.setStyleSheet("border-color: #3A3939;")
             elif subset_name in existed_subsets:

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -227,6 +227,13 @@ class Window(QtWidgets.QDialog):
                 subset_name = subset_name[0].upper() + subset_name[1:]
             result.setText("{}{}".format(family, subset_name))
 
+            if not subset_name:
+                subset.setStyleSheet("border-color: #3A3939;")
+            elif subset_name in existed_subsets:
+                subset.setStyleSheet("border-color: #BB6F4E;")
+            else:  # New subset
+                subset.setStyleSheet("border-color: #7AAB8F;")
+
             item.setData(ExistsRole, True)
             self.echo("Ready ..")
         else:


### PR DESCRIPTION
This PR implement #179. But instead of changing subset `QLineEdit` widget's background color, I chose to use `border-color` for better UX on text editing.

**What's changed?**
* Avalon Creator tool's UX on subset naming

#### Demo GIF
![creator](https://user-images.githubusercontent.com/3357009/64687584-5ca90900-d4bd-11e9-9c21-49689b39b523.gif)
