### PR TITLE
Fix #457: Remove schema validation when parsing containers

### DIFF
--- a/avalon/houdini/pipeline.py
+++ b/avalon/houdini/pipeline.py
@@ -201,12 +201,11 @@ def containerise(name,
     return container
 
 
-def parse_container(container, validate=True):
+def parse_container(container):
     """Return the container node's full container data.
 
     Args:
         container (hou.Node): A container node name.
-        validate(bool): turn the validation for the container on or off
 
     Returns:
         dict: The container schema data for this container node.
@@ -220,9 +219,6 @@ def parse_container(container, validate=True):
     # Append transient data
     data["objectName"] = container.path()
     data["node"] = container
-
-    if validate:
-        schema.validate(data)
 
     return data
 

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -423,13 +423,11 @@ def containerise(name,
     return container
 
 
-def parse_container(container, validate=True):
+def parse_container(container):
     """Return the container node's full container data.
 
     Args:
         container (str): A container node name.
-        validate (bool, optional): Whether to validate the container schema.
-            Defaults to True.
 
     Returns:
         dict: The container schema data for this container node.
@@ -442,9 +440,6 @@ def parse_container(container, validate=True):
 
     # Append transient data
     data["objectName"] = container
-
-    if validate:
-        schema.validate(data)
 
     return data
 

--- a/avalon/nuke/pipeline.py
+++ b/avalon/nuke/pipeline.py
@@ -99,7 +99,7 @@ def containerise(node,
     return node
 
 
-def parse_container(node, validate=True):
+def parse_container(node):
     """Returns containerised data of a node
 
     This reads the imprinted data from `containerise`.
@@ -114,9 +114,6 @@ def parse_container(node, validate=True):
 
     # Store the node's name
     data["objectName"] = node["name"].value()
-
-    if validate:
-        schema.validate(data)
 
     return data
 


### PR DESCRIPTION
This implements #457 by removing the `schema.validate(container)` for `parse_container` which is used by most `ls()` methods of the hosts (only `fusion` didn't have it).