### PR TITLE
Implement Nuke's `lib.read`

### DIFF
--- a/avalon/nuke/__init__.py
+++ b/avalon/nuke/__init__.py
@@ -5,8 +5,10 @@ Anything that isn't defined here is INTERNAL and unreliable for external use.
 """
 
 from .lib import (
-    add_publish_knob,
     maintained_selection,
+    read,
+
+    add_publish_knob,
     get_node_path,
 )
 
@@ -57,6 +59,8 @@ __all__ = [
     "containerise",
     "parse_container",
     "update_container",
+
+    "read",
 
     # Experimental
     "viewer_update_and_undo_stop",

--- a/avalon/nuke/lib.py
+++ b/avalon/nuke/lib.py
@@ -227,7 +227,7 @@ def read(node):
     data = dict()
 
     pattern = ("(?<=addUserKnob {)"
-               "([0-9]*) (\S*)"  # Matching knob type and knob name
+               "([0-9]*) (\\S*)"  # Matching knob type and knob name
                "(?=[ |}])")
     tcl_script = node.writeKnobs(nuke.WRITE_USER_KNOB_DEFS)
     result = re.search(pattern, tcl_script)

--- a/avalon/nuke/lib.py
+++ b/avalon/nuke/lib.py
@@ -237,8 +237,11 @@ def read(node):
         # Collect user knobs from the end of the knob list
         for knob in reversed(node.allKnobs()):
             knob_name = knob.name()
-            knob_type = nuke.knob(knob.fullyQualifiedName(), type=True)
+            if not knob_name:
+                # Ignore unnamed knob
+                continue
 
+            knob_type = nuke.knob(knob.fullyQualifiedName(), type=True)
             value = knob.value()
 
             if (

--- a/avalon/nuke/lib.py
+++ b/avalon/nuke/lib.py
@@ -86,13 +86,15 @@ class Knobby(object):
     Args:
         type (string): Nuke knob type name
         value: Value to be set with `Knob.setValue`, put `None` if not required
+        flags (list, optional): Knob flags to be set with `Knob.setFlag`
         *args: Args other than knob name for initializing knob class
 
     """
 
-    def __init__(self, type, value, *args):
+    def __init__(self, type, value, flags=None, *args):
         self.type = type
         self.value = value
+        self.flags = flags or []
         self.args = args
 
     def create(self, name, nice=None):
@@ -100,6 +102,8 @@ class Knobby(object):
         knob = knob_cls(name, nice, *self.args)
         if self.value is not None:
             knob.setValue(self.value)
+        for flag in self.flags:
+            knob.setFlag(flag)
         return knob
 
 

--- a/avalon/nuke/lib.py
+++ b/avalon/nuke/lib.py
@@ -296,7 +296,9 @@ def set_avalon_knob_data(node, data=None, prefix="avalon:"):
             if key in editable:
                 create[name] = value
             else:
-                create[name] = Knobby("Text_Knob", str(value))
+                create[name] = Knobby("String_Knob",
+                                      str(value),
+                                      flags=[nuke.READ_ONLY])
 
     if tab_name in existed_knobs:
         tab_name = None

--- a/avalon/nuke/lib.py
+++ b/avalon/nuke/lib.py
@@ -195,7 +195,7 @@ def create_knobs(data, tab=None):
     return knobs
 
 
-KNOB_TYPE_EXCLUDED_ON_READ = (
+EXCLUDED_KNOB_TYPE_ON_READ = (
     20,  # Tab Knob
     26,  # Text Knob
 )
@@ -226,7 +226,7 @@ def read(node):
             knob_name = knob.name()
             knob_type = nuke.knob(knob.fullyQualifiedName(), type=True)
 
-            if knob_type not in KNOB_TYPE_EXCLUDED_ON_READ:
+            if knob_type not in EXCLUDED_KNOB_TYPE_ON_READ:
                 data[knob_name] = knob.value()
 
             if knob_name == first_user_knob:

--- a/avalon/nuke/pipeline.py
+++ b/avalon/nuke/pipeline.py
@@ -107,28 +107,25 @@ def parse_container(node):
         node (nuke.Node): Nuke's node object to read imprinted data
 
     Returns:
-        container (dict): imprinted container data
+        dict: The container schema data for this container node.
+
     """
-    data = lib.get_avalon_knob_data(node)
+    data = lib.read(node)
 
-    if not isinstance(data, dict):
-        return
-
+    # (TODO) Remove key validation when `ls` has re-implemented.
+    #
     # If not all required data return the empty container
     required = ["schema", "id", "name",
                 "namespace", "loader", "representation"]
-
     if not all(key in data for key in required):
         return
 
-    container = {key: data[key] for key in required}
-
     # Store the node's name
-    container["objectName"] = node["name"].value()
+    data["objectName"] = node["name"].value()
     # Store reference to the node object
-    container["_node"] = node
+    data["_node"] = node
 
-    return container
+    return data
 
 
 def update_container(node, keys=None):


### PR DESCRIPTION
### Motivation

The Avalon data read-write methods implemented in Nuke was driven by prefixing knob name so to differ which knob is node's default and which is user-defined.

But the prefix may change, and the logic was not the same as other hosts, so if there's a way to differ user-defined and default knobs without prefixing knob name, I think we should opt that in.

### Changes

* For unifying host implementation and pattern, adding `lib.read` to retrieve user-defined knobs from any given node, just like in other hosts. *For layout type knob, like `nuke.Tab_Knob`, divider knob (`nuke.Text_Knob` with empty string value), and unnamed knob will be ignored.*

* Backward compatible for knobs which prefixed with `"avalon:"` or `"ak:"`. (Resolved this [comment](https://github.com/getavalon/core/pull/473#discussion_r348515218))

* Added `flags` optional arg on `lib.Knobby` for setting knob flag. Current *read-only string data imprinting* was implemented by using `nuke.Text_Knob`. But `nuke.Text_Knob` could be a layout divider if the initial value is an empty string, which could be confused with other *read-only* string data while reading. This change reduced the confusion by enabling knob flag setting while imprinting (e.g. `nuke.String_Knob` + `nuke.READ_ONLY`) .