### PR TITLE
Make `api.create` able to run with one specific creator plugin

### DIFF
--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -878,12 +878,13 @@ def create(name, asset, family, options=None, data=None):
 
     host = registered_host()
 
-    plugins = list()
-    for Plugin in discover(Creator):
-        has_family = family == Plugin.family
+    if isinstance(family, str):
+        Plugins = [P for P in discover(Creator) if family == P.family]
+    else:
+        Plugins = [family]
 
-        if not has_family:
-            continue
+    plugins = list()
+    for Plugin in Plugins:
 
         Plugin.log.info(
             "Creating '%s' with '%s'" % (name, Plugin.__name__)

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -436,13 +436,13 @@ class Window(QtWidgets.QDialog):
 
         subset_name = result.text()
         asset = asset.text()
-        family = item.data(FamilyRole)
+        Plugin = item.data(PluginRole)
         use_selection = self.data["Use Selection Checkbox"].isChecked()
 
         try:
             api.create(subset_name,
                        asset,
-                       family,
+                       Plugin,
                        options={"useSelection": use_selection})
 
         except NameError as e:


### PR DESCRIPTION
### Changes
This PR implements #507. Depends on the type of input argument `family` of `api.create`, try matching all plugins via `family` if it's a string, or dierctly run the given plugin if `family` is that plugin.