### PR TITLE
Fix QPushButton::menu-indicator being cut off

### DIFF
--- a/avalon/style/style.qss
+++ b/avalon/style/style.qss
@@ -1064,13 +1064,16 @@ QToolButton::menu-arrow:open {
 QPushButton::menu-indicator  {
     subcontrol-origin: padding;
     subcontrol-position: right;
-    width: 7px;
-    height: 7px;
+    width: 8px;
+    height: 8px;
     padding-right: 5px;
 }
 
 QPushButton::menu-indicator:disabled {
     image: url(:/qss_icons/rc/down_arrow_disabled.png);
+    width: 9px;
+    height: 9px;
+    padding-right: 3px;
 }
 
 QTableView

--- a/avalon/style/style.qss
+++ b/avalon/style/style.qss
@@ -1064,7 +1064,6 @@ QToolButton::menu-arrow:open {
 QPushButton::menu-indicator  {
     subcontrol-origin: padding;
     subcontrol-position: bottom right;
-    left: 8px;
 }
 
 QTableView

--- a/avalon/style/style.qss
+++ b/avalon/style/style.qss
@@ -1063,7 +1063,7 @@ QToolButton::menu-arrow:open {
 
 QPushButton::menu-indicator  {
     subcontrol-origin: padding;
-    subcontrol-position: bottom right;
+    subcontrol-position: right;
 }
 
 QTableView

--- a/avalon/style/style.qss
+++ b/avalon/style/style.qss
@@ -1064,6 +1064,13 @@ QToolButton::menu-arrow:open {
 QPushButton::menu-indicator  {
     subcontrol-origin: padding;
     subcontrol-position: right;
+    width: 7px;
+    height: 7px;
+    padding-right: 5px;
+}
+
+QPushButton::menu-indicator:disabled {
+    image: url(:/qss_icons/rc/down_arrow_disabled.png);
 }
 
 QTableView

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -146,7 +146,7 @@ class Window(QtWidgets.QDialog):
 
         subset_button = QtWidgets.QPushButton()
         subset_button.setFixedWidth(18)
-        subset_button.setFixedHeight(20)
+        subset_button.setFixedHeight(24)
         subset_menu = QtWidgets.QMenu(subset_button)
         subset_button.setMenu(subset_menu)
 
@@ -155,6 +155,7 @@ class Window(QtWidgets.QDialog):
         name_layout = QtWidgets.QHBoxLayout()
         name_layout.addWidget(name)
         name_layout.addWidget(subset_button)
+        name_layout.setSpacing(3)
         name_layout.setContentsMargins(0, 0, 0, 0)
 
         layout = QtWidgets.QVBoxLayout(container)

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -146,7 +146,6 @@ class Window(QtWidgets.QDialog):
 
         subset_button = QtWidgets.QPushButton()
         subset_button.setFixedWidth(18)
-        subset_button.setFixedHeight(24)
         subset_menu = QtWidgets.QMenu(subset_button)
         subset_button.setMenu(subset_menu)
 


### PR DESCRIPTION
## Issue

The Instance Creator's subset dropdown button had it's "triangle" menu indicator cut off on the right hand side. This made it look very confusing and hard to understand. It was clearly wrong, see:

![triangle](https://user-images.githubusercontent.com/2439881/65060463-2fa29d80-d978-11e9-819b-4706acaa8b8b.png)

#### Menu Indicator cut off on right-hand side

This was due to the [`QPushButton::menu-indicator` styling in Avalon's stylesheet](https://github.com/getavalon/core/blob/c000ac5f07a8f849dd0ec0e9a9b81ff00fe521e4/avalon/style/style.qss#L1067).

This was reproducable on just a QPushButton example:
```python
# Assumes QApplication already runs
from avalon.vendor.Qt import QtWidgets
from avalon import style

box = QtWidgets.QPushButton("Test")
box.setStyleSheet(style.load_stylesheet())
menu = QtWidgets.QMenu(box)
menu.addAction("test")
box.setMenu(menu)
box.show()
```
Output:

![](https://files.gitter.im/getavalon/Lobby/mPG4/afbeelding.png)


#### Menu Indicator vertical alignment

Aside of that the vertical alignment of the triangle was also slightly odd, as it was [forced to the bottom right](https://github.com/getavalon/core/blob/c000ac5f07a8f849dd0ec0e9a9b81ff00fe521e4/avalon/style/style.qss#L1066). It's more expected to have this vertically centered on the button on the right-hand side.

Comparison: 

- Before with `bottom right`:

![](https://files.gitter.im/getavalon/Lobby/e2AX/afbeelding.png)

![](https://files.gitter.im/getavalon/Lobby/n4xO/afbeelding.png)

- After with `right`:

![](https://files.gitter.im/getavalon/Lobby/O3i2/afbeelding.png)

![](https://files.gitter.im/getavalon/Lobby/MvJD/afbeelding.png)


## What's changed?
The stylesheet is updated to not have the indicator cut off and have it vertically centered on right hand side.

---

Reference:

- [Discussion on Avalon Gitter](https://gitter.im/getavalon/Lobby?at=5d8103dea6f4896449204223)