### PR TITLE
creationFlags are not supported on linux/osx

### DIFF
--- a/avalon/lib.py
+++ b/avalon/lib.py
@@ -219,13 +219,11 @@ def launch(executable, args=None, environment=None, cwd=None):
 
     # this won't do anything on linux/macos as `creationFlags` are
     # only windows specific.
-    if env.get("CREATE_NEW_CONSOLE"):
-        if IS_WIN32:
-            kwargs["creationflags"] = CREATE_NEW_CONSOLE
+    if IS_WIN32 and env.get("CREATE_NEW_CONSOLE"):
+        kwargs["creationflags"] = CREATE_NEW_CONSOLE
         kwargs.pop("stdout")
         kwargs.pop("stderr")
     else:
-
         if IS_WIN32:
             kwargs["creationflags"] = CREATE_NO_WINDOW
 

--- a/avalon/lib.py
+++ b/avalon/lib.py
@@ -218,7 +218,8 @@ def launch(executable, args=None, environment=None, cwd=None):
     )
 
     if env.get("CREATE_NEW_CONSOLE"):
-        kwargs["creationflags"] = CREATE_NEW_CONSOLE
+        if IS_WIN32:
+            kwargs["creationflags"] = CREATE_NEW_CONSOLE
         kwargs.pop("stdout")
         kwargs.pop("stderr")
     else:

--- a/avalon/lib.py
+++ b/avalon/lib.py
@@ -217,6 +217,8 @@ def launch(executable, args=None, environment=None, cwd=None):
         universal_newlines=True,
     )
 
+    # this won't do anything on linux/macos as `creationFlags` are
+    # only windows specific.
     if env.get("CREATE_NEW_CONSOLE"):
         if IS_WIN32:
             kwargs["creationflags"] = CREATE_NEW_CONSOLE


### PR DESCRIPTION
Avalon is using `creationFlags` to launch subprocess via its `launch()` function. `CreationFlags` are supported only on Windows in Python. It is therefor failing on linux and macos.

**What's changed?**
I've just added condition to use it only on Windows.
