### PR TITLE
Make the workfiles app work in Blender

### DIFF
--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -9,6 +9,8 @@ from ... import style, io, api
 
 from .. import lib as tools_lib
 
+module = sys.modules[__name__]
+module.window = None
 
 class NameWindow(QtWidgets.QDialog):
     """Name Window"""
@@ -300,17 +302,21 @@ class Window(QtWidgets.QDialog):
         self.browse_button.pressed.connect(self.on_browse_pressed)
         self.save_as_button.pressed.connect(self.on_save_as_pressed)
 
+        self._name_window = None
+        self._messagebox = None
+
         self.open_button.setFocus()
 
         self.refresh()
         self.resize(400, 550)
 
     def get_name(self):
-        window = NameWindow(self.root)
-        window.setStyleSheet(style.load_stylesheet())
-        window.exec_()
 
-        return window.get_result()
+        self._name_window = NameWindow(self.root)
+        self._name_window.setStyleSheet(style.load_stylesheet())
+        self._name_window.exec_()
+
+        return self._name_window.get_result()
 
     def refresh(self):
         self.list.clear()
@@ -352,22 +358,22 @@ class Window(QtWidgets.QDialog):
         nuke.scriptSaveAs(file_path)
 
     def save_changes_prompt(self):
-        messagebox = QtWidgets.QMessageBox()
-        messagebox.setWindowFlags(QtCore.Qt.FramelessWindowHint)
-        messagebox.setIcon(messagebox.Warning)
-        messagebox.setWindowTitle("Unsaved Changes!")
-        messagebox.setText(
+        self._messagebox = QtWidgets.QMessageBox()
+        self._messagebox.setWindowFlags(QtCore.Qt.FramelessWindowHint)
+        self._messagebox.setIcon(self._messagebox.Warning)
+        self._messagebox.setWindowTitle("Unsaved Changes!")
+        self._messagebox.setText(
             "There are unsaved changes to the current file."
             "\nDo you want to save the changes?"
         )
-        messagebox.setStandardButtons(
-            messagebox.Yes | messagebox.No | messagebox.Cancel
+        self._messagebox.setStandardButtons(
+            self._messagebox.Yes | self._messagebox.No | self._messagebox.Cancel
         )
-        result = messagebox.exec_()
+        result = self._messagebox.exec_()
 
-        if result == messagebox.Yes:
+        if result == self._messagebox.Yes:
             return True
-        elif result == messagebox.No:
+        elif result == self._messagebox.No:
             return False
         else:
             return None
@@ -453,6 +459,10 @@ class Window(QtWidgets.QDialog):
 def show(root=None, debug=False):
     """Show Work Files GUI"""
 
+    if module.window:
+        module.window.close()
+        del(module.window)
+
     host = api.registered_host()
     if host is None:
         raise RuntimeError("No registered host.")
@@ -490,11 +500,6 @@ def show(root=None, debug=False):
     with tools_lib.application():
         window = Window(root)
         window.setStyleSheet(style.load_stylesheet())
+        window.show()
 
-        if debug:
-            # Enable closing in standalone
-            window.show()
-
-        else:
-            # Cause modal dialog
-            window.exec_()
+        module.window = window

--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -367,7 +367,8 @@ class Window(QtWidgets.QDialog):
             "\nDo you want to save the changes?"
         )
         self._messagebox.setStandardButtons(
-            self._messagebox.Yes | self._messagebox.No | self._messagebox.Cancel
+            self._messagebox.Yes | self._messagebox.No |
+            self._messagebox.Cancel
         )
         result = self._messagebox.exec_()
 


### PR DESCRIPTION
For this I didn't make an issue, because it seems easier to discuss the changes when looking at the code itself. Questions, concerns or suggestions are more then welcome!

There are basically 2 things needed to make it work:

1. Keep a reference to the Qt window (and children) to avoid garbage collection. To keep track of the window `module.window` is now used. This also has the advantage of making it consistent with the other tools which do this already.
2. Avoid running `exec_()` for the main window, because this blocks Blender and creates conflicts between the Qt event loop and Blender event loop (if I'm not mistaken). Instead just `show()` the window and keep it responsive by triggering `processEvents()` all the time from within Blender. This last part is not shown here, because it's part of my Blender integration. This also makes it consistent with the other tools which also just run `show()`. For the `messagebox` and `name_window` it seems fine to run `exec_()`, they are not working if you run `show()`. To be honest I'm not completely sure why.

I hope this doesn't cause any problems with other DCC's, but I suspect it's fine because the other tools also do this.