### PR TITLE
Patch #499: Refactor find_host_config to lib.find_module_in_config

### DIFF
--- a/avalon/fusion/pipeline.py
+++ b/avalon/fusion/pipeline.py
@@ -2,9 +2,10 @@ import sys
 import contextlib
 import importlib
 import logging
-from pyblish import api as pyblish
-from avalon import api as avalon
 
+import pyblish.api
+
+from .. import api
 from ..pipeline import AVALON_CONTAINER_ID
 from ..lib import find_submodule
 
@@ -31,16 +32,16 @@ def ls():
 
     comp = get_current_comp()
     tools = comp.GetToolList(False, "Loader").values()
-    
+
     has_metadata_collector = False
     config_host = find_submodule(api.registered_config(), "fusion")
     if hasattr(config_host, "collect_container_metadata"):
         has_metadata_collector = True
-    
+
     for tool in tools:
         container = parse_container(tool)
         if container:
-        
+
             if has_metadata_collector:
                 metadata = config_host.collect_container_metadata(container)
                 container.update(metadata)
@@ -59,7 +60,7 @@ def install(config):
     # TODO: Set project
     # TODO: Install Fusion menu (this is done with config .fu script actually)
 
-    pyblish.register_host("fusion")
+    pyblish.api.register_host("fusion")
 
     # Remove all handlers associated with the root logger object, because
     # that one sometimes logs as "warnings" incorrectly.
@@ -73,7 +74,7 @@ def install(config):
     handler.setFormatter(formatter)
     logger.addHandler(handler)
     logger.setLevel(logging.DEBUG)
-        
+
 
 def uninstall(config):
     """Uninstall Fusion-specific functionality of avalon-core.

--- a/avalon/fusion/pipeline.py
+++ b/avalon/fusion/pipeline.py
@@ -6,7 +6,7 @@ from pyblish import api as pyblish
 from avalon import api as avalon
 
 from ..pipeline import AVALON_CONTAINER_ID
-from ..lib import find_module_in_config
+from ..lib import find_submodule
 
 
 class CompLogHandler(logging.Handler):
@@ -33,7 +33,7 @@ def ls():
     tools = comp.GetToolList(False, "Loader").values()
     
     has_metadata_collector = False
-    config_host = find_module_in_config(api.registered_config(), "fusion")
+    config_host = find_submodule(api.registered_config(), "fusion")
     if hasattr(config_host, "collect_container_metadata"):
         has_metadata_collector = True
     

--- a/avalon/fusion/pipeline.py
+++ b/avalon/fusion/pipeline.py
@@ -73,11 +73,6 @@ def install(config):
     handler.setFormatter(formatter)
     logger.addHandler(handler)
     logger.setLevel(logging.DEBUG)
-
-    # Trigger install on the config's "fusion" package
-    config_host = find_module_in_config(config, "fusion")
-    if hasattr(config_host, "install"):
-        config_host.install()
         
 
 def uninstall(config):
@@ -89,10 +84,6 @@ def uninstall(config):
         config: configuration module
 
     """
-
-    config_host = find_module_in_config(config, "fusion")
-    if hasattr(config_host, "uninstall"):
-        config_host.uninstall()
 
     pyblish.api.deregister_host("fusion")
 

--- a/avalon/houdini/pipeline.py
+++ b/avalon/houdini/pipeline.py
@@ -219,7 +219,7 @@ def ls():
     if hasattr(config_host, "collect_container_metadata"):
         has_metadata_collector = True
 
-    for container in sorted(container_names):
+    for container in sorted(containers):
         data = parse_container(container)
 
         # Collect custom data if attribute is present

--- a/avalon/houdini/pipeline.py
+++ b/avalon/houdini/pipeline.py
@@ -38,10 +38,6 @@ def install(config):
     pyblish.api.register_host("hpython")
 
     self._has_been_setup = True
-
-    config_host = find_module_in_config(config, "houdini")
-    if hasattr(config_host, "install"):
-        config_host.install()
         
 
 def uninstall(config):
@@ -53,10 +49,6 @@ def uninstall(config):
         config: configuration module
 
     """
-
-    config_host = find_module_in_config(config, "houdini")
-    if hasattr(config_host, "uninstall"):
-        config_host.uninstall()
 
     pyblish.api.deregister_host("hython")
     pyblish.api.deregister_host("hpython")

--- a/avalon/houdini/pipeline.py
+++ b/avalon/houdini/pipeline.py
@@ -10,7 +10,7 @@ import hou
 
 # Local libraries
 from . import lib
-from ..lib import logger
+from ..lib import logger, find_module_in_config
 from avalon import api, schema
 
 from ..pipeline import AVALON_CONTAINER_ID
@@ -39,10 +39,10 @@ def install(config):
 
     self._has_been_setup = True
 
-    config = find_host_config(config)
-    if hasattr(config, "install"):
-        config.install()
-
+    config_host = find_module_in_config(config, "houdini")
+    if hasattr(config_host, "install"):
+        config_host.install()
+        
 
 def uninstall(config):
     """Uninstall Houdini-specific functionality of avalon-core.
@@ -54,25 +54,13 @@ def uninstall(config):
 
     """
 
-    config = find_host_config(config)
-    if hasattr(config, "uninstall"):
-        config.uninstall()
+    config_host = find_module_in_config(config, "houdini")
+    if hasattr(config_host, "uninstall"):
+        config_host.uninstall()
 
     pyblish.api.deregister_host("hython")
     pyblish.api.deregister_host("hpython")
     pyblish.api.deregister_host("houdini")
-
-
-def find_host_config(config):
-    config_name = config.__name__
-    try:
-        config = importlib.import_module(config_name + ".houdini")
-    except ImportError as exc:
-        if str(exc) != "No module name {}".format(config_name + ".houdini"):
-            raise
-        config = None
-
-    return config
 
 
 def get_main_window():
@@ -236,13 +224,17 @@ def ls():
                        "pyblish.mindbender.container"):
         containers += lib.lsattr("id", identifier)
 
-    for container in sorted(containers):
+    has_metadata_collector = False
+    config_host = find_module_in_config(api.registered_config(), "houdini")
+    if hasattr(config_host, "collect_container_metadata"):
+        has_metadata_collector = True
+
+    for container in sorted(container_names):
         data = parse_container(container)
 
         # Collect custom data if attribute is present
-        config = find_host_config(api.registered_config())
-        if hasattr(config, "collect_container_metadata"):
-            metadata = config.collect_container_metadata(container)
+        if has_metadata_collector:
+            metadata = config_host.collect_container_metadata(container)
             data.update(metadata)
 
         yield data

--- a/avalon/houdini/pipeline.py
+++ b/avalon/houdini/pipeline.py
@@ -11,7 +11,7 @@ import hou
 # Local libraries
 from . import lib
 from ..lib import logger, find_submodule
-from avalon import api
+from .. import api
 
 from ..pipeline import AVALON_CONTAINER_ID
 

--- a/avalon/houdini/pipeline.py
+++ b/avalon/houdini/pipeline.py
@@ -10,8 +10,8 @@ import hou
 
 # Local libraries
 from . import lib
-from ..lib import logger, find_module_in_config
-from avalon import api, schema
+from ..lib import logger, find_submodule
+from avalon import api
 
 from ..pipeline import AVALON_CONTAINER_ID
 
@@ -38,7 +38,7 @@ def install(config):
     pyblish.api.register_host("hpython")
 
     self._has_been_setup = True
-        
+
 
 def uninstall(config):
     """Uninstall Houdini-specific functionality of avalon-core.
@@ -68,8 +68,6 @@ def reload_pipeline(*args):
     CAUTION: This is primarily for development and debugging purposes.
 
     """
-
-    import importlib
 
     api.uninstall()
 
@@ -217,7 +215,7 @@ def ls():
         containers += lib.lsattr("id", identifier)
 
     has_metadata_collector = False
-    config_host = find_module_in_config(api.registered_config(), "houdini")
+    config_host = find_submodule(api.registered_config(), "houdini")
     if hasattr(config_host, "collect_container_metadata"):
         has_metadata_collector = True
 

--- a/avalon/lib.py
+++ b/avalon/lib.py
@@ -300,4 +300,4 @@ def find_module_in_config(config, module):
         return importlib.import_module(module_name)
     except ImportError as exc:
         if str(exc) != "No module name {}".format(module_name):
-            log.warning("Config has no '%s' module." % module_name)
+            log_.warning("Config has no '%s' module." % module_name)

--- a/avalon/lib.py
+++ b/avalon/lib.py
@@ -5,6 +5,7 @@ import sys
 import json
 import logging
 import datetime
+import importlib
 import subprocess
 import types
 
@@ -281,23 +282,23 @@ def modules_from_path(path):
         modules.append(module)
 
     return modules
-    
-    
-def find_module_in_config(config, module):
-    """Find and return submodule of the config.
-    
+
+
+def find_submodule(module, submodule):
+    """Find and return submodule of the module.
+
     Args:
-        config (types.ModuleType): The config to search in.
-        module (str): The config's submodule to search.
-    
+        module (types.ModuleType): The module to search in.
+        submodule (str): The submodule name to find.
+
     Returns:
         types.ModuleType or None: The module, if found.
-        
+
     """
-    config_name = config.__name__
-    module_name = "%s.%s" % (config_name, module)
+    name = "%s.%s" % (module.__name__, submodule)
     try:
-        return importlib.import_module(module_name)
+        return importlib.import_module(name)
     except ImportError as exc:
-        if str(exc) != "No module name {}".format(module_name):
-            log_.warning("Config has no '%s' module." % module_name)
+        if str(exc) != "No module name {}".format(name):
+            log_.warning("Could not find '%s' in module: %s" % (submodule,
+                                                                module))

--- a/avalon/lib.py
+++ b/avalon/lib.py
@@ -281,3 +281,23 @@ def modules_from_path(path):
         modules.append(module)
 
     return modules
+    
+    
+def find_module_in_config(config, module):
+    """Find and return submodule of the config.
+    
+    Args:
+        config (types.ModuleType): The config to search in.
+        module (str): The config's submodule to search.
+    
+    Returns:
+        types.ModuleType or None: The module, if found.
+        
+    """
+    config_name = config.__name__
+    module_name = "%s.%s" % (config_name, module)
+    try:
+        return importlib.import_module(module_name)
+    except ImportError as exc:
+        if str(exc) != "No module name {}".format(module_name):
+            log.warning("Config has no '%s' module." % module_name)

--- a/avalon/lib.py
+++ b/avalon/lib.py
@@ -237,7 +237,7 @@ def modules_from_path(path):
     """Get python scripts as modules from a path.
 
     Arguments:
-        path (str): Path to python scrips.
+        path (str): Path to folder containing python scripts.
 
     Returns:
         List of modules.
@@ -276,7 +276,7 @@ def modules_from_path(path):
             sys.modules[mod_name] = module
 
         except Exception as err:
-            print("Skipped: \"%s\" (%s)", mod_name, err)
+            print("Skipped: \"{0}\" ({1})".format(mod_name, err))
             continue
 
         modules.append(module)

--- a/avalon/lib.py
+++ b/avalon/lib.py
@@ -300,5 +300,6 @@ def find_submodule(module, submodule):
         return importlib.import_module(name)
     except ImportError as exc:
         if str(exc) != "No module name {}".format(name):
-            log_.warning("Could not find '%s' in module: %s" % (submodule,
-                                                                module))
+            log_.warning("Could not find '%s' in module: %s",
+                         submodule,
+                         module)

--- a/avalon/lib.py
+++ b/avalon/lib.py
@@ -295,7 +295,7 @@ def find_submodule(module, submodule):
         types.ModuleType or None: The module, if found.
 
     """
-    name = "%s.%s" % (module.__name__, submodule)
+    name = "{0}.{1}".format(module.__name__, submodule)
     try:
         return importlib.import_module(name)
     except ImportError as exc:

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -10,7 +10,7 @@ import maya.api.OpenMaya as om
 from pyblish import api as pyblish
 
 from . import lib, compat
-from ..lib import logger
+from ..lib import logger, find_module_in_config
 from .. import api, schema
 from ..tools import workfiles
 from ..vendor.Qt import QtCore, QtWidgets
@@ -57,10 +57,10 @@ def install(config):
     pyblish.register_host("mayabatch")
     pyblish.register_host("mayapy")
     pyblish.register_host("maya")
-
-    config = find_host_config(config)
-    if hasattr(config, "install"):
-        config.install()
+    
+    config_host = find_module_in_config(config, "maya")
+    if hasattr(config_host, "install"):
+        config_host.install()
 
 
 def _set_project():
@@ -84,17 +84,6 @@ def _set_project():
     cmds.workspace(workdir, openWorkspace=True)
 
 
-def find_host_config(config):
-    try:
-        config = importlib.import_module(config.__name__ + ".maya")
-    except ImportError as exc:
-        if str(exc) != "No module name {}".format(config.__name__ + ".maya"):
-            raise
-        config = None
-
-    return config
-
-
 def get_main_window():
     """Acquire Maya's main window"""
     if self._parent is None:
@@ -111,9 +100,9 @@ def uninstall(config):
     This function is called automatically on calling `api.uninstall()`.
 
     """
-    config = find_host_config(config)
-    if hasattr(config, "uninstall"):
-        config.uninstall()
+    config_host = find_module_in_config(config, "maya")
+    if hasattr(config_host, "uninstall"):
+        config_host.uninstall()
 
     _uninstall_menu()
 
@@ -517,8 +506,8 @@ def ls():
     container_names = _ls()
 
     has_metadata_collector = False
-    config = find_host_config(api.registered_config())
-    if hasattr(config, "collect_container_metadata"):
+    config_host = find_module_in_config(api.registered_config(), "maya")
+    if hasattr(config_host, "collect_container_metadata"):
         has_metadata_collector = True
 
     for container in sorted(container_names):
@@ -526,7 +515,7 @@ def ls():
 
         # Collect custom data if attribute is present
         if has_metadata_collector:
-            metadata = config.collect_container_metadata(container)
+            metadata = config_host.collect_container_metadata(container)
             data.update(metadata)
 
         yield data

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -57,10 +57,6 @@ def install(config):
     pyblish.register_host("mayabatch")
     pyblish.register_host("mayapy")
     pyblish.register_host("maya")
-    
-    config_host = find_module_in_config(config, "maya")
-    if hasattr(config_host, "install"):
-        config_host.install()
 
 
 def _set_project():
@@ -100,9 +96,6 @@ def uninstall(config):
     This function is called automatically on calling `api.uninstall()`.
 
     """
-    config_host = find_module_in_config(config, "maya")
-    if hasattr(config_host, "uninstall"):
-        config_host.uninstall()
 
     _uninstall_menu()
 

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -10,8 +10,8 @@ import maya.api.OpenMaya as om
 from pyblish import api as pyblish
 
 from . import lib, compat
-from ..lib import logger, find_module_in_config
-from .. import api, schema
+from ..lib import logger, find_submodule
+from .. import api
 from ..tools import workfiles
 from ..vendor.Qt import QtCore, QtWidgets
 
@@ -212,8 +212,6 @@ def reload_pipeline(*args):
 
     """
 
-    import importlib
-
     api.uninstall()
 
     for module in ("avalon.io",
@@ -254,13 +252,13 @@ def reload_pipeline(*args):
 
 
 def _uninstall_menu():
-    
+
     # In Maya 2020+ don't use the QApplication.instance()
     # during startup (userSetup.py) as it will return a
     # QtCore.QCoreApplication instance which does not have
     # the allWidgets method. As such, we call the staticmethod.
     all_widgets = QtWidgets.QApplication.allWidgets()
-    
+
     widgets = dict((w.objectName(), w) for w in all_widgets)
     menu = widgets.get(self._menu)
 
@@ -499,7 +497,7 @@ def ls():
     container_names = _ls()
 
     has_metadata_collector = False
-    config_host = find_module_in_config(api.registered_config(), "maya")
+    config_host = find_submodule(api.registered_config(), "maya")
     if hasattr(config_host, "collect_container_metadata"):
         has_metadata_collector = True
 

--- a/avalon/nuke/pipeline.py
+++ b/avalon/nuke/pipeline.py
@@ -10,6 +10,7 @@ from pyblish import api as pyblish
 
 from . import lib, command
 from .. import api
+from ..lib import find_module_in_config
 from ..vendor.Qt import QtWidgets
 from ..pipeline import AVALON_CONTAINER_ID
 
@@ -227,24 +228,13 @@ def install(config):
     _register_events()
 
     pyblish.register_host("nuke")
+    
     # Trigger install on the config's "nuke" package
-    config = find_host_config(config)
-
-    if hasattr(config, "install"):
-        config.install()
+    config_host = find_module_in_config(config, "nuke")
+    if hasattr(config_host, "install"):
+        config_host.install()
 
     log.info("config.nuke installed")
-
-
-def find_host_config(config):
-    try:
-        config = importlib.import_module(config.__name__ + ".nuke")
-    except ImportError as exc:
-        if str(exc) != "No module name {}".format(config.__name__ + ".nuke"):
-            raise
-        config = None
-
-    return config
 
 
 def get_main_window():
@@ -270,9 +260,9 @@ def uninstall(config):
     modifying the menu or registered families.
 
     """
-    config = find_host_config(config)
-    if hasattr(config, "uninstall"):
-        config.uninstall()
+    config_host = find_module_in_config(config, "nuke")
+    if hasattr(config_host, "uninstall"):
+        config_host.uninstall()
 
     _uninstall_menu()
 

--- a/avalon/nuke/pipeline.py
+++ b/avalon/nuke/pipeline.py
@@ -10,7 +10,6 @@ from pyblish import api as pyblish
 
 from . import lib, command
 from .. import api
-from ..lib import find_module_in_config
 from ..vendor.Qt import QtWidgets
 from ..pipeline import AVALON_CONTAINER_ID
 
@@ -228,11 +227,6 @@ def install(config):
     _register_events()
 
     pyblish.register_host("nuke")
-    
-    # Trigger install on the config's "nuke" package
-    config_host = find_module_in_config(config, "nuke")
-    if hasattr(config_host, "install"):
-        config_host.install()
 
     log.info("config.nuke installed")
 
@@ -260,9 +254,6 @@ def uninstall(config):
     modifying the menu or registered families.
 
     """
-    config_host = find_module_in_config(config, "nuke")
-    if hasattr(config_host, "uninstall"):
-        config_host.uninstall()
 
     _uninstall_menu()
 

--- a/avalon/nuke/pipeline.py
+++ b/avalon/nuke/pipeline.py
@@ -28,8 +28,6 @@ def reload_pipeline():
 
     """
 
-    import importlib
-
     api.uninstall()
     _uninstall_menu()
 

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -77,6 +77,11 @@ def install(host):
     # Optional host install function
     if hasattr(host, "install"):
         host.install(config)
+        
+    # Optional config.host.install()
+    config_host = lib.find_module_in_config(config, host.__name__)
+    if hasattr(config_host, "install"):
+        config_host.install()
 
     register_host(host)
     register_config(config)
@@ -104,9 +109,15 @@ def find_config():
 def uninstall():
     """Undo all of what `install()` did"""
     config = registered_config()
-
+    host = registered_host()
+        
+    # Optional config.host.uninstall()
+    config_host = lib.find_module_in_config(config, host.__name__)
+    if hasattr(config_host, "uninstall"):
+        config_host.uninstall()
+    
     try:
-        registered_host().uninstall(config)
+        host.uninstall(config)
     except AttributeError:
         pass
 

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -79,7 +79,8 @@ def install(host):
         host.install(config)
         
     # Optional config.host.install()
-    config_host = lib.find_module_in_config(config, host.__name__)
+    host_name = host.__name__.rsplit(".", 1)[-1]
+    config_host = lib.find_module_in_config(config, host_name)
     if hasattr(config_host, "install"):
         config_host.install()
 
@@ -112,7 +113,8 @@ def uninstall():
     host = registered_host()
         
     # Optional config.host.uninstall()
-    config_host = lib.find_module_in_config(config, host.__name__)
+    host_name = host.__name__.rsplit(".", 1)[-1]
+    config_host = lib.find_module_in_config(config, host_name)
     if hasattr(config_host, "uninstall"):
         config_host.uninstall()
     

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -77,10 +77,10 @@ def install(host):
     # Optional host install function
     if hasattr(host, "install"):
         host.install(config)
-        
+
     # Optional config.host.install()
     host_name = host.__name__.rsplit(".", 1)[-1]
-    config_host = lib.find_module_in_config(config, host_name)
+    config_host = lib.find_submodule(config, host_name)
     if hasattr(config_host, "install"):
         config_host.install()
 
@@ -111,13 +111,13 @@ def uninstall():
     """Undo all of what `install()` did"""
     config = registered_config()
     host = registered_host()
-        
+
     # Optional config.host.uninstall()
     host_name = host.__name__.rsplit(".", 1)[-1]
-    config_host = lib.find_module_in_config(config, host_name)
+    config_host = lib.find_submodule(config, host_name)
     if hasattr(config_host, "uninstall"):
         config_host.uninstall()
-    
+
     try:
         host.uninstall(config)
     except AttributeError:


### PR DESCRIPTION
This PR is related to #499 

This now makes sure the way the `config.{host}` module is retrieved per host matches across each integration using `avalon.lib.find_module_in_config` as a replacement for the `find_host_config` function that each `avalon.{host}` module implemented.

Aside of that, I've made the variable names consistently `config_host` as opposed to replacing the `config` variable that could previously had left some confusion thinking it was the config module, but was actually the `config.{host}` mdoule.

And of course, as per #499 this should now allow `config.{host}` module to not exist at all for each of the integrations with only a logged warning along the lines of: `Config has no '{config}.{host}' module.`

Additionally this makes these changes:

- Add `uninstall()` function to `avalon.fusion` as that was missing.
- Match Houdini and Fusion metadata collecting to Maya implementation, which had an optimization.

### Discussion

**NOTE:** This code should still be tested. However I wanted to set up this PR to discuss the code choices.

1. Is the code clear enough?

2. This imports the `find_module_in_host` function from `avalon.lib` as it became more readable than doing the following. However I believe this was frowned upon by the code style, but I couldn't find that mentioned anywhere.
```python
# in this PR
from ..lib import find_module_in_host
find_module_in_host(config, "maya")

# the other option
import ..lib as avalon_lib
avalon_lib.find_module_in_host(config, "maya")
```
    
3. Can we simplify further? Could the function be simplified to: `get_submodule`? This would shorten the function name and make it more generic. Then however, it logging the warning message feels to "specific" to the use cases. Maybe removing the warning is actually fine?
