### PR TITLE
Sort creator plugins by label instead of classname

### DIFF
--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -136,6 +136,7 @@ class Window(QtWidgets.QDialog):
         container = QtWidgets.QWidget()
 
         listing = QtWidgets.QListWidget()
+        listing.setSortingEnabled(True)
         asset = QtWidgets.QLineEdit()
         name = SubsetNameLineEdit()
         result = QtWidgets.QLineEdit()


### PR DESCRIPTION
### Changes

This PR fixes #508 by enabling `QListWidget` sorting in Creator App. 🚀 
