### PR TITLE
Fix loader in Houdini 18 as it returns 'long' instead of 'int'

### DIFF
--- a/avalon/tools/delegates.py
+++ b/avalon/tools/delegates.py
@@ -1,3 +1,5 @@
+import numbers
+
 from ..vendor.Qt import QtWidgets, QtCore
 from .. import io
 
@@ -16,7 +18,7 @@ class VersionDelegate(QtWidgets.QStyledItemDelegate):
         return "v{0:03d}".format(value)
 
     def displayText(self, value, locale):
-        assert isinstance(value, int), "Version is not `int`"
+        assert isinstance(value, numbers.Integral), "Version is not integer"
         return self._format_version(value)
 
     def createEditor(self, parent, option, index):
@@ -46,7 +48,7 @@ class VersionDelegate(QtWidgets.QStyledItemDelegate):
 
         # Current value of the index
         value = index.data(QtCore.Qt.DisplayRole)
-        assert isinstance(value, int), "Version is not `int`"
+        assert isinstance(value, numbers.Integral), "Version is not integer"
 
         # Add all available versions to the editor
         item = index.data(TreeModel.ItemRole)


### PR DESCRIPTION
**What's changed?**

It seems somehow the returned version number is not an `int` in Houdini 18 but a `long`. As such, the assertion in the `VersionDelegate` would catch it incorrectly. 

This is now resolved by checking it against `numbers.Integral` to ensure it's also Python 3+ proof where `long` no longer exists.
