### PR TITLE
Re-implement Nuke `imprint`

### DIFF
--- a/avalon/nuke/lib.py
+++ b/avalon/nuke/lib.py
@@ -244,7 +244,7 @@ def set_avalon_knob_data(node, data=None, prefix="avalon:"):
     body[("divd", "")] = Knobby("Text_Knob", "")
 
     for key, value in data.items():
-        name = prefix + key
+        name = (prefix + key, key)  # Hide prefix on GUI
         if key in editable:
             body[name] = value
         else:

--- a/avalon/nuke/lib.py
+++ b/avalon/nuke/lib.py
@@ -193,11 +193,20 @@ def create_knobs(data, tab=None):
 
 
 def add_publish_knob(node):
+    """Add Publish knob to node
+
+    Arguments:
+        node (obj): nuke node to be processed
+
+    Returns:
+        node (obj): processed nuke node
+
+    """
     if "publish" not in node.knobs():
-        knob = nuke.Boolean_Knob("publish", "Publish")
-        knob.setFlag(0x1000)
-        knob.setValue(False)
-        node.addKnob(knob)
+        body = OrderedDict()
+        body[("divd", "")] = Knobby("Text_Knob", "")
+        body["publish"] = True
+        imprint(node, body)
     return node
 
 

--- a/avalon/nuke/lib.py
+++ b/avalon/nuke/lib.py
@@ -153,6 +153,7 @@ def create_knobs(data, tab=None):
         elif isinstance(value, bool):
             knob = nuke.Boolean_Knob(name, nice)
             knob.setValue(value)
+            knob.setFlag(nuke.STARTLINE)
 
         elif isinstance(value, int):
             knob = nuke.Int_Knob(name, nice)

--- a/avalon/nuke/lib.py
+++ b/avalon/nuke/lib.py
@@ -180,10 +180,14 @@ def create_knobs(data, tab=None):
         elif isinstance(value, dict):
             if all(isinstance(v, dict) for v in value.values()):
                 # Create a group of tabs
-                knobs.append(nuke.BeginTabGroup_Knob())
+                begain = nuke.BeginTabGroup_Knob()
+                end = nuke.EndTabGroup_Knob()
+                begain.setName(name)
+                end.setName(name + "_End")
+                knobs.append(begain)
                 for k, v in value.items():
                     knobs += create_knobs(v, tab=k)
-                knobs.append(nuke.EndTabGroup_Knob())
+                knobs.append(end)
             else:
                 # Create a group of knobs
                 knobs.append(nuke.Tab_Knob(name, nice, nuke.TABBEGINGROUP))

--- a/avalon/nuke/lib.py
+++ b/avalon/nuke/lib.py
@@ -3,6 +3,7 @@ import contextlib
 import nuke
 import re
 import logging
+from collections import OrderedDict
 
 from ..vendor import six
 
@@ -21,19 +22,6 @@ def maintained_selection():
         # and select all previously selected nodes
         if previous_selection:
             [n['selected'].setValue(True) for n in previous_selection]
-
-
-def add_avalon_tab_knob(node):
-    """Adding a tab and a knob into a node
-    """
-    try:
-        node['avalon'].value()
-    except Exception:
-        tab = nuke.Tab_Knob("Avalon")
-        uk = nuke.Text_Knob('avalon', 'avalon data')
-        node.addKnob(tab)
-        node.addKnob(uk)
-        log.info("created new user knob avalon")
 
 
 def imprint(node, data, tab=None):
@@ -209,6 +197,48 @@ def add_publish_knob(node):
         knob.setFlag(0x1000)
         knob.setValue(False)
         node.addKnob(knob)
+    return node
+
+
+def set_avalon_knob_data(node, data=None, prefix="avalon:"):
+    """ Sets data into nodes's avalon knob
+
+    Arguments:
+        node (obj): Nuke node to imprint with data,
+        data ( dict): Data to be imprinted into AvalonTab
+        prefix (str, optional): filtering prefix
+
+    Returns:
+        node (obj)
+
+    Examples:
+        data = {
+            'asset': 'sq020sh0280',
+            'family': 'render',
+            'subset': 'subsetMain'
+        }
+    """
+    editable = ["asset", "subset", "name", "namespace"]
+
+    data = data or dict()
+
+    group = OrderedDict()
+    body = OrderedDict()
+
+    group["avalonDataGroup"] = body
+    body[("warn", "")] = Knobby("Text_Knob",
+                                "Warning! Do not change following data!")
+    body[("divd", "")] = Knobby("Text_Knob", "")
+
+    for key, value in data.items():
+        name = prefix + key
+        if key in editable:
+            body[name] = value
+        else:
+            body[name] = Knobby("Text_Knob", str(value))
+
+    imprint(node, group, tab="AvalonTab")
+
     return node
 
 

--- a/avalon/nuke/lib.py
+++ b/avalon/nuke/lib.py
@@ -199,10 +199,10 @@ def add_publish_knob(node):
     """Add Publish knob to node
 
     Arguments:
-        node (obj): nuke node to be processed
+        node (nuke.Node): nuke node to be processed
 
     Returns:
-        node (obj): processed nuke node
+        node (nuke.Node): processed nuke node
 
     """
     if "publish" not in node.knobs():
@@ -217,12 +217,12 @@ def set_avalon_knob_data(node, data=None, prefix="avalon:"):
     """ Sets data into nodes's avalon knob
 
     Arguments:
-        node (obj): Nuke node to imprint with data,
-        data ( dict): Data to be imprinted into AvalonTab
+        node (nuke.Node): Nuke node to imprint with data,
+        data (dict, optional): Data to be imprinted into AvalonTab
         prefix (str, optional): filtering prefix
 
     Returns:
-        node (obj)
+        node (nuke.Node)
 
     Examples:
         data = {
@@ -259,7 +259,7 @@ def get_avalon_knob_data(node, prefix="avalon:"):
     """ Get data from nodes's avalon knob
 
     Arguments:
-        node (obj): Nuke node to search for data,
+        node (nuke.Node): Nuke node to search for data,
         prefix (str, optional): filtering prefix
 
     Returns:

--- a/avalon/nuke/lib.py
+++ b/avalon/nuke/lib.py
@@ -252,6 +252,24 @@ def set_avalon_knob_data(node, data=None, prefix="avalon:"):
     return node
 
 
+def get_avalon_knob_data(node, prefix="avalon:"):
+    """ Get data from nodes's avalon knob
+
+    Arguments:
+        node (obj): Nuke node to search for data,
+        prefix (str, optional): filtering prefix
+
+    Returns:
+        data (dict)
+    """
+    data = {
+        knob[len(prefix):]: node[knob].value()
+        for knob in node.knobs().keys()
+        if knob.startsWith(prefix)
+    }
+    return data
+
+
 def fix_data_for_node_create(data):
     for k, v in data.items():
 

--- a/avalon/nuke/lib.py
+++ b/avalon/nuke/lib.py
@@ -27,7 +27,7 @@ def maintained_selection():
 def imprint(node, data, tab=None):
     """Store attributes with value on node
 
-    Parse user data into Node konbs.
+    Parse user data into Node knobs.
     Use `collections.OrderedDict` to ensure knob order.
 
     Args:

--- a/avalon/nuke/lib.py
+++ b/avalon/nuke/lib.py
@@ -268,7 +268,7 @@ def get_avalon_knob_data(node, prefix="avalon:"):
     data = {
         knob[len(prefix):]: node[knob].value()
         for knob in node.knobs().keys()
-        if knob.startsWith(prefix)
+        if knob.startswith(prefix)
     }
     return data
 

--- a/avalon/nuke/lib.py
+++ b/avalon/nuke/lib.py
@@ -231,26 +231,43 @@ def set_avalon_knob_data(node, data=None, prefix="avalon:"):
             'subset': 'subsetMain'
         }
     """
+    data = data or dict()
+    create = OrderedDict()
+
+    tab_name = "AvalonTab"
     editable = ["asset", "subset", "name", "namespace"]
 
-    data = data or dict()
-
-    group = OrderedDict()
-    body = OrderedDict()
-
-    group["avalonDataGroup"] = body
-    body[("warn", "")] = Knobby("Text_Knob",
-                                "Warning! Do not change following data!")
-    body[("divd", "")] = Knobby("Text_Knob", "")
+    existed_knobs = node.knobs()
 
     for key, value in data.items():
-        name = (prefix + key, key)  # Hide prefix on GUI
-        if key in editable:
-            body[name] = value
-        else:
-            body[name] = Knobby("Text_Knob", str(value))
+        knob_name = prefix + key
+        gui_name = key
 
-    imprint(node, group, tab="AvalonTab")
+        if knob_name in existed_knobs:
+            # Set value
+            node[knob_name].setValue(value)
+        else:
+            # New knob
+            name = (knob_name, gui_name)  # Hide prefix on GUI
+            if key in editable:
+                create[name] = value
+            else:
+                create[name] = Knobby("Text_Knob", str(value))
+
+    if tab_name in existed_knobs:
+        tab_name = None
+    else:
+        tab = OrderedDict()
+        warn = Knobby("Text_Knob", "Warning! Do not change following data!")
+        divd = Knobby("Text_Knob", "")
+        head = [
+            (("warn", ""), warn),
+            (("divd", ""), divd),
+        ]
+        tab["avalonDataGroup"] = OrderedDict(head + create.items())
+        create = tab
+
+    imprint(node, create, tab=tab_name)
 
     return node
 

--- a/avalon/nuke/lib.py
+++ b/avalon/nuke/lib.py
@@ -115,6 +115,9 @@ def create_knobs(data, tab=None):
         list: nuke.Enumeration_Knob
         six.string_types: nuke.String_Knob
 
+        dict: If it's a nested dict (all values are dict), will turn into
+            A tabs group. Or just a knobs group.
+
     Args:
         data (dict): collection of attributes and their value
         tab (string, optional): Knobs' tab name

--- a/avalon/nuke/pipeline.py
+++ b/avalon/nuke/pipeline.py
@@ -64,21 +64,20 @@ def containerise(node,
                  context,
                  loader=None,
                  data=None):
-    """Bundle `nodes` into an assembly and imprint it with metadata
+    """Bundle `node` into an assembly and imprint it with metadata
 
     Containerisation enables a tracking of version, author and origin
     for loaded assets.
 
     Arguments:
-        node (object): The node in Nuke to imprint as container,
-        usually a Reader.
+        node (nuke.Node): Nuke's node object to imprint as container
         name (str): Name of resulting assembly
         namespace (str): Namespace under which to host container
         context (dict): Asset information
         loader (str, optional): Name of node used to produce this container.
 
     Returns:
-        Node
+        node (nuke.Node): containerised nuke's node object
 
     """
 
@@ -105,7 +104,7 @@ def parse_container(node):
     Reads the imprinted data from `containerise`.
 
     Arguments:
-        node (obj): Nuke's node object to read imprinted data
+        node (nuke.Node): Nuke's node object to read imprinted data
 
     Returns:
         container (dict): imprinted container data
@@ -136,11 +135,11 @@ def update_container(node, keys=None):
     """Returns node with updateted containder data
 
     Arguments:
-        node (object): The node in Nuke to imprint as container,
+        node (nuke.Node): The node in Nuke to imprint as container,
         keys (dict, optional): data which should be updated
 
     Returns:
-        node (object): nuke node with updated container data
+        node (nuke.Node): nuke node with updated container data
     """
     keys = keys or dict()
 

--- a/avalon/nuke/pipeline.py
+++ b/avalon/nuke/pipeline.py
@@ -95,11 +95,7 @@ def containerise(node,
     if data:
         {data_imprint.update({k: v}) for k, v in data.items()}
 
-    log.info("data: {}".format(data_imprint))
-
-    lib.add_avalon_tab_knob(node)
-
-    node['avalon'].setValue(toml.dumps(data_imprint))
+    lib.set_avalon_knob_data(node, data_imprint)
 
     return node
 

--- a/avalon/nuke/pipeline.py
+++ b/avalon/nuke/pipeline.py
@@ -155,10 +155,13 @@ class Creator(api.Creator):
         if (self.options or {}).get("useSelection"):
             nodes = nuke.selectedNodes()
 
-        instance = [n for n in nodes
-                    if n["name"].value() in self.name] or None
+        nodes = [n for n in nodes
+                 if n["name"].value() in self.name] or None
 
-        instance = lib.imprint(instance, self.data)
+        node = nodes[0]
+        lib.set_avalon_knob_data(node, self.data)
+        lib.add_publish_knob(node)
+        instance = node
 
         return instance
 

--- a/avalon/nuke/pipeline.py
+++ b/avalon/nuke/pipeline.py
@@ -80,20 +80,20 @@ def containerise(node,
         node (nuke.Node): containerised nuke's node object
 
     """
+    data = OrderedDict(
+        [
+            ("schema", "avalon-core:container-2.0"),
+            ("id", AVALON_CONTAINER_ID),
+            ("name", name),
+            ("namespace", namespace),
+            ("loader", str(loader)),
+            ("representation", context["representation"]["_id"]),
+        ],
 
-    data_imprint = OrderedDict({
-        "schema": "avalon-core:container-2.0",
-        "id": AVALON_CONTAINER_ID,
-        "name": str(name),
-        "namespace": str(namespace),
-        "loader": str(loader),
-        "representation": str(context["representation"]["_id"]),
-    })
+        **data or dict()
+    )
 
-    if data:
-        {data_imprint.update({k: v}) for k, v in data.items()}
-
-    lib.set_avalon_knob_data(node, data_imprint)
+    lib.set_avalon_knob_data(node, data)
 
     return node
 

--- a/avalon/nuke/pipeline.py
+++ b/avalon/nuke/pipeline.py
@@ -132,16 +132,17 @@ def parse_container(node):
     return container
 
 
-def update_container(node, keys=dict()):
+def update_container(node, keys=None):
     """Returns node with updateted containder data
 
     Arguments:
         node (object): The node in Nuke to imprint as container,
-        keys (dict): data which should be updated
+        keys (dict, optional): data which should be updated
 
     Returns:
         node (object): nuke node with updated container data
     """
+    keys = keys or dict()
 
     data = lib.get_avalon_knob_data(node)
 

--- a/avalon/nuke/pipeline.py
+++ b/avalon/nuke/pipeline.py
@@ -140,20 +140,18 @@ def update_container(node, keys=None):
 
     Returns:
         node (nuke.Node): nuke node with updated container data
+
+    Raises:
+        TypeError on given an invalid container node
+
     """
     keys = keys or dict()
 
-    data = lib.get_avalon_knob_data(node)
+    container = parse_container(node)
+    if not container:
+        raise TypeError("Not a valid container node.")
 
-    container = dict()
-    container = {key: data[key] for key in data}
-
-    for key, value in container.items():
-        try:
-            container[key] = keys[key]
-        except KeyError:
-            pass
-
+    container.update(keys)
     node = lib.set_avalon_knob_data(node, container)
 
     return node


### PR DESCRIPTION
This PR is the first step of refactoring #438, for resolving `imprint` which functionality was a bit rigid.

### What's changed

* Re-implemented `lib.imprint`
* Changed following functions to adopt new `lib.imprint`:
    - `lib.set_avalon_knob_data`
    - `lib.add_publish_knob`
    - `pipeline.Creator`
* Add back `lib.get_avalon_knob_data` from #438

### About `lib.imprint`

Nuke has [three categories of knobs](https://learn.foundry.com/nuke/developers/90/ndkdevguide/knobs-and-handles/intro.html#knob-classifications), *data-stored knob*, *layout knob* and *complex data knob*, but let's put *complex data knob* aside for now.

On *data-stored knob*, `imprint` will create knob which fits to regular data types, like `bool`, `int`, `float`, `str`, `list`. For `dict`, it will become a group of knobs, or a group of tabs.

For example:

```python
# Creating two group of knobs
node = nuke.createNode("NoOp")
data = {
    "group1": {
        "group1.var1": 5,
        "group1.var2": "hello",
        "group1.var3": ["a", "b"],
    },
    "group2": {
        "group2.var1": 6,
        "group2.var2": "world",
        "group2.var3": ["o", "p"],
    },
}
lib.imprint(node, data, tab="User")
```
Which you will get

![image](https://user-images.githubusercontent.com/3357009/68457788-0bf32980-023c-11ea-820d-8db6a11b782a.png)

And this:

```python
data = {
    "tabGroup": {
        "tab1": {"count": 5},
        "tab2": {"isGood": True},
        "tab3": {"direction": ["Left", "Right"]},
    },
}
node = nuke.createNode("NoOp")
lib.imprint(node, data, tab="User")
```

Will looks like this

![image](https://user-images.githubusercontent.com/3357009/68457930-81f79080-023c-11ea-99ac-c9307d0ad492.png)

And if you wish to use other kind of knobs which is not mapped in `lib.create_knob`, you could use `lib.Knobby`, for example:

```python
data = {
    # Using tuple as key for manual nice naming
    ("my_knob", "Nice Knob"): lib.Knobby("Text_Knob", "Non-editable text"),
    ("divider", ""): lib.Knobby("Text_Knob", ""),
    "MyFilePath": lib.Knobby("File_Knob", "/file/path"),
}
node = nuke.createNode("NoOp")
lib.imprint(node, data, tab="User")
```

And you have a file path knob

![image](https://user-images.githubusercontent.com/3357009/68458324-78baf380-023d-11ea-8d87-4fcddef0b7cb.png)

---

Hope this PR make sense to you, please let me know what you think. :relaxed: 




