### PR TITLE
Style tweak, dimming highlight color

### DIFF
--- a/avalon/style/style.qss
+++ b/avalon/style/style.qss
@@ -314,9 +314,9 @@ QWidget:disabled
 
 QAbstractItemView
 {
-    alternate-background-color: #3A3939;
+    alternate-background-color: #2D2C2C;
     color: silver;
-    border: 1px solid 3A3939;
+    border: 1px solid #2D2C2C;
     border-radius: 2px;
     padding: 1px;
 }

--- a/avalon/style/style.qss
+++ b/avalon/style/style.qss
@@ -1103,7 +1103,7 @@ QHeaderView
 
 QHeaderView::section  {
     background-color: #3A3939;
-    color: silver;
+    /*color: silver;*/
     padding: 4px;
     border: 1px solid #6c6c6c;
     border-radius: 0px;

--- a/avalon/style/style.qss
+++ b/avalon/style/style.qss
@@ -505,14 +505,6 @@ QPlainTextEdit
     border: 1px solid #3A3939;
 }
 
-QHeaderView::section
-{
-    background-color: #3A3939;
-    color: silver;
-    padding-left: 4px;
-    border: 1px solid #6c6c6c;
-}
-
 QSizeGrip {
     image: url(:/qss_icons/rc/sizegrip.png);
     width: 12px;

--- a/avalon/style/style.qss
+++ b/avalon/style/style.qss
@@ -4,6 +4,11 @@
     font-family: "Open Sans";
 }
 
+/*
+@ Selection highlight: #40576D
+*/
+
+
 QProgressBar:horizontal {
     border: 1px solid #3A3939;
     text-align: center;
@@ -27,7 +32,7 @@ QWidget
 {
     color: silver;
     background-color: #302F2F;
-    selection-background-color:#3d8ec9;
+    selection-background-color: #40576D;
     selection-color: black;
     background-clip: border;
     border-image: none;
@@ -43,7 +48,7 @@ QWidget:item:hover
 
 QWidget:item:selected
 {
-    background-color: #3d8ec9;
+    background-color: #40576D;
 }
 
 QCheckBox
@@ -218,7 +223,7 @@ QMenuBar::item:selected
 QMenuBar::item:pressed
 {
     border: 1px solid #3A3939;
-    background-color: #3d8ec9;
+    background-color: #40576D;
     color: black;
     margin-bottom:-1px;
     padding-bottom:1px;
@@ -609,13 +614,13 @@ QPushButton:disabled
 }
 
 QPushButton:focus {
-    background-color: #3d8ec9;
+    background-color: #40576D;
     color: white;
 }
 
 QComboBox
 {
-    selection-background-color: #3d8ec9;
+    selection-background-color: #40576D;
     background-color: #201F1F;
     border-style: solid;
     border: 1px solid #3A3939;
@@ -648,7 +653,7 @@ QComboBox QAbstractItemView
     background-color: #201F1F;
     border-radius: 2px;
     border: 1px solid #444;
-    selection-background-color: #3d8ec9;
+    selection-background-color: #40576D;
 }
 
 QComboBox::drop-down
@@ -958,7 +963,7 @@ QListView::item:!selected:hover, QListView::item:!selected:hover, QTreeView::ite
 }
 
 QListView::item:selected:hover, QListView::item:selected:hover, QTreeView::item:selected:hover  {
-    background: #3d8ec9;
+    background: #40576D;
     color: #FFFFFF;
 }
 
@@ -1088,7 +1093,7 @@ QTableView::item:pressed, QListView::item:pressed, QTreeView::item:pressed  {
 }
 
 QTableView::item:selected:active, QTreeView::item:selected:active, QListView::item:selected:active  {
-    background: #3d8ec9;
+    background: #40576D;
     color: #FFFFFF;
 }
 
@@ -1170,7 +1175,7 @@ QToolBox::tab {
  QToolBox::tab:selected { /* italicize selected tabs */
     font: italic;
     background-color: #302F2F;
-    border-color: #3d8ec9;
+    border-color: #40576D;
  }
 
 QStatusBar::item {


### PR DESCRIPTION
### What's changed
* Comment out `QHeaderView::section`'s color attribute so one could customize it
* Dimming selection highlight color so the icons could pop-up, having more contrast

#### Before
![9986041b-fa52-44ba-bc62-fd64defeee5d](https://user-images.githubusercontent.com/3357009/74675196-ff448100-51ed-11ea-80ee-910dbf791a72.gif)

#### After
![3c8e4214-919b-47ea-bfff-9fa2a790d7bf](https://user-images.githubusercontent.com/3357009/74675171-f5bb1900-51ed-11ea-8a57-4088b9cba515.gif)

#### Custom header section text color
![image](https://user-images.githubusercontent.com/3357009/74675307-3b77e180-51ee-11ea-8ba3-15670e7fd170.png)

### Motivation
Although I did think about overriding styles from the config, but then I thought it could become a bit harder to develop GUI in style that everyone could adopt since what other sees would be different from mine. So I decide to push the change I need and have a open discuss to see if everyone feels okay with it.

It's not much but I think it could improve the overall color contrast for seeing icons and other things that are a bit more important than selections. Bright icon friendly style. ☺️ 
