### PR TITLE
Fix Avalon-Nuke implementation

### DIFF
--- a/avalon/nuke/__init__.py
+++ b/avalon/nuke/__init__.py
@@ -6,7 +6,6 @@ Anything that isn't defined here is INTERNAL and unreliable for external use.
 
 from .lib import (
     add_publish_knob,
-    ls_img_sequence,
     maintained_selection,
     get_node_path,
 )
@@ -63,7 +62,6 @@ __all__ = [
     "viewer_update_and_undo_stop",
 
     "add_publish_knob",
-    "ls_img_sequence",
     "maintained_selection",
     "get_node_path",
 ]

--- a/avalon/nuke/lib.py
+++ b/avalon/nuke/lib.py
@@ -3,7 +3,8 @@ import contextlib
 import nuke
 import re
 import logging
-import toml
+
+from ..vendor import toml
 
 log = logging.getLogger(__name__)
 

--- a/avalon/nuke/pipeline.py
+++ b/avalon/nuke/pipeline.py
@@ -238,15 +238,12 @@ def uninstall(config):
 def _install_menu():
     from ..tools import (
         creator,
-        # publish,
+        publish,
         workfiles,
         loader,
         sceneinventory,
         contextmanager
     )
-    # for now we are using `lite` version
-    # TODO: just for now untill qml in Nuke will be fixed (pyblish-qml#301)
-    import pyblish_lite as publish
 
     # Create menu
     menubar = nuke.menu("Nuke")

--- a/avalon/nuke/pipeline.py
+++ b/avalon/nuke/pipeline.py
@@ -1,15 +1,15 @@
 import os
-from collections import OrderedDict
 import importlib
-from .. import api, io, schema
-
 import contextlib
-from pyblish import api as pyblish
-from ..vendor import toml
 import logging
-import nuke
-from . import lib
+from collections import OrderedDict
 
+import nuke
+from pyblish import api as pyblish
+
+from . import lib
+from .. import api, io
+from ..vendor import toml
 from ..pipeline import AVALON_CONTAINER_ID
 
 log = logging.getLogger(__name__)

--- a/avalon/version.py
+++ b/avalon/version.py
@@ -8,7 +8,7 @@ deployed, this number is embedded into the Python package.
 """
 
 VERSION_MAJOR = 5
-VERSION_MINOR = 5
+VERSION_MINOR = 6
 VERSION_PATCH = 0
 
 version = "%s.%s" % (VERSION_MAJOR, VERSION_MINOR)
@@ -36,7 +36,7 @@ except ImportError:
         ).rstrip())
 
         # Builds since previous minor version
-        VERSION_PATCH -= 1489
+        VERSION_PATCH -= 1531
         VERSION_PATCH -= 83
         VERSION_PATCH -= 86
 


### PR DESCRIPTION
### Problem

Nuke launched from Avalon will instantly crashed due to some missing function and module-not-found error. 

### What's changed

* Cleanup a bit so I can launch Nuke without any error.
    - Import `toml` from `avalon.vendor` (c78255b)
    - Remove `ls_img_sequence` (fb4cde5)
* Instead of hard-coded to use `pyblish-lite`, revert back to use `avalon.tools.publish` so one can register any pyblish GUI on demand via using `pyblish.register_gui` in config module. (Also, did not encounter pyblish/pyblish-qml#301, even so, no reason to hard code for fix :relieved: ) (b668318)
