### PR TITLE
Prompt proper message if no creator plugin been found

### DIFF
--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -295,10 +295,11 @@ class Window(QtWidgets.QDialog):
         # Get the asset from the database which match with the name
         asset = io.find_one({"name": asset_name, "type": "asset"},
                             projection={"_id": 1})
+        # Get plugin
+        plugin = item.data(PluginRole)
 
-        if asset:
-            # Get plugin and family
-            plugin = item.data(PluginRole)
+        if asset and plugin:
+            # Get family
             family = plugin.family.rsplit(".", 1)[-1]
 
             # Get all subsets of the current asset
@@ -340,7 +341,11 @@ class Window(QtWidgets.QDialog):
         else:
             self._build_menu([])
             item.setData(ExistsRole, False)
-            self.echo("Asset '%s' not found .." % asset_name)
+
+            if not plugin:
+                self.echo("No registered families ..")
+            else:
+                self.echo("Asset '%s' not found .." % asset_name)
 
         # Update the valid state
         valid = (


### PR DESCRIPTION
### What happened ?

If no creator plugin been registered, launching creator tool will raise following error
```python
# Traceback (most recent call last):
#   File "...\avalon-core\avalon\tools\creator\app.py", line 302, in _on_data_changed
#     family = plugin.family.rsplit(".", 1)[-1]
# AttributeError: 'NoneType' object has no attribute 'family'
```
Should prompt a message instead.

### What's changed ?

The "no creator plugin" scenario has been handled plus echoing a message on GUI.
