### PR TITLE
change fps mapping in maya

### DIFF
--- a/avalon/maya/commands.py
+++ b/avalon/maya/commands.py
@@ -8,6 +8,7 @@ For interactive use, see :mod:`interactive.py`
 """
 
 from maya import cmds
+import math
 
 from .. import io, api
 

--- a/avalon/maya/commands.py
+++ b/avalon/maya/commands.py
@@ -8,7 +8,6 @@ For interactive use, see :mod:`interactive.py`
 """
 
 from maya import cmds
-import math
 
 from .. import io, api
 

--- a/avalon/maya/commands.py
+++ b/avalon/maya/commands.py
@@ -34,29 +34,22 @@ def reset_frame_range():
         cmds.warning("No edit information found for %s" % shot["name"])
         return
 
-    # this handles fps set as decimal number. For example
-    # fps 25.0 is corrected to int so mapping will still work
-    avalon_fps = api.Session.get("AVALON_FPS")
-    d, i = math.modf(float(api.Session.get("AVALON_FPS", 25)))
-    if d == 0.0:
-        avalon_fps = int(i)
-
-    fps = {'15': 'game',
-           '24': 'film',
-           '25': 'pal',
-           '30': 'ntsc',
-           '48': 'show',
-           '50': 'palf',
-           '60': 'ntscf',
-           '23.98': '23.976fps',
-           '23.976': '23.976fps',
-           '29.97': '29.97fps',
-           '47.952': '47.952fps',
-           '47.95': '47.952fps',
-           '59.94': '59.94fps',
-           '44100': '44100fps',
-           '48000': '48000fps'
-           }.get(str(avalon_fps), "pal")  # Default to "pal"
+    fps = {15: 'game',
+           24: 'film',
+           25: 'pal',
+           30: 'ntsc',
+           48: 'show',
+           50: 'palf',
+           60: 'ntscf',
+           23.98: '23.976fps',
+           23.976: '23.976fps',
+           29.97: '29.97fps',
+           47.952: '47.952fps',
+           47.95: '47.952fps',
+           59.94: '59.94fps',
+           44100: '44100fps',
+           48000: '48000fps'
+           }.get(float(api.Session.get("AVALON_FPS", 25)), "pal")
 
     cmds.currentUnit(time=fps)
 

--- a/avalon/maya/commands.py
+++ b/avalon/maya/commands.py
@@ -33,17 +33,29 @@ def reset_frame_range():
         cmds.warning("No edit information found for %s" % shot["name"])
         return
 
-    fps = {
-        "12": "12fps",
-        "15": "game",
-        "16": "16fps",
-        "24": "film",
-        "25": "pal",
-        "30": "ntsc",
-        "48": "show",
-        "50": "palf",
-        "60": "ntscf"
-    }.get(api.Session.get("AVALON_FPS"), "pal")  # Default to "pal"
+    # this handles fps set as decimal number. For example
+    # fps 25.0 is corrected to int so mapping will still work
+    avalon_fps = api.Session.get("AVALON_FPS")
+    d, i = math.modf(float(api.Session.get("AVALON_FPS", 25)))
+    if d == 0.0:
+        avalon_fps = int(i)
+
+    fps = {'15': 'game',
+           '24': 'film',
+           '25': 'pal',
+           '30': 'ntsc',
+           '48': 'show',
+           '50': 'palf',
+           '60': 'ntscf',
+           '23.98': '23.976fps',
+           '23.976': '23.976fps',
+           '29.97': '29.97fps',
+           '47.952': '47.952fps',
+           '47.95': '47.952fps',
+           '59.94': '59.94fps',
+           '44100': '44100fps',
+           '48000': '48000fps'
+           }.get(str(avalon_fps), "pal")  # Default to "pal"
 
     cmds.currentUnit(time=fps)
 


### PR DESCRIPTION

**What's changed?**
Fps in Maya is set by mapping actual fps number to string constants used by Maya to set time units.  You can have fps set as integer - 25 or as float 25.0 They are numerically same but mapping recognize only integer. If you pull fps from system like ftrack, where this attribute is set as decimal to allow values like 23.976 it will also returns 25 as 25.0. To handle it, this change cast numbers like 25.0 to integer so mapping still works and adds few other Maya string constants.