### PR TITLE
Use the active project in debug mode (fix #460)

### DIFF
--- a/avalon/tools/loader/app.py
+++ b/avalon/tools/loader/app.py
@@ -414,16 +414,6 @@ def show(debug=False, parent=None, use_context=False):
         import traceback
         sys.excepthook = lambda typ, val, tb: traceback.print_last()
 
-        io.install()
-
-        any_project = next(
-            project for project in io.projects()
-            if project.get("active", True) is not False
-        )
-
-        api.Session["AVALON_PROJECT"] = any_project["name"]
-        module.project = any_project["name"]
-
     with lib.application():
 
         # TODO: Global state, remove these

--- a/avalon/tools/sceneinventory/app.py
+++ b/avalon/tools/sceneinventory/app.py
@@ -928,15 +928,9 @@ def show(root=None, debug=False, parent=None):
     except (RuntimeError, AttributeError):
         pass
 
-    if debug is True:
-        io.install()
-
-        any_project = next(
-            project for project in io.projects()
-            if project.get("active", True) is not False
-        )
-
-        api.Session["AVALON_PROJECT"] = any_project["name"]
+    if debug:
+        import traceback
+        sys.excepthook = lambda typ, val, tb: traceback.print_last()
 
     with tools_lib.application():
         window = Window(parent)


### PR DESCRIPTION
**What's changed?**
Previously if `AVALON_DEBUG` was set to `True` the _Loader_ and _Scene Inventory_ would use the first project found in the database instead of the current active project.
This PR removes this behavior. It also adds overwriting the `sys.excepthook` for the _Scene Inventory_ when in debug mode. This should prevent crashing the host when there is an error in the code. This was already in the _Loader_.