### PR TITLE
Optimize Maya host.ls() method

### DIFF
--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -428,6 +428,8 @@ def parse_container(container, validate=True):
 
     Args:
         container (str): A container node name.
+        validate (bool, optional): Whether to validate the container schema.
+            Defaults to True.
 
     Returns:
         dict: The container schema data for this container node.
@@ -487,12 +489,19 @@ def _ls():
             yield fn_dep.name()
 
 
-def ls():
-    """List containers from active Maya scene
+def ls(validate=True):
+    """Yields containers from active Maya scene
 
     This is the host-equivalent of api.ls(), but instead of listing
     assets on disk, it lists assets already loaded in Maya; once loaded
     they are called 'containers'
+
+    Args:
+        validate (bool, optional): Whether to validate the container schema.
+            Defaults to True.
+
+    Yields:
+        dict: container
 
     """
     container_names = _ls()
@@ -503,7 +512,7 @@ def ls():
         has_metadata_collector = True
 
     for container in sorted(container_names):
-        data = parse_container(container)
+        data = parse_container(container, validate=validate)
 
         # Collect custom data if attribute is present
         if has_metadata_collector:

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -5,6 +5,7 @@ import importlib
 import contextlib
 
 from maya import cmds, OpenMaya
+import maya.api.OpenMaya as om
 from pyblish import api as pyblish
 
 from . import lib, compat
@@ -447,12 +448,44 @@ def parse_container(container, validate=True):
 
 
 def _ls():
-    containers = list()
-    for identifier in (AVALON_CONTAINER_ID,
-                       "pyblish.mindbender.container"):
-        containers += lib.lsattr("id", identifier)
+    """Yields Avalon container node names.
 
-    return containers
+    Used by `ls()` to retrieve the nodes and then query the full container's
+    data.
+
+    Yields:
+        str: Avalon container node name (objectSet)
+
+    """
+
+    def _maya_iterate(iterator):
+        """Helper to iterate a maya iterator"""
+        while not iterator.isDone():
+            yield iterator.thisNode()
+            iterator.next()
+
+    ids = {AVALON_CONTAINER_ID,
+           # Backwards compatibility
+           "pyblish.mindbender.container"}
+
+    # Iterate over all 'set' nodes in the scene to detect whether
+    # they have the avalon container ".id" attribute.
+    fn_dep = om.MFnDependencyNode()
+    iterator = om.MItDependencyNodes(om.MFn.kSet)
+    for mobject in _maya_iterate(iterator):
+        if mobject.apiTypeStr != "kSet":
+            # Only match by exact type
+            continue
+
+        fn_dep.setObject(mobject)
+        try:
+            plug = fn_dep.findPlug("id", True)
+        except RuntimeError:
+            continue
+
+        value = plug.asString()
+        if value in ids:
+            yield fn_dep.name()
 
 
 def ls():

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -478,11 +478,10 @@ def _ls():
             continue
 
         fn_dep.setObject(mobject)
-        try:
-            plug = fn_dep.findPlug("id", True)
-        except RuntimeError:
+        if not fn_dep.hasAttribute("id"):
             continue
 
+        plug = fn_dep.findPlug("id", True)
         value = plug.asString()
         if value in ids:
             yield fn_dep.name()

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -489,16 +489,12 @@ def _ls():
             yield fn_dep.name()
 
 
-def ls(validate=True):
+def ls():
     """Yields containers from active Maya scene
 
     This is the host-equivalent of api.ls(), but instead of listing
     assets on disk, it lists assets already loaded in Maya; once loaded
     they are called 'containers'
-
-    Args:
-        validate (bool, optional): Whether to validate the container schema.
-            Defaults to True.
 
     Yields:
         dict: container
@@ -512,7 +508,7 @@ def ls(validate=True):
         has_metadata_collector = True
 
     for container in sorted(container_names):
-        data = parse_container(container, validate=validate)
+        data = parse_container(container)
 
         # Collect custom data if attribute is present
         if has_metadata_collector:


### PR DESCRIPTION
### Issue

In large scenes with many nodes the `host.ls()` query for host Maya is slower than it needs to be. I've seen cases where a single query took [3.7 seconds](https://gitter.im/getavalon/Lobby?at=5d8ce5cedeb6da63d7b0d344).

### What's changed?

The `_ls()` method that was used to just list all the relevant avalon containers in maya by node name was relatively slow in the way it queried it when used in large scenes. It previously did a full query on all nodes by an ".id" attribute whereas we should do it only over `objectSets` as those are the container nodes in the Maya pipeline. This has now been changed to using the Maya Python API 2.0 to iterate over all dependency nodes of type `maya.api.OpenMaya.MFn.kSet`

Also, it did that full iteration twice, because it also had to look up for the backwards compatibility id `pyblish.mindbender.container`.  This has now been changed to just detect whether the id value is any of the two directly as opposed to iterating the scene twice.

#### Speed comparison

As I was developing an optimized method I've built [some prototype functions](https://gist.github.com/BigRoy/d72245e5ea5ef5fd6ba275c3718c2059#file-avalon_maya_host_ls_optimizations-py) as a replacement and compared timings in smaller and big scenes. In all cases I've found that this new implementation was *much* faster.

In my large test scene the difference was huge:
```
Current: 3.75600004196
New 1: 0.605000019073
New 2: 0.0550000667572
New 3: 0.325999975204
```

The newer method being faster also confirmed in a small test scene by @tokejepsen [here](https://gitter.im/getavalon/Lobby?at=5d8ce5cedeb6da63d7b0d344):
```
Current: 0.00500011444092
New 1: 0.0019998550415
New 2: 0.000999927520752
New 3: 0.000999927520752
```

The implementation in this PR is `New 2` in those tests.

#### Fact: Containers are objectSets?

In the Maya pipeline in Avalon containers are created with the [`containerise` function](https://github.com/getavalon/core/blob/75e6681ebb410e64537e7d5630118d350316ccc8/avalon/maya/pipeline.py#L356) that is exposed in avalon core, this creates the `objectSet` that encapsulates the nodes that belong to specific loaded data. As such this implementation assumes that all nodes that we allow to be a `container` actually is of type `set` because that's what Avalon core provides, plus it's what I've seen (logically) used throughout all available configs.

However, do note, that if someone ever relied on something having the `.id` on a random node in the scene and get detected as a container that with this change it will *not* be detected if it's not an `objectSet`.