### PR TITLE
Fix #487: Preserve loader styling in Maya 2020

### DIFF
--- a/avalon/style/style.qss
+++ b/avalon/style/style.qss
@@ -1220,3 +1220,7 @@ QSplitter::handle:horizontal:hover {
     background-color: #787876;
     border: 1px solid #3A3939;
 }
+
+QSplitter {
+    border: 0px;
+}

--- a/avalon/tools/loader/app.py
+++ b/avalon/tools/loader/app.py
@@ -58,9 +58,6 @@ class Window(QtWidgets.QDialog):
         split.addWidget(version)
         split.setSizes([180, 950, 200])
 
-        # Remove QSplitter border
-        split.setStyleSheet("QSplitter { border: 0px; }")
-
         container_layout.addWidget(split)
 
         body_layout = QtWidgets.QHBoxLayout(body)


### PR DESCRIPTION
**What's changed?**

This fixes #487 by avoiding the need to set a stylesheet to the `QSplitter` and instead have it be applied in the global avalon stylesheet.

I felt this was the best approach from the proposed solutions as it required the least amount of code, plus allows anyone to still override any styling themselves if they'd want.

Note: to test this with Maya 2020 you'll need #486 if you want to have Maya set up the Avalon menu correctly. You could still test it without that code, but you'd need to show the Avalon Loader through code manually.