### PR TITLE
Make the "No Task" entry clearly distinct from actual tasks by its icon

### DIFF
--- a/avalon/tools/models.py
+++ b/avalon/tools/models.py
@@ -240,10 +240,11 @@ class TasksModel(TreeModel):
         default_icon = self._icons["__default__"]
 
         if not tasks:
+            no_task_icon = self._icons["__no_task__"]
             item = Item({
                 "name": "No task",
                 "count": 0,
-                "icon": self._icons["__no_task__"],
+                "icon": no_task_icon,
                 "enabled": False,
             })
 

--- a/avalon/tools/models.py
+++ b/avalon/tools/models.py
@@ -195,7 +195,9 @@ class TasksModel(TreeModel):
         self._num_assets = 0
         self._icons = {
             "__default__": qtawesome.icon("fa.male",
-                                          color=style.colors.default)
+                                          color=style.colors.default),
+            "__no_task__": qtawesome.icon("fa.exclamation-circle",
+                                          color=style.colors.mid)
         }
 
         self._get_task_icons()
@@ -241,7 +243,7 @@ class TasksModel(TreeModel):
             item = Item({
                 "name": "No task",
                 "count": 0,
-                "icon": default_icon,
+                "icon": self._icons["__no_task__"],
                 "enabled": False,
             })
 


### PR DESCRIPTION
The "No Task" entry icon is the same default as tasks in an asset which makes it harder to distinguish on first sight than it needs to be.

**What's changed?**

The "No Task" icon is changed into `exclamation-circle` and now drawn in a greyish color to stand out from the actual tasks which are by default orange.

_Example:_

![afbeelding](https://user-images.githubusercontent.com/2439881/65162285-4a891680-da39-11e9-9281-3f7e20236cd7.png)

