### PR TITLE
Refactor Work Files API to not shadow built-in `open`

### DIFF
--- a/avalon/fusion/__init__.py
+++ b/avalon/fusion/__init__.py
@@ -52,3 +52,7 @@ __all__ = [
     "maintained_selection"
 
 ]
+
+# Backwards API compatibility
+open = open_file
+save = save_file

--- a/avalon/fusion/__init__.py
+++ b/avalon/fusion/__init__.py
@@ -18,8 +18,8 @@ from .pipeline import (
 )
 
 from .workio import (
-    open,
-    save,
+    open_file,
+    save_file,
     current_file,
     has_unsaved_changes,
     file_extensions,
@@ -42,8 +42,8 @@ __all__ = [
     "comp_lock_and_undo_chunk",
 
     # Workfiles API
-    "open",
-    "save",
+    "open_file",
+    "save_file",
     "current_file",
     "has_unsaved_changes",
     "file_extensions",

--- a/avalon/fusion/workio.py
+++ b/avalon/fusion/workio.py
@@ -14,14 +14,14 @@ def has_unsaved_changes():
     return comp.GetAttrs()["COMPB_Modified"]
 
 
-def save(filepath):
+def save_file(filepath):
     from avalon.fusion.pipeline import get_current_comp
 
     comp = get_current_comp()
     comp.Save(filepath)
 
 
-def open(filepath):
+def open_file(filepath):
     # Hack to get fusion, see avalon.fusion.pipeline.get_current_comp()
     fusion = getattr(sys.modules["__main__"], "fusion", None)
 

--- a/avalon/houdini/__init__.py
+++ b/avalon/houdini/__init__.py
@@ -53,3 +53,7 @@ __all__ = [
     "maintained_selection",
     "unique_name"
 ]
+
+# Backwards API compatibility
+open = open_file
+save = save_file

--- a/avalon/houdini/__init__.py
+++ b/avalon/houdini/__init__.py
@@ -10,8 +10,8 @@ from .pipeline import (
 )
 
 from .workio import (
-    open,
-    save,
+    open_file,
+    save_file,
     current_file,
     has_unsaved_changes,
     file_extensions,
@@ -38,8 +38,8 @@ __all__ = [
     "containerise",
 
     # Workfiles API
-    "open",
-    "save",
+    "open_file",
+    "save_file",
     "current_file",
     "has_unsaved_changes",
     "file_extensions",

--- a/avalon/houdini/workio.py
+++ b/avalon/houdini/workio.py
@@ -12,7 +12,7 @@ def has_unsaved_changes():
     return hou.hipFile.hasUnsavedChanges()
 
 
-def save(filepath):
+def save_file(filepath):
 
     # Force forwards slashes to avoid segfault
     filepath = filepath.replace("\\", "/")
@@ -23,7 +23,7 @@ def save(filepath):
     return filepath
 
 
-def open(filepath):
+def open_file(filepath):
 
     # Force forwards slashes to avoid segfault
     filepath = filepath.replace("\\", "/")

--- a/avalon/maya/__init__.py
+++ b/avalon/maya/__init__.py
@@ -93,3 +93,7 @@ __all__ = [
     "suspended_refresh",
 
 ]
+
+# Backwards API compatibility
+open = open_file
+save = save_file

--- a/avalon/maya/__init__.py
+++ b/avalon/maya/__init__.py
@@ -27,8 +27,8 @@ from .pipeline import (
 )
 
 from .workio import (
-    open,
-    save,
+    open_file,
+    save_file,
     current_file,
     has_unsaved_changes,
     file_extensions,
@@ -71,8 +71,8 @@ __all__ = [
     "lock_ignored",
 
     # Workfiles API
-    "open",
-    "save",
+    "open_file",
+    "save_file",
     "current_file",
     "has_unsaved_changes",
     "file_extensions",

--- a/avalon/maya/workio.py
+++ b/avalon/maya/workio.py
@@ -12,12 +12,12 @@ def has_unsaved_changes():
     return cmds.file(query=True, modified=True)
 
 
-def save(filepath):
+def save_file(filepath):
     cmds.file(rename=filepath)
     cmds.file(save=True, type="mayaAscii")
 
 
-def open(filepath):
+def open_file(filepath):
     return cmds.file(filepath, open=True, force=True)
 
 

--- a/avalon/nuke/__init__.py
+++ b/avalon/nuke/__init__.py
@@ -14,8 +14,8 @@ from .lib import (
 from .workio import (
     file_extensions,
     has_unsaved_changes,
-    save,
-    open,
+    save_file,
+    open_file,
     current_file,
     work_root,
 )
@@ -50,8 +50,8 @@ __all__ = [
 
     "file_extensions",
     "has_unsaved_changes",
-    "save",
-    "open",
+    "save_file",
+    "open_file",
     "current_file",
     "work_root",
 

--- a/avalon/nuke/__init__.py
+++ b/avalon/nuke/__init__.py
@@ -67,3 +67,7 @@ __all__ = [
     "maintained_selection",
     "get_node_path",
 ]
+
+# Backwards API compatibility
+open = open_file
+save = save_file

--- a/avalon/nuke/workio.py
+++ b/avalon/nuke/workio.py
@@ -11,7 +11,7 @@ def has_unsaved_changes():
     return nuke.root().modified()
 
 
-def save(filepath):
+def save_file(filepath):
     path = filepath.replace("\\", "/")
     nuke.scriptSaveAs(path)
     nuke.Root()["name"].setValue(path)
@@ -19,7 +19,7 @@ def save(filepath):
     nuke.Root().setModified(False)
 
 
-def open(filepath):
+def open_file(filepath):
     filepath = filepath.replace("\\", "/")
 
     # To remain in the same window, we have to clear the script and read

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -821,8 +821,8 @@ def debug_host():
 
     host.__dict__.update({
         "ls": ls,
-        "open": lambda fname: None,
-        "save": lambda fname: None,
+        "open_file": lambda fname: None,
+        "save_file": lambda fname: None,
         "current_file": lambda: os.path.expanduser("~/temp.txt"),
         "has_unsaved_changes": lambda: False,
         "work_root": lambda: os.path.expanduser("~/temp"),

--- a/avalon/tools/workfiles/README.md
+++ b/avalon/tools/workfiles/README.md
@@ -61,8 +61,8 @@ For the Work Files tool to work with a new host integration the host must
 implement the following functions:
 
 - `file_extensions()`: The files the host should allow to open and show in the Work Files view.
-- `open(filepath)`: Open a file.
-- `save(filepath)`: Save the current file. This should return None if it failed to save, and return the path if it succeeded
+- `open_file(filepath)`: Open a file.
+- `save_file(filepath)`: Save the current file. This should return None if it failed to save, and return the path if it succeeded
 - `has_unsaved_changes()`: Return whether the current scene has unsaved changes.
 - `current_file()`: The path to the current file. None if not saved.
 - `work_root()`: The path to where the work files for this app should be saved.
@@ -88,7 +88,7 @@ def has_unsaved_changes():
     """Return whether current file has unsaved modifications."""
 
 
-def save(filepath):
+def save_file(filepath):
     """Save to filepath.
     
     This should return None if it failed to save, and return the path if it 
@@ -97,7 +97,7 @@ def save(filepath):
     pass
 
 
-def open(filepath):
+def open_file(filepath):
     """Open file"""
     pass
 

--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -383,13 +383,13 @@ class Window(QtWidgets.QDialog):
 
             if result:
                 # Save current scene, continue to open file
-                host.save(host.current_file())
+                host.save_file(host.current_file())
 
             else:
                 # Don't save, continue to open file
                 pass
 
-        return host.open(filepath)
+        return host.open_file(filepath)
 
     def on_duplicate_pressed(self):
         work_file = self.get_name()
@@ -445,7 +445,7 @@ class Window(QtWidgets.QDialog):
             return
 
         file_path = os.path.join(self.root, work_file)
-        self.host.save(file_path)
+        self.host.save_file(file_path)
 
         self.close()
 

--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -458,8 +458,8 @@ def show(root=None, debug=False):
         raise RuntimeError("No registered host.")
 
     # Verify the host has implemented the api for Work Files
-    required = ["open",
-                "save",
+    required = ["open_file",
+                "save_file",
                 "current_file",
                 "has_unsaved_changes",
                 "work_root",


### PR DESCRIPTION
This resolves #407 so that the Work Files API does not shadow the built-in function `open` and refactors it to `open_file`. To keep a consistent API I've implemented the same change for `save` to `save_file`.

**What's changed?**

Update the Work Files API:
- Refactor `open()` -> `open_file()`
- Refactor `save()` -> `save_file()` to match with `open_file`.

This is updated for the implemented hosts, the Work Files tool `README` that describes the API and the work files tool itself of course.