### PR TITLE
Porting#438

### DIFF
--- a/avalon/nuke/__init__.py
+++ b/avalon/nuke/__init__.py
@@ -33,6 +33,7 @@ from .pipeline import (
     containerise,
     parse_container,
     update_container,
+    get_handles,
 
     # Experimental
     viewer_update_and_undo_stop,
@@ -59,6 +60,7 @@ __all__ = [
     "containerise",
     "parse_container",
     "update_container",
+    "get_handles",
 
     "read",
 

--- a/avalon/nuke/__init__.py
+++ b/avalon/nuke/__init__.py
@@ -6,6 +6,7 @@ Anything that isn't defined here is INTERNAL and unreliable for external use.
 
 from .lib import (
     maintained_selection,
+    imprint,
     read,
 
     add_publish_knob,
@@ -62,6 +63,7 @@ __all__ = [
     "update_container",
     "get_handles",
 
+    "imprint",
     "read",
 
     # Experimental

--- a/avalon/nuke/command.py
+++ b/avalon/nuke/command.py
@@ -1,0 +1,136 @@
+
+import logging
+import contextlib
+import nuke
+
+from .. import api, io
+
+
+log = logging.getLogger(__name__)
+
+
+def reset_frame_range():
+    """ Set frame range to current asset
+        Also it will set a Viewer range with
+        displayed handles
+    """
+
+    fps = float(api.Session.get("AVALON_FPS", 25))
+
+    nuke.root()["fps"].setValue(fps)
+    name = api.Session["AVALON_ASSET"]
+    asset = io.find_one({"name": name, "type": "asset"})
+    asset_data = asset["data"]
+
+    handles = get_handles(asset)
+
+    frame_start = int(asset_data.get(
+        "frameStart",
+        asset_data.get("edit_in")))
+
+    frame_end = int(asset_data.get(
+        "frameEnd",
+        asset_data.get("edit_out")))
+
+    if not all([frame_start, frame_end]):
+        missing = ", ".join(["frame_start", "frame_end"])
+        msg = "'{}' are not set for asset '{}'!".format(missing, name)
+        log.warning(msg)
+        nuke.message(msg)
+        return
+
+    frame_start -= handles
+    frame_end += handles
+
+    nuke.root()["first_frame"].setValue(frame_start)
+    nuke.root()["last_frame"].setValue(frame_end)
+
+    # setting active viewers
+    vv = nuke.activeViewer().node()
+    vv["frame_range_lock"].setValue(True)
+    vv["frame_range"].setValue("{0}-{1}".format(
+        int(asset_data["frameStart"]),
+        int(asset_data["frameEnd"]))
+    )
+
+
+def get_handles(asset):
+    """ Gets handles data
+
+    Arguments:
+        asset (dict): avalon asset entity
+
+    Returns:
+        handles (int)
+    """
+    data = asset["data"]
+    if "handles" in data and data["handles"] is not None:
+        return int(data["handles"])
+
+    parent_asset = None
+    if "visualParent" in data:
+        vp = data["visualParent"]
+        if vp is not None:
+            parent_asset = io.find_one({"_id": io.ObjectId(vp)})
+
+    if parent_asset is None:
+        parent_asset = io.find_one({"_id": io.ObjectId(asset["parent"])})
+
+    if parent_asset is not None:
+        return get_handles(parent_asset)
+    else:
+        return 0
+
+
+def reset_resolution():
+    """Set resolution to project resolution."""
+    project = io.find_one({"type": "project"})
+    p_data = project["data"]
+
+    width = p_data.get("resolution_width",
+                       p_data.get("resolutionWidth"))
+    height = p_data.get("resolution_height",
+                        p_data.get("resolutionHeight"))
+
+    if not all([width, height]):
+        missing = ", ".join(["width", "height"])
+        msg = "No resolution information `{0}` found for '{1}'.".format(
+            missing,
+            project["name"])
+        log.warning(msg)
+        nuke.message(msg)
+        return
+
+    current_width = nuke.root()["format"].value().width()
+    current_height = nuke.root()["format"].value().height()
+
+    if width != current_width or height != current_height:
+
+        fmt = None
+        for f in nuke.formats():
+            if f.width() == width and f.height() == height:
+                fmt = f.name()
+
+        if not fmt:
+            nuke.addFormat(
+                "{0} {1} {2}".format(int(width), int(height), project["name"])
+            )
+            fmt = project["name"]
+
+        nuke.root()["format"].setValue(fmt)
+
+
+@contextlib.contextmanager
+def viewer_update_and_undo_stop():
+    """Lock viewer from updating and stop recording undo steps"""
+    try:
+        # stop active viewer to update any change
+        viewer = nuke.activeViewer()
+        if viewer:
+            viewer.stop()
+        else:
+            log.warning("No available active Viewer")
+        nuke.Undo.disable()
+        yield
+    finally:
+        nuke.Undo.enable()

--- a/avalon/nuke/lib.py
+++ b/avalon/nuke/lib.py
@@ -387,13 +387,9 @@ def fix_data_for_node_create(data):
     """Fixing data to be used for nuke knobs
     """
     for k, v in data.items():
-        try:
-            if isinstance(v, unicode):
-                data[k] = str(v)
-        except Exception:
+        if isinstance(v, six.text_type):
             data[k] = str(v)
-
-        if "0x" in str(v):
+        if str(v).startswith("0x"):
             data[k] = int(v, 16)
     return data
 

--- a/avalon/nuke/lib.py
+++ b/avalon/nuke/lib.py
@@ -12,6 +12,14 @@ log = logging.getLogger(__name__)
 
 @contextlib.contextmanager
 def maintained_selection():
+    """Maintain selection during context
+
+    Example:
+        >>> with maintained_selection():
+        ...     node['selected'].setValue(True)
+        >>> print(node['selected'].value())
+        False
+    """
     previous_selection = nuke.selectedNodes()
     try:
         yield
@@ -357,6 +365,8 @@ def get_avalon_knob_data(node, prefix="avalon:"):
 
 
 def fix_data_for_node_create(data):
+    """Fixing data to be used for nuke knobs
+    """
     for k, v in data.items():
 
         data[k] = str(v)
@@ -371,6 +381,15 @@ def fix_data_for_node_create(data):
 
 
 def add_write_node(name, **kwarg):
+    """Adding nuke write node
+
+    Arguments:
+        name (str): nuke node name
+        kwarg (attrs): data for nuke knobs
+
+    Returns:
+        node (obj): nuke write node
+    """
     frame_range = kwarg.get("frame_range", None)
 
     w = nuke.createNode(
@@ -401,24 +420,24 @@ def add_write_node(name, **kwarg):
 def get_node_path(path, padding=4):
     """Get filename for the Nuke write with padded number as '#'
 
-    >>> get_frame_path("test.exr")
-    ('test', 4, '.exr')
-
-    >>> get_frame_path("filename.#####.tif")
-    ('filename.', 5, '.tif')
-
-    >>> get_frame_path("foobar##.tif")
-    ('foobar', 2, '.tif')
-
-    >>> get_frame_path("foobar_%08d.tif")
-    ('foobar_', 8, '.tif')
-
-    Args:
+    Arguments:
         path (str): The path to render to.
 
     Returns:
         tuple: head, padding, tail (extension)
 
+    Examples:
+        >>> get_frame_path("test.exr")
+        ('test', 4, '.exr')
+
+        >>> get_frame_path("filename.#####.tif")
+        ('filename.', 5, '.tif')
+
+        >>> get_frame_path("foobar##.tif")
+        ('foobar', 2, '.tif')
+
+        >>> get_frame_path("foobar_%08d.tif")
+        ('foobar_', 8, '.tif')
     """
     filename, ext = os.path.splitext(path)
 

--- a/avalon/nuke/lib.py
+++ b/avalon/nuke/lib.py
@@ -368,14 +368,13 @@ def fix_data_for_node_create(data):
     """Fixing data to be used for nuke knobs
     """
     for k, v in data.items():
+        try:
+            if isinstance(v, unicode):
+                data[k] = str(v)
+        except Exception:
+            data[k] = str(v)
 
-        data[k] = str(v)
-
-        if "True" in v:
-            data[k] = True
-        if "False" in v:
-            data[k] = False
-        if "0x" in v:
+        if "0x" in str(v):
             data[k] = int(v, 16)
     return data
 

--- a/avalon/nuke/lib.py
+++ b/avalon/nuke/lib.py
@@ -412,7 +412,6 @@ def add_write_node(name, **kwarg):
         w["first"].setValue(frame_range[0])
         w["last"].setValue(frame_range[1])
 
-    log.info(w)
     return w
 
 

--- a/avalon/nuke/pipeline.py
+++ b/avalon/nuke/pipeline.py
@@ -155,6 +155,8 @@ def update_container(node, keys=None):
 
 
 class Creator(api.Creator):
+    """Creator class wrapper
+    """
     def process(self):
         nodes = nuke.allNodes()
 
@@ -242,7 +244,7 @@ def get_main_window():
 
 
 def uninstall(config):
-    """Uninstall all tha was installed
+    """Uninstall all that was previously installed
 
     This is where you undo everything that was done in `install()`.
     That means, removing menus, deregistering families and  data
@@ -262,6 +264,8 @@ def uninstall(config):
 
 
 def _install_menu():
+    """Installing Avalon menu to Nuke
+    """
     from ..tools import (
         creator,
         publish,
@@ -310,6 +314,8 @@ def _install_menu():
 
 
 def _uninstall_menu():
+    """Uninstalling Avalon menu to Nuke
+    """
     menubar = nuke.menu("Nuke")
     menubar.removeItem(api.Session["AVALON_LABEL"])
 

--- a/avalon/nuke/pipeline.py
+++ b/avalon/nuke/pipeline.py
@@ -155,15 +155,14 @@ class Creator(api.Creator):
     """Creator class wrapper
     """
     def process(self):
-        nodes = nuke.allNodes()
-
         if (self.options or {}).get("useSelection"):
             nodes = nuke.selectedNodes()
 
-        nodes = [n for n in nodes
-                 if n["name"].value() in self.name] or None
+        if len(nodes) > 0:
+            node = nodes[0]
+        elif len(nodes) > 1:
+            nuke.message("Please select only one node")
 
-        node = nodes[0]
         lib.set_avalon_knob_data(node, self.data)
         lib.add_publish_knob(node)
         instance = node

--- a/avalon/nuke/pipeline.py
+++ b/avalon/nuke/pipeline.py
@@ -3,6 +3,7 @@ import sys
 import importlib
 import logging
 from collections import OrderedDict
+from __builtin__ import reload
 
 import nuke
 from pyblish import api as pyblish

--- a/avalon/nuke/pipeline.py
+++ b/avalon/nuke/pipeline.py
@@ -153,18 +153,37 @@ def update_container(node, keys=None):
 class Creator(api.Creator):
     """Creator class wrapper
     """
+    node_color = "0xdfea5dff"
+
     def process(self):
+        from nukescripts import autoBackdrop
+
+        instance = None
+
         if (self.options or {}).get("useSelection"):
+
             nodes = nuke.selectedNodes()
+            if not nodes:
+                nuke.message("Please select nodes that you "
+                             "wish to add to a container")
+                return
 
-        if len(nodes) > 0:
-            node = nodes[0]
-        elif len(nodes) > 1:
-            nuke.message("Please select only one node")
+            elif len(nodes) == 1:
+                # only one node is selected
+                instance = nodes[0]
 
-        lib.set_avalon_knob_data(node, self.data)
-        lib.add_publish_knob(node)
-        instance = node
+        if not instance:
+            # Not using selection or multiple nodes selected
+            bckd_node = autoBackdrop()
+            bckd_node["tile_color"].setValue(int(self.node_color, 16))
+            bckd_node["note_font_size"].setValue(24)
+            bckd_node["label"].setValue("[{}]".format(self.name))
+
+            instance = bckd_node
+
+        # add avalon knobs
+        lib.set_avalon_knob_data(instance, self.data)
+        lib.add_publish_knob(instance)
 
         return instance
 

--- a/avalon/nuke/pipeline.py
+++ b/avalon/nuke/pipeline.py
@@ -460,13 +460,12 @@ def viewer_update_and_undo_stop():
     """Lock viewer from updating and stop recording undo steps"""
     try:
         # stop active viewer to update any change
-        try:
-            nuke.activeViewer().stop()
-        except Exception as e:
-            log.warning("No available active Viewer: `{}`".format(e))
+        viewer = nuke.activeViewer()
+        if viewer:
+            viewer.stop()
+        else:
+            log.warning("No available active Viewer")
         nuke.Undo.disable()
         yield
     finally:
-        # nuke.Root().knob('lock_connections').setValue(0)
-        # nuke.activeViewer().start()
         nuke.Undo.enable()

--- a/avalon/nuke/pipeline.py
+++ b/avalon/nuke/pipeline.py
@@ -1,15 +1,14 @@
 import os
 import sys
 import importlib
-import contextlib
 import logging
 from collections import OrderedDict
 
 import nuke
 from pyblish import api as pyblish
 
-from . import lib
-from .. import api, io
+from . import lib, command
+from .. import api
 from ..vendor.Qt import QtWidgets
 from ..pipeline import AVALON_CONTAINER_ID
 
@@ -303,8 +302,8 @@ def _install_menu():
                     )
 
     menu.addSeparator()
-    menu.addCommand("Reset Frame Range", reset_frame_range_handles)
-    menu.addCommand("Reset Resolution", reset_resolution)
+    menu.addCommand("Reset Frame Range", command.reset_frame_range)
+    menu.addCommand("Reset Resolution", command.reset_resolution)
 
     # add reload pipeline only in debug mode
     if bool(os.getenv("NUKE_DEBUG")):
@@ -317,117 +316,6 @@ def _uninstall_menu():
     """
     menubar = nuke.menu("Nuke")
     menubar.removeItem(api.Session["AVALON_LABEL"])
-
-
-def reset_frame_range_handles():
-    """ Set frame range to current asset
-        Also it will set a Viewer range with
-        displayed handles
-    """
-
-    fps = float(api.Session.get("AVALON_FPS", 25))
-
-    nuke.root()["fps"].setValue(fps)
-    name = api.Session["AVALON_ASSET"]
-    asset = io.find_one({"name": name, "type": "asset"})
-    asset_data = asset["data"]
-
-    handles = get_handles(asset)
-
-    frame_start = int(asset_data.get(
-        "frameStart",
-        asset_data.get("edit_in")))
-
-    frame_end = int(asset_data.get(
-        "frameEnd",
-        asset_data.get("edit_out")))
-
-    if not all([frame_start, frame_end]):
-        missing = ", ".join(["frame_start", "frame_end"])
-        msg = "'{}' are not set for asset '{}'!".format(missing, name)
-        log.warning(msg)
-        nuke.message(msg)
-        return
-
-    frame_start -= handles
-    frame_end += handles
-
-    nuke.root()["first_frame"].setValue(frame_start)
-    nuke.root()["last_frame"].setValue(frame_end)
-
-    # setting active viewers
-    vv = nuke.activeViewer().node()
-    vv['frame_range_lock'].setValue(True)
-    vv['frame_range'].setValue('{0}-{1}'.format(
-        int(asset_data["frameStart"]),
-        int(asset_data["frameEnd"]))
-    )
-
-
-def get_handles(asset):
-    """ Gets handles data
-
-    Arguments:
-        asset (dict): avalon asset entity
-
-    Returns:
-        handles (int)
-    """
-    data = asset["data"]
-    if "handles" in data and data["handles"] is not None:
-        return int(data["handles"])
-
-    parent_asset = None
-    if "visualParent" in data:
-        vp = data["visualParent"]
-        if vp is not None:
-            parent_asset = io.find_one({"_id": io.ObjectId(vp)})
-
-    if parent_asset is None:
-        parent_asset = io.find_one({"_id": io.ObjectId(asset['parent'])})
-
-    if parent_asset is not None:
-        return get_handles(parent_asset)
-    else:
-        return 0
-
-
-def reset_resolution():
-    """Set resolution to project resolution."""
-    project = io.find_one({"type": "project"})
-    p_data = project["data"]
-
-    width = p_data.get("resolution_width",
-                       p_data.get("resolutionWidth"))
-    height = p_data.get("resolution_height",
-                        p_data.get("resolutionHeight"))
-
-    if not all([width, height]):
-        missing = ", ".join(["width", "height"])
-        msg = "No resolution information `{0}` found for '{1}'.".format(
-            missing,
-            project["name"])
-        log.warning(msg)
-        nuke.message(msg)
-        return
-
-    current_width = nuke.root()["format"].value().width()
-    current_height = nuke.root()["format"].value().height()
-
-    if width != current_width or height != current_height:
-
-        fmt = None
-        for f in nuke.formats():
-            if f.width() == width and f.height() == height:
-                fmt = f.name()
-
-        if not fmt:
-            nuke.addFormat(
-                "{0} {1} {2}".format(int(width), int(height), project["name"])
-            )
-            fmt = project["name"]
-
-        nuke.root()["format"].setValue(fmt)
 
 
 def publish():
@@ -449,17 +337,8 @@ def _on_task_changed(*args):
     _install_menu()
 
 
-@contextlib.contextmanager
-def viewer_update_and_undo_stop():
-    """Lock viewer from updating and stop recording undo steps"""
-    try:
-        # stop active viewer to update any change
-        viewer = nuke.activeViewer()
-        if viewer:
-            viewer.stop()
-        else:
-            log.warning("No available active Viewer")
-        nuke.Undo.disable()
-        yield
-    finally:
-        nuke.Undo.enable()
+# Backwards compatibility
+reset_frame_range_handles = command.reset_frame_range
+get_handles = command.get_handles
+reset_resolution = command.reset_resolution
+viewer_update_and_undo_stop = command.viewer_update_and_undo_stop

--- a/avalon/nuke/pipeline.py
+++ b/avalon/nuke/pipeline.py
@@ -330,13 +330,7 @@ def reset_frame_range_handles():
     nuke.root()["fps"].setValue(fps)
     name = api.Session["AVALON_ASSET"]
     asset = io.find_one({"name": name, "type": "asset"})
-    asset_data = asset.get("data")
-
-    if not asset_data:
-        msg = "Asset {} don't have set any 'data'".format(name)
-        log.warning(msg)
-        nuke.message(msg)
-        return
+    asset_data = asset["data"]
 
     handles = get_handles(asset)
 

--- a/avalon/nuke/pipeline.py
+++ b/avalon/nuke/pipeline.py
@@ -341,6 +341,32 @@ def reset_frame_range():
 
     nuke.root()["first_frame"].setValue(edit_in)
     nuke.root()["last_frame"].setValue(edit_out)
+def get_handles(asset):
+    """ Gets handles data
+
+    Arguments:
+        asset (dict): avalon asset entity
+
+    Returns:
+        handles (int)
+    """
+    data = asset["data"]
+    if "handles" in data and data["handles"] is not None:
+        return int(data["handles"])
+
+    parent_asset = None
+    if "visualParent" in data:
+        vp = data["visualParent"]
+        if vp is not None:
+            parent_asset = io.find_one({"_id": io.ObjectId(vp)})
+
+    if parent_asset is None:
+        parent_asset = io.find_one({"_id": io.ObjectId(asset['parent'])})
+
+    if parent_asset is not None:
+        return get_handles(parent_asset)
+    else:
+        return 0
 
 
 def reset_resolution():

--- a/avalon/nuke/pipeline.py
+++ b/avalon/nuke/pipeline.py
@@ -459,12 +459,11 @@ def _on_task_changed(*args):
 def viewer_update_and_undo_stop():
     """Lock viewer from updating and stop recording undo steps"""
     try:
-        # nuke = getattr(sys.modules["__main__"], "nuke", None)
-        # lock all connections between nodes
-        # nuke.Root().knob('lock_connections').setValue(1)
-
         # stop active viewer to update any change
-        nuke.activeViewer().stop()
+        try:
+            nuke.activeViewer().stop()
+        except Exception as e:
+            log.warning("No available active Viewer: `{}`".format(e))
         nuke.Undo.disable()
         yield
     finally:

--- a/avalon/nuke/pipeline.py
+++ b/avalon/nuke/pipeline.py
@@ -180,13 +180,14 @@ def ls():
     See the `container.json` schema for details on how it should look,
     and the Maya equivalent, which is in `avalon.maya.pipeline`
     """
-    all_nodes = nuke.allNodes(recurseGroups=True)
+    all_nodes = nuke.allNodes(recurseGroups=False)
 
     # TODO: add readgeo, readcamera, readimage
-    reads = [n for n in all_nodes if n.Class() == 'Read']
+    nodes = [n for n in all_nodes]
 
-    for r in reads:
-        container = parse_container(r)
+    for n in nodes:
+        log.debug("name: `{}`".format(n.name()))
+        container = parse_container(n)
         if container:
             yield container
 

--- a/avalon/nuke/pipeline.py
+++ b/avalon/nuke/pipeline.py
@@ -399,16 +399,20 @@ def get_handles(asset):
 def reset_resolution():
     """Set resolution to project resolution."""
     project = io.find_one({"type": "project"})
+    p_data = project["data"]
 
-    try:
-        width = project["data"].get("resolution_width", 1920)
-        height = project["data"].get("resolution_height", 1080)
-    except KeyError:
-        print(
-            "No resolution information found for \"{0}\".".format(
-                project["name"]
-            )
-        )
+    width = p_data.get("resolution_width",
+                       p_data.get("resolutionWidth"))
+    height = p_data.get("resolution_height",
+                        p_data.get("resolutionHeight"))
+
+    if not all([width, height]):
+        missing = ", ".join(["width", "height"])
+        msg = "No resolution information `{0}` found for '{1}'.".format(
+            missing,
+            project["name"])
+        log.warning(msg)
+        nuke.message(msg)
         return
 
     current_width = nuke.root()["format"].value().width()

--- a/avalon/nuke/pipeline.py
+++ b/avalon/nuke/pipeline.py
@@ -303,11 +303,13 @@ def _install_menu():
                     )
 
     menu.addSeparator()
-    menu.addCommand("Reset Frame Range", reset_frame_range)
+    menu.addCommand("Reset Frame Range", reset_frame_range_handles)
     menu.addCommand("Reset Resolution", reset_resolution)
 
-    menu.addSeparator()
-    menu.addCommand("Reload Pipeline", reload_pipeline)
+    # add reload pipeline only in debug mode
+    if bool(os.getenv("NUKE_DEBUG")):
+        menu.addSeparator()
+        menu.addCommand("Reload Pipeline", reload_pipeline)
 
 
 def _uninstall_menu():

--- a/avalon/nuke/pipeline.py
+++ b/avalon/nuke/pipeline.py
@@ -33,28 +33,25 @@ def reload_pipeline():
     api.uninstall()
     _uninstall_menu()
 
-    for module in ("avalon.io",
+    for module in ("avalon.api",
+                   "avalon.io",
                    "avalon.lib",
                    "avalon.pipeline",
-                   "avalon.nuke.pipeline",
-                   "avalon.nuke.lib",
-                   "avalon.tools.loader.app",
-                   "avalon.tools.creator.app",
-                   "avalon.tools.manager.app",
-
-                   "avalon.api",
                    "avalon.tools",
                    "avalon.nuke",
-                   "{}".format(AVALON_CONFIG),
-                   "{}.lib".format(AVALON_CONFIG)):
+                   "avalon.nuke.pipeline",
+                   "avalon.nuke.lib",
+                   "avalon.nuke.workio"
+                   ):
+
         log.info("Reloading module: {}...".format(module))
+
         module = importlib.import_module(module)
-        importlib.reload(module)
+        reload(module)
 
     import avalon.nuke
     api.install(avalon.nuke)
 
-    _install_menu()
     _register_events()
 
 


### PR DESCRIPTION
This PR is aim to resolve #438.

PR #438 was huge, and a few parts of it was build on top of old tech-debt. But after PR #471, #473, #476, I think this is the final piece to finish up the rest.

### What's changed

* `nuke.ls` now listing containers from all types of nodes, not just `Read` type node.
* Changed `nuke.Creator` to allow instance to have multiple nodes with backdrop.
* Added `nuke.command` and move util functions from `nuke.pipeline` to there. (Backwards compatible)
* Added a few helper functions to `nuke.lib`

Please let me know if there's anything missing or broken. @jezscha 
