### PR TITLE
Optionally initialize Session['AVALON_HIERARCHY']

### DIFF
--- a/avalon/io.py
+++ b/avalon/io.py
@@ -139,7 +139,7 @@ def _from_environment():
             ("AVALON_SCENEDIR", None),
 
             # Optional hierarchy for the current Asset. This can be referenced
-            # as `{hierarchy}` is your file templates.
+            # as `{hierarchy}` in your file templates.
             # This will be (re-)computed when you switch the context to another
             # asset. It is computed by checking asset['data']['parents'] and
             # joining those together with `os.path.sep`.

--- a/avalon/io.py
+++ b/avalon/io.py
@@ -144,7 +144,7 @@ def _from_environment():
             # asset. It is computed by checking asset['data']['parents'] and
             # joining those together with `os.path.sep`.
             # E.g.: ['ep101', 'scn0010'] -> 'ep101/scn0010'.
-            ("AVALON_HIERARCHY", None)
+            ("AVALON_HIERARCHY", None),
 
             # Name of current Config
             # TODO(marcus): Establish a suitable default config

--- a/avalon/io.py
+++ b/avalon/io.py
@@ -138,6 +138,14 @@ def _from_environment():
             # Optional path to scenes directory (see Work Files API)
             ("AVALON_SCENEDIR", None),
 
+            # Optional hierarchy for the current Asset. This can be referenced
+            # as `{hierarchy}` is your file templates.
+            # This will be (re-)computed when you switch the context to another
+            # asset. It is computed by checking asset['data']['parents'] and
+            # joining those together with `os.path.sep`.
+            # E.g.: ['ep101', 'scn0010'] -> 'ep101/scn0010'.
+            ("AVALON_HIERARCHY", None)
+
             # Name of current Config
             # TODO(marcus): Establish a suitable default config
             ("AVALON_CONFIG", "no_config"),


### PR DESCRIPTION
In [this PR](https://github.com/getavalon/core/pull/371) the concept of an extra hierarchy for assets was introduced. You can reference this in your file templates with `{hierarchy}`. The value is computed when you set the context to a different asset.
However if you start your DCC (only relying on Avalon env variables) and you don't switch to another asset, `Session['AVALON_HIERARCHY']` doesn't exist. That gives an error when you open the workfiles app and try to save your work (at least in the new [combined context/workfiles app](https://github.com/getavalon/core/pull/442).

**What's changed?**
If the environment variable 'AVALON_HIERARCHY' is present Session['AVALON_HIERARCHY'] will be initialized on start up. That way there is no error when saving your work file without switching context to another asset first.
