### PR TITLE
Parenting tools

### DIFF
--- a/avalon/houdini/pipeline.py
+++ b/avalon/houdini/pipeline.py
@@ -75,6 +75,13 @@ def find_host_config(config):
     return config
 
 
+def get_main_window():
+    """Acquire Houdini's main window"""
+    if self._parent is None:
+        self._parent = hou.ui.mainQtWindow()
+    return self._parent
+
+
 def reload_pipeline(*args):
     """Attempt to reload pipeline at run-time.
 
@@ -116,7 +123,7 @@ def reload_pipeline(*args):
         module = importlib.import_module(module)
         reload(module)
 
-    self._parent = {hou.ui.mainQtWindow().objectName(): hou.ui.mainQtWindow()}
+    get_main_window()
 
     import avalon.houdini
     api.install(avalon.houdini)
@@ -317,9 +324,7 @@ def on_file_event_callback(event):
 
 
 def on_houdini_initialize():
-
-    main_window = hou.qt.mainWindow()
-    self._parent = {main_window.objectName(): main_window}
+    get_main_window()
 
 
 def _register_callbacks():

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -94,6 +94,16 @@ def find_host_config(config):
     return config
 
 
+def get_main_window():
+    """Acquire Maya's main window"""
+    if self._parent is None:
+        self._parent = {
+            widget.objectName(): widget
+            for widget in QtWidgets.QApplication.topLevelWidgets()
+        }["MayaWindow"]
+    return self._parent
+
+
 def uninstall(config):
     """Uninstall Maya-specific functionality of avalon-core.
 
@@ -250,10 +260,7 @@ def reload_pipeline(*args):
         module = importlib.import_module(module)
         reload(module)
 
-    self._parent = {
-        widget.objectName(): widget
-        for widget in QtWidgets.QApplication.topLevelWidgets()
-    }["MayaWindow"]
+    get_main_window()
 
     import avalon.maya
     api.install(avalon.maya)
@@ -625,10 +632,7 @@ def _on_maya_initialized(*args):
         return
 
     # Keep reference to the main Window, once a main window exists.
-    self._parent = {
-        widget.objectName(): widget
-        for widget in QtWidgets.QApplication.topLevelWidgets()
-    }["MayaWindow"]
+    get_main_window()
 
 
 def _on_scene_new(*args):

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -203,7 +203,8 @@ def launch_workfiles_app(*args):
         os.path.join(
             cmds.workspace(query=True, rootDirectory=True),
             cmds.workspace(fileRuleEntry="scene")
-        )
+        ),
+        parent=self._parent
     )
 
 

--- a/avalon/nuke/pipeline.py
+++ b/avalon/nuke/pipeline.py
@@ -286,8 +286,8 @@ def _install_menu():
     menu.addSeparator()
     menu.addCommand("Work Files...",
                     lambda: workfiles.show(
-                        os.environ["AVALON_WORKDIR"]
-                    )
+                        os.environ["AVALON_WORKDIR"],
+                        parent=get_main_window())
                     )
 
     menu.addSeparator()

--- a/avalon/nuke/pipeline.py
+++ b/avalon/nuke/pipeline.py
@@ -224,8 +224,10 @@ def get_main_window():
     """Acquire Nuke's main window"""
     if self._parent is None:
         top_widgets = QtWidgets.QApplication.topLevelWidgets()
+        name = "Foundry::UI::DockMainWindow"
         main_window = next(widget for widget in top_widgets if
-                           widget.isWindow() and not widget.isHidden())
+                           widget.inherits("QMainWindow") and
+                           widget.metaObject().className() == name)
         self._parent = main_window
     return self._parent
 

--- a/avalon/style/style.qss
+++ b/avalon/style/style.qss
@@ -1203,8 +1203,20 @@ QSplitter::handle:hover {
 
 QSplitter::handle:horizontal {
     width: 1px;
+    background-color: transparent;
 }
 
 QSplitter::handle:vertical {
     height: 1px;
+    background-color: transparent;
+}
+
+QSplitter::handle:vertical:hover {
+    background-color: #787876;
+    border: 1px solid #3A3939;
+}
+
+QSplitter::handle:horizontal:hover {
+    background-color: #787876;
+    border: 1px solid #3A3939;
 }

--- a/avalon/style/style.qss
+++ b/avalon/style/style.qss
@@ -32,6 +32,7 @@ QWidget
     background-clip: border;
     border-image: none;
     outline: 0;
+    font-size: 12px;
 }
 
 QWidget:item:hover

--- a/avalon/tools/contextmanager/app.py
+++ b/avalon/tools/contextmanager/app.py
@@ -223,7 +223,7 @@ def show(parent=None):
 
     with lib.application():
         window = App(parent)
-        window.setStyleSheet(style.load_stylesheet())
         window.show()
+        window.setStyleSheet(style.load_stylesheet())
 
         module.window = window

--- a/avalon/tools/contextmanager/app.py
+++ b/avalon/tools/contextmanager/app.py
@@ -42,6 +42,7 @@ class App(QtWidgets.QDialog):
         task_view.setIndentation(0)
         task_model = TasksModel()
         task_view.setModel(task_model)
+        task_view_selection = task_view.selectionModel()
         tasks_layout.addWidget(task_view)
         tasks_layout.addWidget(accept_btn)
         task_view.setColumnHidden(1, True)
@@ -84,8 +85,7 @@ class App(QtWidgets.QDialog):
 
         assets.selection_changed.connect(self.on_asset_changed)
         accept_btn.clicked.connect(self.on_accept_clicked)
-        task_view.selectionModel().selectionChanged.connect(
-            self.on_task_changed)
+        task_view_selection.selectionChanged.connect(self.on_task_changed)
         assets.assets_refreshed.connect(self.on_task_changed)
         assets.refresh()
 

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -583,8 +583,8 @@ def show(debug=False, parent=None):
 
     with lib.application():
         window = Window(parent)
-        window.setStyleSheet(style.load_stylesheet())
         window.refresh()
         window.show()
+        window.setStyleSheet(style.load_stylesheet())
 
         module.window = window

--- a/avalon/tools/loader/app.py
+++ b/avalon/tools/loader/app.py
@@ -421,8 +421,8 @@ def show(debug=False, parent=None, use_context=False):
         lib.refresh_group_config_cache()
 
         window = Window(parent)
-        window.setStyleSheet(style.load_stylesheet())
         window.show()
+        window.setStyleSheet(style.load_stylesheet())
 
         if use_context:
             context = {"asset": api.Session["AVALON_ASSET"],

--- a/avalon/tools/projectmanager/app.py
+++ b/avalon/tools/projectmanager/app.py
@@ -233,8 +233,8 @@ def show(root=None, debug=False, parent=None):
 
     with tools_lib.application():
         window = Window(parent)
-        window.setStyleSheet(style.load_stylesheet())
         window.show()
+        window.setStyleSheet(style.load_stylesheet())
         window.refresh()
 
         module.window = window

--- a/avalon/tools/sceneinventory/app.py
+++ b/avalon/tools/sceneinventory/app.py
@@ -934,8 +934,8 @@ def show(root=None, debug=False, parent=None):
 
     with tools_lib.application():
         window = Window(parent)
-        window.setStyleSheet(style.load_stylesheet())
         window.show()
+        window.setStyleSheet(style.load_stylesheet())
         window.refresh()
 
         module.window = window

--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -236,8 +236,8 @@ class NameWindow(QtWidgets.QDialog):
 class Window(QtWidgets.QDialog):
     """Work Files Window"""
 
-    def __init__(self, root=None):
-        super(Window, self).__init__()
+    def __init__(self, root=None, parent=None):
+        super(Window, self).__init__(parent)
         self.setWindowTitle("Work Files")
         self.setWindowFlags(QtCore.Qt.WindowCloseButtonHint)
 
@@ -457,7 +457,7 @@ class Window(QtWidgets.QDialog):
         self.close()
 
 
-def show(root=None, debug=False):
+def show(root=None, debug=False, parent=None):
     """Show Work Files GUI"""
 
     if module.window:
@@ -499,7 +499,7 @@ def show(root=None, debug=False):
         api.Session["AVALON_TASK"] = "Testing"
 
     with tools_lib.application():
-        window = Window(root)
+        window = Window(root, parent=parent)
         window.setStyleSheet(style.load_stylesheet())
         window.show()
 

--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -337,14 +337,11 @@ class Window(QtWidgets.QDialog):
 
         # Select last modified file
         if self.list.count():
-            index = modified.index(max(modified))
-            item = self.list.item(index)
+            item = self.list.item(modified.index(max(modified)))
             item.setSelected(True)
 
             # Scroll list so item is visible
-            def scroll_to_item():
-                self.list.scrollToItem(self.list.item(index))
-            QtCore.QTimer.singleShot(100, scroll_to_item)
+            QtCore.QTimer.singleShot(100, lambda: self.list.scrollToItem(item))
 
             self.duplicate_button.setEnabled(True)
         else:

--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -239,7 +239,7 @@ class Window(QtWidgets.QDialog):
     def __init__(self, root=None, parent=None):
         super(Window, self).__init__(parent)
         self.setWindowTitle("Work Files")
-        self.setWindowFlags(QtCore.Qt.WindowCloseButtonHint)
+        self.setWindowFlags(QtCore.Qt.Window | QtCore.Qt.WindowCloseButtonHint)
 
         self.root = root
 

--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -337,11 +337,14 @@ class Window(QtWidgets.QDialog):
 
         # Select last modified file
         if self.list.count():
-            item = self.list.item(modified.index(max(modified)))
+            index = modified.index(max(modified))
+            item = self.list.item(index)
             item.setSelected(True)
 
             # Scroll list so item is visible
-            QtCore.QTimer.singleShot(100, lambda: self.list.scrollToItem(item))
+            def scroll_to_item():
+                self.list.scrollToItem(self.list.item(index))
+            QtCore.QTimer.singleShot(100, scroll_to_item)
 
             self.duplicate_button.setEnabled(True)
         else:

--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -504,7 +504,7 @@ def show(root=None, debug=False, parent=None):
 
     with tools_lib.application():
         window = Window(root, parent=parent)
-        window.setStyleSheet(style.load_stylesheet())
         window.show()
+        window.setStyleSheet(style.load_stylesheet())
 
         module.window = window

--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -12,6 +12,7 @@ from .. import lib as tools_lib
 module = sys.modules[__name__]
 module.window = None
 
+
 class NameWindow(QtWidgets.QDialog):
     """Name Window"""
 

--- a/res/houdini/MainMenuCommon.XML
+++ b/res/houdini/MainMenuCommon.XML
@@ -11,7 +11,8 @@ return "%s - %s" % (api.Session["AVALON_ASSET"], api.Session["AVALON_TASK"])
                 <scriptItem id="avalon_context_switch">
                     <label>Set Context</label>
                     <scriptCode><![CDATA[
-from avalon.tools import contextmanager; contextmanager.show()
+from avalon.tools import contextmanager
+contextmanager.show(parent=hou.ui.mainQtWindow())
 ]]></scriptCode>
                 </scriptItem>
             </subMenu>
@@ -22,7 +23,7 @@ from avalon.tools import contextmanager; contextmanager.show()
                 <label>Create ..</label>
                 <scriptCode><![CDATA[
 from avalon.tools import creator
-creator.show()
+creator.show(parent=hou.ui.mainQtWindow())
 ]]></scriptCode>
             </scriptItem>
 
@@ -30,7 +31,7 @@ creator.show()
                 <label>Load ..</label>
                 <scriptCode><![CDATA[
 from avalon.tools import loader
-loader.show(use_context=True)
+loader.show(parent=hou.ui.mainQtWindow(), use_context=True)
 ]]></scriptCode>
             </scriptItem>
 
@@ -38,7 +39,7 @@ loader.show(use_context=True)
                 <label>Manage ..</label>
                 <scriptCode><![CDATA[
 from avalon.tools import sceneinventory
-sceneinventory.show()
+sceneinventory.show(parent=hou.ui.mainQtWindow())
 ]]></scriptCode>
             </scriptItem>
 
@@ -47,8 +48,7 @@ sceneinventory.show()
                 <scriptCode><![CDATA[
 import hou
 from avalon.tools import publish
-parent = hou.qt.mainWindow()
-publish.show(parent)
+publish.show(parent=hou.ui.mainQtWindow())
                 ]]></scriptCode>
             </scriptItem>
 

--- a/res/houdini/MainMenuCommon.XML
+++ b/res/houdini/MainMenuCommon.XML
@@ -12,7 +12,8 @@ return "%s - %s" % (api.Session["AVALON_ASSET"], api.Session["AVALON_TASK"])
                     <label>Set Context</label>
                     <scriptCode><![CDATA[
 from avalon.tools import contextmanager
-contextmanager.show(parent=hou.ui.mainQtWindow())
+from avalon.houdini import pipeline
+contextmanager.show(parent=pipeline.get_main_window())
 ]]></scriptCode>
                 </scriptItem>
             </subMenu>
@@ -23,7 +24,8 @@ contextmanager.show(parent=hou.ui.mainQtWindow())
                 <label>Create ..</label>
                 <scriptCode><![CDATA[
 from avalon.tools import creator
-creator.show(parent=hou.ui.mainQtWindow())
+from avalon.houdini import pipeline
+creator.show(parent=pipeline.get_main_window())
 ]]></scriptCode>
             </scriptItem>
 
@@ -31,7 +33,8 @@ creator.show(parent=hou.ui.mainQtWindow())
                 <label>Load ..</label>
                 <scriptCode><![CDATA[
 from avalon.tools import loader
-loader.show(parent=hou.ui.mainQtWindow(), use_context=True)
+from avalon.houdini import pipeline
+loader.show(parent=pipeline.get_main_window(), use_context=True)
 ]]></scriptCode>
             </scriptItem>
 
@@ -39,7 +42,8 @@ loader.show(parent=hou.ui.mainQtWindow(), use_context=True)
                 <label>Manage ..</label>
                 <scriptCode><![CDATA[
 from avalon.tools import sceneinventory
-sceneinventory.show(parent=hou.ui.mainQtWindow())
+from avalon.houdini import pipeline
+sceneinventory.show(parent=pipeline.get_main_window())
 ]]></scriptCode>
             </scriptItem>
 
@@ -48,7 +52,8 @@ sceneinventory.show(parent=hou.ui.mainQtWindow())
                 <scriptCode><![CDATA[
 import hou
 from avalon.tools import publish
-publish.show(parent=hou.ui.mainQtWindow())
+from avalon.houdini import pipeline
+publish.show(parent=pipeline.get_main_window())
                 ]]></scriptCode>
             </scriptItem>
 
@@ -59,7 +64,8 @@ publish.show(parent=hou.ui.mainQtWindow())
                 <scriptCode><![CDATA[
 import hou
 from avalon.tools import workfiles
-workfiles.show(parent=hou.ui.mainQtWindow())
+from avalon.houdini import pipeline
+workfiles.show(parent=pipeline.get_main_window())
                 ]]></scriptCode>
             </scriptItem>
 

--- a/res/houdini/MainMenuCommon.XML
+++ b/res/houdini/MainMenuCommon.XML
@@ -59,8 +59,7 @@ publish.show(parent=hou.ui.mainQtWindow())
                 <scriptCode><![CDATA[
 import hou
 from avalon.tools import workfiles
-#parent = hou.qt.mainWindow()
-workfiles.show()
+workfiles.show(parent=hou.ui.mainQtWindow())
                 ]]></scriptCode>
             </scriptItem>
 


### PR DESCRIPTION
### Problem

Avalon tools like Loader, Creator, Scene Manager, Context Manager, Workfile were not parented in Houdini and Nuke's main window.

And the Workfile app's `show()` wasn't accept `parent` arg at all.

### Changes

* Implemented main window getter function for Nuke **(Update: Also Houdini and Maya)**
* Add `parent` flag to `avalon.tools.workfiles.show()`
* Parenting tools for Nuke and Houdini
* Fix tools style after parented in Houdini

---

While I was working on Houdini, I encountered two problems:
1. The Qt style sheet was overridden by Houdini.
2. Calling Context Manager raised `Segmentation fault` fatal error.

On problem 1, the Loader has become:

<details>
<summary> See Image </summary>

![image](https://user-images.githubusercontent.com/3357009/68201708-428f3100-fffd-11e9-9f33-ea7cc88287d3.png)

</details>

And the Context Manager:

<details>
<summary> See Image </summary>

![image](https://user-images.githubusercontent.com/3357009/68201798-6c485800-fffd-11e9-9330-41e91a770c15.png)

</details>

Which looks cool but I love Avalon flavor more.
Interestingly, Creator and Scene Manager did not have this issue, not sure why :(
> Edit: :point_up:  Actually they do, see comments below.

<details>
<summary> See Image </summary>

![image](https://user-images.githubusercontent.com/3357009/68202029-dcef7480-fffd-11e9-9322-db3442f1ce7a.png)

</details>

On problem 2, it was because of directly connecting `QtWidgets.QTreeView.selectionModel()` to the handler, and leads to a `Segmentation fault` error and crash Houdini.

The only useful info I could find was this [tweet](https://twitter.com/yantor3d/status/1161869142971961344?s=20).
