### PR TITLE
Remove unneeded `config` variable from host (un)install (closes #505)

### DIFF
--- a/avalon/fusion/pipeline.py
+++ b/avalon/fusion/pipeline.py
@@ -49,7 +49,7 @@ def ls():
             yield container
 
 
-def install(config):
+def install():
     """Install Fusion-specific functionality of avalon-core.
 
     This function is called automatically on calling `api.install(fusion)`.
@@ -76,14 +76,10 @@ def install(config):
     logger.setLevel(logging.DEBUG)
 
 
-def uninstall(config):
+def uninstall():
     """Uninstall Fusion-specific functionality of avalon-core.
 
     This function is called automatically on calling `api.uninstall()`.
-
-    Args:
-        config: configuration module
-
     """
 
     pyblish.api.deregister_host("fusion")

--- a/avalon/houdini/pipeline.py
+++ b/avalon/houdini/pipeline.py
@@ -24,7 +24,7 @@ AVALON_CONTAINERS = "/obj/AVALON_CONTAINERS"
 IS_HEADLESS = not hasattr(hou, "ui")
 
 
-def install(config):
+def install():
     """Setup integration
     Register plug-ins and integrate into the host
 
@@ -40,14 +40,10 @@ def install(config):
     self._has_been_setup = True
 
 
-def uninstall(config):
+def uninstall():
     """Uninstall Houdini-specific functionality of avalon-core.
 
     This function is called automatically on calling `api.uninstall()`.
-
-    Args:
-        config: configuration module
-
     """
 
     pyblish.api.deregister_host("hython")

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -33,7 +33,7 @@ AVALON_CONTAINERS = ":AVALON_CONTAINERS"
 IS_HEADLESS = not hasattr(cmds, "about") or cmds.about(batch=True)
 
 
-def install(config):
+def install():
     """Install Maya-specific functionality of avalon-core.
 
     This function is called automatically on calling `api.install(maya)`.
@@ -90,7 +90,7 @@ def get_main_window():
     return self._parent
 
 
-def uninstall(config):
+def uninstall():
     """Uninstall Maya-specific functionality of avalon-core.
 
     This function is called automatically on calling `api.uninstall()`.

--- a/avalon/nuke/pipeline.py
+++ b/avalon/nuke/pipeline.py
@@ -209,7 +209,7 @@ def ls():
             yield container
 
 
-def install(config):
+def install():
     """Install Nuke-specific functionality of avalon-core.
 
     This is where you install menus and register families, data
@@ -241,7 +241,7 @@ def get_main_window():
     return self._parent
 
 
-def uninstall(config):
+def uninstall():
     """Uninstall all that was previously installed
 
     This is where you undo everything that was done in `install()`.

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -76,7 +76,7 @@ def install(host):
 
     # Optional host install function
     if hasattr(host, "install"):
-        host.install(config)
+        host.install()
 
     # Optional config.host.install()
     host_name = host.__name__.rsplit(".", 1)[-1]
@@ -119,7 +119,7 @@ def uninstall():
         config_host.uninstall()
 
     try:
-        host.uninstall(config)
+        host.uninstall()
     except AttributeError:
         pass
 


### PR DESCRIPTION
**What's changed?**
Removed the config variable from the `host.install` and `host.uninstall` functions. They were still expected, but not used anymore. After #501 was merged, host integrations don't need to care about the config anymore.
