### PR TITLE
Fix OptionalMenu highlighting in loader

### DIFF
--- a/avalon/tools/loader/widgets.py
+++ b/avalon/tools/loader/widgets.py
@@ -10,7 +10,7 @@ from ... import pipeline
 
 from .. import lib as tools_lib
 from ..delegates import VersionDelegate
-from ..widgets import OptionalMenu, OptionalAction, OptionDialog
+from ..widgets import OptionalAction, OptionDialog
 
 from .model import (
     SubsetsModel,
@@ -178,7 +178,7 @@ class SubsetWidget(QtWidgets.QWidget):
             return Plugin.order, Plugin.__name__
 
         # List the available loaders
-        menu = OptionalMenu(self)
+        menu = QtWidgets.QMenu(self)
         for representation, loader in sorted(loaders, key=sorter):
 
             # Label

--- a/avalon/tools/widgets.py
+++ b/avalon/tools/widgets.py
@@ -381,22 +381,6 @@ class OptionalAction(QtWidgets.QWidgetAction):
     def on_option(self):
         self.optioned = True
 
-    def set_highlight(self, state, global_pos=None):
-        body = self.widget.body
-        option = self.widget.option
-
-        role = QtGui.QPalette.Highlight if state else QtGui.QPalette.Window
-        body.setBackgroundRole(role)
-        body.setAutoFillBackground(state)
-
-        if not self.use_option:
-            return
-
-        state = option.is_hovered(global_pos)
-        role = QtGui.QPalette.Highlight if state else QtGui.QPalette.Window
-        option.setBackgroundRole(role)
-        option.setAutoFillBackground(state)
-
 
 class OptionalActionWidget(QtWidgets.QWidget):
     """Main widget class for `OptionalAction`"""
@@ -521,12 +505,6 @@ class OptionBox(QtWidgets.QLabel):
 
         self.setMouseTracking(True)
         self.setStyleSheet("background: transparent;")
-
-    def is_hovered(self, global_pos):
-        if global_pos is None:
-            return False
-        pos = self.mapFromGlobal(global_pos)
-        return self.rect().contains(pos)
 
 
 class OptionDialog(QtWidgets.QDialog):

--- a/avalon/tools/widgets.py
+++ b/avalon/tools/widgets.py
@@ -417,6 +417,7 @@ class OptionalActionWidget(QtWidgets.QWidget):
         self.setFixedHeight(32)
 
         self.icon = icon
+        self.label = label
         self.option = option
         self.body = body
 

--- a/avalon/tools/widgets.py
+++ b/avalon/tools/widgets.py
@@ -422,6 +422,7 @@ class OptionalActionWidget(QtWidgets.QWidget):
         self.body = body
 
         self.mouse_entered = False
+        self.mouse_pressed = False
         # (NOTE) For removing ugly QLable shadow FX when highlighted in Nuke.
         #   See https://stackoverflow.com/q/52838690/4145300
         label.setStyle(QtWidgets.QStyleFactory.create("Plastique"))
@@ -429,6 +430,32 @@ class OptionalActionWidget(QtWidgets.QWidget):
     def setIcon(self, icon):
         pixmap = icon.pixmap(16, 16)
         self.icon.setPixmap(pixmap)
+
+    def mouseReleaseEvent(self, event):
+        """Emit option clicked signal if mouse released on it"""
+
+        if not self.mouse_pressed:
+            return
+
+        self.mouse_pressed = False
+
+        pos = self.body.mapFromGlobal(QtGui.QCursor.pos())
+        body_hovered = self.body.rect().contains(pos)
+
+        pos = self.option.mapFromGlobal(QtGui.QCursor.pos())
+        option_hovered = self.option.rect().contains(pos)
+
+        if not (option_hovered or body_hovered):
+            return
+
+        if option_hovered:
+            self.option.clicked.emit()
+
+        super(OptionalActionWidget, self).mouseReleaseEvent(event)
+
+    def mousePressEvent(self, event):
+        self.mouse_pressed = True
+        super(OptionalActionWidget, self).mousePressEvent(event)
 
     def handle_mouse_move_event(self, event):
         if event.type() == QtCore.QEvent.Type.MouseMove:

--- a/avalon/tools/widgets.py
+++ b/avalon/tools/widgets.py
@@ -324,24 +324,6 @@ def _list_project_silos():
     return list(sorted(silos))
 
 
-class OptionalMenu(QtWidgets.QMenu):
-    """A subclass of `QtWidgets.QMenu` to work with `OptionalAction`
-
-    This menu has reimplemented `mouseReleaseEvent`, `mouseMoveEvent` and
-    `leaveEvent` to provide better action hightlighting and triggering for
-    actions that were instances of `QtWidgets.QWidgetAction`.
-
-    """
-
-    def mouseReleaseEvent(self, event):
-        """Emit option clicked signal if mouse released on it"""
-        active = self.actionAt(event.pos())
-        if active and active.use_option:
-            option = active.widget.option
-            if option.is_hovered(event.globalPos()):
-                option.clicked.emit()
-        super(OptionalMenu, self).mouseReleaseEvent(event)
-
 class OptionalAction(QtWidgets.QWidgetAction):
     """Menu action with option box
 

--- a/avalon/tools/widgets.py
+++ b/avalon/tools/widgets.py
@@ -458,7 +458,7 @@ class OptionalActionWidget(QtWidgets.QWidget):
         self.icon.setPixmap(pixmap)
 
 
-class OptionBox(QtWidgets.QWidget):
+class OptionBox(QtWidgets.QLabel):
     """Option box widget class for `OptionalActionWidget`"""
 
     clicked = QtCore.Signal()
@@ -466,18 +466,18 @@ class OptionBox(QtWidgets.QWidget):
     def __init__(self, parent):
         super(OptionBox, self).__init__(parent)
 
-        label = QtWidgets.QLabel()
-
-        layout = QtWidgets.QHBoxLayout(self)
+        layout = self.layout()
+        if not layout:
+            layout = QtWidgets.QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.addSpacing(8)
-        layout.addWidget(label)
+        self.setLayout(layout)
+
+        self.setAlignment(QtCore.Qt.AlignCenter)
 
         icon = qtawesome.icon("fa.sticky-note-o", color="#c6c6c6")
         pixmap = icon.pixmap(18, 18)
-        label.setPixmap(pixmap)
+        self.setPixmap(pixmap)
 
-        label.setMouseTracking(True)
         self.setMouseTracking(True)
         self.setStyleSheet("background: transparent;")
 


### PR DESCRIPTION
**Issue to solve:**
- OptionMenu sometimes doesn't get mouseMoveEvent and is ignoring mouseEnterEvent, hence it the highlight of actions isn't triggered sometimes.
- mouse release triggers action where cursor currently is rather than the on where it originally clicked

**Suggestion:**
- re-implemented mouse movement (enter, leave, move) and press (pressed, released) event handling in OptionalActionWidget instead of OptionalMenu
    - OptionalMenu currently must iterate through all it's actions to filter them but Qt app does that itself, so widgets deal with only their events
- it is now possible to trigger action only if release event happened on the same action where the mouse was pressed. But hovering to option box after mouse is pressed still works.
- OptionalMenu was removed since all it's re-implemented methods were moved
- OptionBox was changed from QWidget to QLabel since it's only child was QLabel