### PR TITLE
Fix #485: Allow avalon to initialize correctly with Maya 2020

### DIFF
--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -274,7 +274,7 @@ def reload_pipeline(*args):
 def _uninstall_menu():
     
     # In Maya 2020+ don't use the QApplication.instance()
-    # during startup (userSetup.py) as it will return about
+    # during startup (userSetup.py) as it will return a
     # QtCore.QCoreApplication instance which does not have
     # the allWidgets method. As such, we call the staticmethod.
     all_widgets = QtWidgets.QApplication.allWidgets()


### PR DESCRIPTION
**What's changed?**

This fixes #485 so that Avalon launches without errors in Maya 2020. Without this change the Avalon menu would not initialize with Avalon's `userSetup.py` for Maya and would give errors in the Output Window.

I've tested this change in Maya 2019 and 2020. 