### PR TITLE
Resolve #463: RuntimeError doesn't have message attribute

### DIFF
--- a/avalon/tools/loader/app.py
+++ b/avalon/tools/loader/app.py
@@ -404,7 +404,7 @@ def show(debug=False, parent=None, use_context=False):
             module.window.refresh()
             return
         except RuntimeError as e:
-            if not e.message.rstrip().endswith("already deleted."):
+            if not str(e).rstrip().endswith("already deleted."):
                 raise
 
             # Garbage collected


### PR DESCRIPTION
**What's changed?**
Very simple and basic fix for #463 . This makes it also work in Python 3 which doesn't have the `message` attribute on a `RuntimeError`.
