### PR TITLE
Expose the "loader" column in Scene Inventory

### DIFF
--- a/avalon/tools/sceneinventory/model.py
+++ b/avalon/tools/sceneinventory/model.py
@@ -15,7 +15,7 @@ from . import lib
 class InventoryModel(TreeModel):
     """The model for the inventory"""
 
-    Columns = ["Name", "version", "count", "family", "objectName"]
+    Columns = ["Name", "version", "count", "family", "loader", "objectName"]
 
     OUTDATED_COLOR = QtGui.QColor(235, 30, 30)
     CHILD_OUTDATED_COLOR = QtGui.QColor(200, 160, 30)


### PR DESCRIPTION
This implements a fix for #454 so that it's visible to the artist which Loader is being used for specific loaded content directly within the Scene Inventory.

This implements solution option 1) as presented in the issue. It's a very minor change in code. :)

**BEFORE**

![before](https://user-images.githubusercontent.com/2439881/65243825-76fc6b80-dae9-11e9-8ec2-500dc3805662.png)

**AFTER**

![after](https://user-images.githubusercontent.com/2439881/65243665-0c4b3000-dae9-11e9-8d6b-e165c24bc31c.png)

