### PR TITLE
Highlight update fix 2

### DIFF
--- a/avalon/tools/widgets.py
+++ b/avalon/tools/widgets.py
@@ -458,7 +458,7 @@ class OptionalActionWidget(QtWidgets.QWidget):
         self.icon.setPixmap(pixmap)
 
 
-class OptionBox(QtWidgets.QWidget):
+class OptionBox(QtWidgets.QLabel):
     """Option box widget class for `OptionalActionWidget`"""
 
     clicked = QtCore.Signal()
@@ -466,19 +466,12 @@ class OptionBox(QtWidgets.QWidget):
     def __init__(self, parent):
         super(OptionBox, self).__init__(parent)
 
-        label = QtWidgets.QLabel()
-
-        layout = QtWidgets.QHBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addSpacing(8)
-        layout.addWidget(label)
+        self.setAlignment(QtCore.Qt.AlignCenter)
 
         icon = qtawesome.icon("fa.sticky-note-o", color="#c6c6c6")
         pixmap = icon.pixmap(18, 18)
-        label.setPixmap(pixmap)
+        self.setPixmap(pixmap)
 
-        label.setMouseTracking(True)
-        self.setMouseTracking(True)
         self.setStyleSheet("background: transparent;")
 
     def is_hovered(self, global_pos):

--- a/avalon/tools/widgets.py
+++ b/avalon/tools/widgets.py
@@ -442,6 +442,8 @@ class OptionalActionWidget(QtWidgets.QWidget):
         layout.addWidget(option)
 
         body.setMouseTracking(True)
+        label.setMouseTracking(True)
+        option.setMouseTracking(True)
         self.setMouseTracking(True)
         self.setFixedHeight(32)
 

--- a/avalon/tools/widgets.py
+++ b/avalon/tools/widgets.py
@@ -448,6 +448,7 @@ class OptionalActionWidget(QtWidgets.QWidget):
         self.setFixedHeight(32)
 
         self.icon = icon
+        self.label = label
         self.option = option
         self.body = body
 


### PR DESCRIPTION
**Issue to solve:**
Follow up previous PR #518 
- OptionMenu sometimes doesn't get mouseMoveEvent and is ignoring mouseEnterEvent, hence it the highlight of actions isn't triggered sometimes.

**Suggestion:**
- added mouse tracking for `label` in OptionalActionWidget
- OptionBox was changed from QWidget to QLabel since it's only child was QLabel