### PR TITLE
Optimize AssetModel refresh time

### DIFF
--- a/avalon/tools/models.py
+++ b/avalon/tools/models.py
@@ -319,13 +319,16 @@ class AssetModel(TreeModel):
     def _add_hierarchy(self, assets, parent=None):
         """Add the assets that are related to the parent as children items.
 
+        This method does *not* query the database. These instead are queried
+        in a single batch upfront as an optimization to reduce database
+        queries. Resulting in up to 10x speed increase.
+
         Args:
             assets (dict): All assets in the currently active silo stored
                 by key/value
 
-        Note: This method does *not* query the database. These instead are
-              queried in a single batch upfront as an optimization to reduce
-              database queries. Resulting in up to 10x speed increase.
+        Returns:
+            None
 
         """
 
@@ -352,11 +355,9 @@ class AssetModel(TreeModel):
             })
             self.add_child(item, parent=parent)
 
-            # Add asset's children recursively
+            # Add asset's children recursively if it has children
             if asset["_id"] in assets:
-                assets = self._add_hierarchy(assets, parent=item)
-
-        return assets
+                self._add_hierarchy(assets, parent=item)
 
     def refresh(self):
         """Refresh the data for the model."""

--- a/avalon/tools/models.py
+++ b/avalon/tools/models.py
@@ -316,11 +316,11 @@ class AssetModel(TreeModel):
         if refresh:
             self.refresh()
 
-    def _add_hierarchy(self, parent=None, assets={}):
+    def _add_hierarchy(self, parent=None, assets=None):
 
         # Find the assets under the parent
         current_assets = []
-        if parent is None:
+        if assets is None:
             db_assets = io.find({
                 "type": "asset",
                 "silo": self._silo
@@ -334,7 +334,10 @@ class AssetModel(TreeModel):
                     assets[parent_id].append(asset)
                 else:
                     current_assets.append(asset)
-        else:
+
+        if parent is not None:
+            # clean up for case that assets are None
+            current_assets = []
             if parent["_id"] in assets:
                 current_assets = assets.pop(parent["_id"])
 
@@ -347,7 +350,7 @@ class AssetModel(TreeModel):
             # store for the asset for optimization
             deprecated = "deprecated" in tags
 
-            node = Node({
+            item = Item({
                 "_id": asset["_id"],
                 "name": asset["name"],
                 "label": label,
@@ -356,11 +359,11 @@ class AssetModel(TreeModel):
                 "deprecated": deprecated,
                 "_document": asset
             })
-            self.add_child(node, parent=parent)
+            self.add_child(item, parent=parent)
 
             # Add asset's children recursively
             if asset["_id"] in assets:
-                assets = self._add_hierarchy(node, assets)
+                assets = self._add_hierarchy(item, assets)
 
         return assets
 

--- a/avalon/tools/models.py
+++ b/avalon/tools/models.py
@@ -324,7 +324,7 @@ class AssetModel(TreeModel):
             db_assets = io.find({
                 "type": "asset",
                 "silo": self._silo
-            }).sort('name', 1)
+            }).sort("name", 1)
             assets = {}
             for asset in db_assets:
                 parent_id = asset.get("data", {}).get("visualParent")
@@ -341,17 +341,17 @@ class AssetModel(TreeModel):
         for asset in current_assets:
             # get label from data, otherwise use name
             data = asset.get("data", {})
-            label = data.get("label", asset['name'])
+            label = data.get("label", asset["name"])
             tags = data.get("tags", [])
 
             # store for the asset for optimization
             deprecated = "deprecated" in tags
 
             node = Node({
-                "_id": asset['_id'],
+                "_id": asset["_id"],
                 "name": asset["name"],
                 "label": label,
-                "type": asset['type'],
+                "type": asset["type"],
                 "tags": ", ".join(tags),
                 "deprecated": deprecated,
                 "_document": asset
@@ -359,7 +359,7 @@ class AssetModel(TreeModel):
             self.add_child(node, parent=parent)
 
             # Add asset's children recursively
-            if asset['_id'] in assets:
+            if asset["_id"] in assets:
                 assets = self._add_hierarchy(node, assets)
 
         return assets


### PR DESCRIPTION
### Issue

There have been reports of the Asset Widget being slow to refresh on bigger projects. This resulted in slow launch times of the **Loader** and **Project Manager** for listing the assets.

*Where large project is defined as for example 2 seasons of 20 episodes, with each 30 shots. Resulting in 2 * 20 * 30 = 1200 assets and [there have been reports of very slow load times](https://gitter.im/getavalon/Lobby?at=5d67cd66f94e7d10a16125dd)

### What has changed?

This is an optimization of the method that builds the hierarchy in the asset widget that is much faster for large projects. The way the assets are queried is now optimized to do less queries against the database, allowing it do more caching (as it will hit the same query more often) and have less problems with any delay in the connection with the database as there are much less calls to be made.

Funnily enough, it's also much faster for small projects. Win-win. 🚀 

#### Indication of speed changes

- Tested myself: 0.2790s -> 0.0055s
- Reported by @iLLiCiTiT: 4.5s -> 0.01s
- Reported by @tokejepsen: 10x speed improvement

---

_Thanks to the team at [pypeclub](https://github.com/pypeclub) and @iLLiCiTiT to quickly separate out some commits related to the optimization._