### PR TITLE
Avoid keyPress event interfering other widgets

### DIFF
--- a/avalon/tools/loader/app.py
+++ b/avalon/tools/loader/app.py
@@ -276,7 +276,8 @@ class Window(QtWidgets.QDialog):
             self.show_grouping_dialog()
             return
 
-        return super(Window, self).keyPressEvent(event)
+        super(Window, self).keyPressEvent(event)
+        event.setAccepted(True)  # Avoid interfering other widgets
 
     def show_grouping_dialog(self):
         subsets = self.data["model"]["subsets"]

--- a/avalon/tools/projectmanager/app.py
+++ b/avalon/tools/projectmanager/app.py
@@ -97,6 +97,16 @@ class Window(QtWidgets.QDialog):
 
         self.echo("Connected to project: {0}".format(project_name))
 
+    def keyPressEvent(self, event):
+        """Custom keyPressEvent.
+
+        Override keyPressEvent to do nothing so that Maya's panels won't
+        take focus when pressing "SHIFT" whilst mouse is over viewport or
+        outliner. This way users don't accidently perform Maya commands
+        whilst trying to name an instance.
+
+        """
+
     def refresh(self):
         self.data["model"]["assets"].refresh()
 

--- a/avalon/tools/sceneinventory/app.py
+++ b/avalon/tools/sceneinventory/app.py
@@ -899,6 +899,16 @@ class Window(QtWidgets.QDialog):
 
         tools_lib.refresh_family_config_cache()
 
+    def keyPressEvent(self, event):
+        """Custom keyPressEvent.
+
+        Override keyPressEvent to do nothing so that Maya's panels won't
+        take focus when pressing "SHIFT" whilst mouse is over viewport or
+        outliner. This way users don't accidently perform Maya commands
+        whilst trying to name an instance.
+
+        """
+
     def refresh(self):
         with tools_lib.preserve_expanded_rows(tree_view=self.view,
                                               role=self.model.UniqueRole):

--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -788,6 +788,16 @@ class Window(QtWidgets.QMainWindow):
 
         self.resize(900, 600)
 
+    def keyPressEvent(self, event):
+        """Custom keyPressEvent.
+
+        Override keyPressEvent to do nothing so that Maya's panels won't
+        take focus when pressing "SHIFT" whilst mouse is over viewport or
+        outliner. This way users don't accidently perform Maya commands
+        whilst trying to name an instance.
+
+        """
+
     def on_task_changed(self):
         # Since we query the disk give it slightly more delay
         tools_lib.schedule(self._on_task_changed, 100, channel="mongo")


### PR DESCRIPTION
### Motivation

While using arrow keys to navigate tree view or other widgets, key press event often *leaks* from current focused widget and interfering other Apps. In Maya for example, it accidently performing Maya commands like pickwalking in outliner.

### Solution

Overriding main window's `keyPressEvent`.

##### Before
![73d9704e-5bb1-4259-a877-dd583efd598d](https://user-images.githubusercontent.com/3357009/76203004-d2095280-6230-11ea-8645-261e02c9f93d.gif)

##### After
![396b436b-1739-4b36-836b-eca46e257e30](https://user-images.githubusercontent.com/3357009/76203078-f82ef280-6230-11ea-97e4-55e84d494264.gif)
