### PR TITLE
Make Silos optional

### DIFF
--- a/avalon/io.py
+++ b/avalon/io.py
@@ -199,7 +199,7 @@ def _from_environment():
         ) if os.getenv(item[0], item[1]) is not None
     }
 
-    session["schema"] = "avalon-core:session-1.0"
+    session["schema"] = "avalon-core:session-2.0"
     try:
         schema.validate(session)
     except schema.ValidationError as e:

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -993,7 +993,7 @@ def compute_session_changes(session, task=None, asset=None, app=None):
     if "AVALON_ASSET" in changes:
 
         # Update silo
-        changes["AVALON_SILO"] = asset_document.get("silo")
+        changes["AVALON_SILO"] = asset_document.get("silo") or ""
 
         # Update hierarchy
         parents = asset_document['data'].get('parents', [])

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -336,7 +336,6 @@ class Application(Action):
     def is_compatible(self, session):
         required = ["AVALON_PROJECTS",
                     "AVALON_PROJECT",
-                    "AVALON_SILO",
                     "AVALON_ASSET",
                     "AVALON_TASK"]
         missing = [x for x in required if x not in session]
@@ -994,7 +993,7 @@ def compute_session_changes(session, task=None, asset=None, app=None):
     if "AVALON_ASSET" in changes:
 
         # Update silo
-        changes["AVALON_SILO"] = asset_document["silo"]
+        changes["AVALON_SILO"] = asset_document.get("silo")
 
         # Update hierarchy
         parents = asset_document['data'].get('parents', [])
@@ -1068,12 +1067,12 @@ def _format_work_template(template, session=None):
     return template.format(**{
         "root": registered_root(),
         "project": session["AVALON_PROJECT"],
-        "silo": session["AVALON_SILO"],
         "asset": session["AVALON_ASSET"],
         "task": session["AVALON_TASK"],
         "app": session["AVALON_APP"],
 
         # Optional
+        "silo": session.get("AVALON_SILO"),
         "user": session.get("AVALON_USER", getpass.getuser()),
         "hierarchy": session.get("AVALON_HIERARCHY"),
     })
@@ -1317,7 +1316,7 @@ def get_representation_path(representation):
             "root": registered_root(),
             "project": project["name"],
             "asset": asset["name"],
-            "silo": asset["silo"],
+            "silo": asset.get("silo"),
             "subset": subset["name"],
             "version": version_["name"],
             "representation": representation["name"],

--- a/avalon/schema/asset-3.0.json
+++ b/avalon/schema/asset-3.0.json
@@ -1,0 +1,53 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "avalon-core:asset-3.0",
+    "description": "A unit of data",
+
+    "type": "object",
+
+    "additionalProperties": true,
+
+    "required": [
+        "schema",
+        "type",
+        "name",
+        "data"
+    ],
+
+    "properties": {
+        "schema": {
+            "description": "Schema identifier for payload",
+            "type": "string",
+            "enum": ["avalon-core:asset-3.0"],
+            "example": "avalon-core:asset-3.0"
+        },
+        "type": {
+            "description": "The type of document",
+            "type": "string",
+            "enum": ["asset"],
+            "example": "asset"
+        },
+        "parent": {
+            "description": "Unique identifier to parent document",
+            "example": "592c33475f8c1b064c4d1696"
+        },
+        "name": {
+            "description": "Name of asset",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.]*$",
+            "example": "Bruce"
+        },
+        "silo": {
+            "description": "(Deprecated) Group or container of asset",
+            "example": "assets"
+        },
+        "data": {
+            "description": "Document metadata",
+            "type": "object",
+            "example": {"key": "value"}
+        }
+    },
+
+    "definitions": {}
+}

--- a/avalon/schema/session-2.0.json
+++ b/avalon/schema/session-2.0.json
@@ -1,0 +1,147 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "avalon-core:session-2.0",
+    "description": "The Avalon environment",
+
+    "type": "object",
+
+    "additionalProperties": true,
+
+    "required": [
+        "AVALON_PROJECTS",
+        "AVALON_PROJECT",
+        "AVALON_ASSET",
+        "AVALON_CONFIG"
+    ],
+
+    "properties": {
+        "AVALON_PROJECTS": {
+            "description": "Absolute path to root of project directories",
+            "type": "string",
+            "example": "/nas/projects"
+        },
+        "AVALON_PROJECT": {
+            "description": "Name of project",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "Hulk"
+        },
+        "AVALON_ASSET": {
+            "description": "Name of asset",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "Bruce"
+        },
+        "AVALON_SILO": {
+            "description": "Name of asset group or container",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "assets"
+        },
+        "AVALON_TASK": {
+            "description": "Name of task",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "modeling"
+        },
+        "AVALON_CONFIG": {
+            "description": "Name of Avalon configuration",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "polly"
+        },
+        "AVALON_WORKDIR": {
+            "description": "Current working directory of a host, such as Maya's location of workspace.mel",
+            "type": "string",
+            "example": "/mnt/projects/alita/assets/vector/maya"
+        },
+        "AVALON_APP": {
+            "description": "Name of application",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "maya2016"
+        },
+        "AVALON_MONGO": {
+            "description": "Address to the asset database",
+            "type": "string",
+            "pattern": "^mongodb://[\\w/@:.]*$",
+            "example": "mongodb://localhost:27017",
+            "default": "mongodb://localhost:27017"
+        },
+        "AVALON_DB": {
+            "description": "Name of database",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "avalon",
+            "default": "avalon"
+        },
+        "AVALON_LABEL": {
+            "description": "Nice name of Avalon, used in e.g. graphical user interfaces",
+            "type": "string",
+            "example": "Mindbender",
+            "default": "Avalon"
+        },
+        "AVALON_SENTRY": {
+            "description": "Address to Sentry",
+            "type": "string",
+            "pattern": "^http[\\w/@:.]*$",
+            "example": "https://5b872b280de742919b115bdc8da076a5:8d278266fe764361b8fa6024af004a9c@logs.mindbender.com/2",
+            "default": null
+        },
+        "AVALON_DEADLINE": {
+            "description": "Address to Deadline",
+            "type": "string",
+            "pattern": "^http[\\w/@:.]*$",
+            "example": "http://192.168.99.101",
+            "default": null
+        },
+        "AVALON_TIMEOUT": {
+            "description": "Wherever there is a need for a timeout, this is the default value.",
+            "type": "string",
+            "pattern": "^[0-9]*$",
+            "default": "1000",
+            "example": "1000"
+        },
+        "AVALON_UPLOAD": {
+            "description": "Boolean of whether to upload published material to central asset repository",
+            "type": "string",
+            "default": null,
+            "example": "True"
+        },
+        "AVALON_USERNAME": {
+            "description": "Generic username",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "default": "avalon",
+            "example": "myself"
+        },
+        "AVALON_PASSWORD": {
+            "description": "Generic password",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "default": "secret",
+            "example": "abc123"
+        },
+        "AVALON_INSTANCE_ID": {
+            "description": "Unique identifier for instances in a working file",
+            "type": "string",
+            "pattern": "^[\\w.]*$",
+            "default": "avalon.instance",
+            "example": "avalon.instance"
+        },
+        "AVALON_CONTAINER_ID": {
+            "description": "Unique identifier for a loaded representation in a working file",
+            "type": "string",
+            "pattern": "^[\\w.]*$",
+            "default": "avalon.container",
+            "example": "avalon.container"
+        },
+        "AVALON_DEBUG": {
+            "description": "Enable debugging mode. Some applications may use this for e.g. extended verbosity or mock plug-ins.",
+            "type": "string",
+            "default": null,
+            "example": "True"
+        }
+    }
+}

--- a/avalon/tools/lib.py
+++ b/avalon/tools/lib.py
@@ -108,6 +108,75 @@ def iter_model_rows(model,
 
 
 @contextlib.contextmanager
+def preserve_states(
+    tree_view, column=0, role=None,
+    preserve_expanded=True, preserve_selection=True,
+    expanded_role=QtCore.Qt.DisplayRole, selection_role=QtCore.Qt.DisplayRole
+
+):
+    """Preserves row selection in QTreeView by column's data role.
+    This function is created to maintain the selection status of
+    the model items. When refresh is triggered the items which are expanded
+    will stay expanded and vise versa.
+        tree_view (QWidgets.QTreeView): the tree view nested in the application
+        column (int): the column to retrieve the data from
+        role (int): the role which dictates what will be returned
+    Returns:
+        None
+    """
+    # When `role` is set then override both expanded and selection roles
+    if role:
+        expanded_role = role
+        selection_role = role
+
+    model = tree_view.model()
+    selection_model = tree_view.selectionModel()
+    flags = selection_model.Select | selection_model.Rows
+
+    expanded = set()
+
+    if preserve_expanded:
+        for index in iter_model_rows(
+            model, column=column, include_root=False
+        ):
+            if tree_view.isExpanded(index):
+                value = index.data(expanded_role)
+                expanded.add(value)
+
+    selected = None
+
+    if preserve_selection:
+        selected_rows = selection_model.selectedRows()
+        if selected_rows:
+            selected = set(row.data(selection_role) for row in selected_rows)
+
+    try:
+        yield
+    finally:
+        if expanded:
+            for index in iter_model_rows(
+                model, column=0, include_root=False
+            ):
+                value = index.data(expanded_role)
+                is_expanded = value in expanded
+                # skip if new index was created meanwhile
+                if is_expanded is None:
+                    continue
+                tree_view.setExpanded(index, is_expanded)
+
+        if selected:
+            # Go through all indices, select the ones with similar data
+            for index in iter_model_rows(
+                model, column=column, include_root=False
+            ):
+                value = index.data(selection_role)
+                state = value in selected
+                if state:
+                    tree_view.scrollTo(index)  # Ensure item is visible
+                    selection_model.select(index, flags)
+
+
+@contextlib.contextmanager
 def preserve_expanded_rows(tree_view,
                            column=0,
                            role=QtCore.Qt.DisplayRole):

--- a/avalon/tools/lib.py
+++ b/avalon/tools/lib.py
@@ -452,3 +452,19 @@ def get_active_group_config(asset_id, include_predefined=False):
         })
 
     return ordered
+
+
+def project_use_silo(project_doc):
+    """Check if templates of project document contain `{silo}`.
+
+    Args:
+        project_doc (dict): Project document queried from database.
+
+    Returns:
+        bool: True if any project's template contain "{silo}".
+    """
+    templates = project_doc["config"].get("template") or {}
+    for template in templates.values():
+        if "{silo}" in template:
+            return True
+    return False

--- a/avalon/tools/lib.py
+++ b/avalon/tools/lib.py
@@ -108,12 +108,13 @@ def iter_model_rows(model,
 
 
 @contextlib.contextmanager
-def preserve_states(
-    tree_view, column=0, role=None,
-    preserve_expanded=True, preserve_selection=True,
-    expanded_role=QtCore.Qt.DisplayRole, selection_role=QtCore.Qt.DisplayRole
-
-):
+def preserve_states(tree_view,
+                    column=0,
+                    role=None,
+                    preserve_expanded=True,
+                    preserve_selection=True,
+                    expanded_role=QtCore.Qt.DisplayRole,
+                    selection_role=QtCore.Qt.DisplayRole):
     """Preserves row selection in QTreeView by column's data role.
     This function is created to maintain the selection status of
     the model items. When refresh is triggered the items which are expanded

--- a/avalon/tools/loader/app.py
+++ b/avalon/tools/loader/app.py
@@ -39,9 +39,9 @@ class Window(QtWidgets.QDialog):
 
         container = QtWidgets.QWidget()
 
-        assets = AssetWidget(parent=self)
+        assets = AssetWidget()
         families = FamilyListWidget()
-        subsets = SubsetWidget(parent=self)
+        subsets = SubsetWidget()
         version = VersionWidget()
 
         # Create splitter to show / hide family filters
@@ -425,8 +425,8 @@ def show(debug=False, parent=None, use_context=False):
         lib.refresh_group_config_cache()
 
         window = Window(parent)
-        window.setStyleSheet(style.load_stylesheet())
         window.show()
+        window.setStyleSheet(style.load_stylesheet())
 
         if use_context:
             context = {"asset": api.Session["AVALON_ASSET"]}

--- a/avalon/tools/loader/app.py
+++ b/avalon/tools/loader/app.py
@@ -408,7 +408,7 @@ def show(debug=False, parent=None, use_context=False):
             module.window.refresh()
             return
         except RuntimeError as exc:
-            if not exc.message.rstrip().endswith("already deleted."):
+            if not str(exc).rstrip().endswith("already deleted."):
                 raise
 
             # Garbage collected

--- a/avalon/tools/loader/app.py
+++ b/avalon/tools/loader/app.py
@@ -168,19 +168,29 @@ class Window(QtWidgets.QDialog):
 
         t1 = time.time()
 
-        asset_item = assets_model.get_active_index()
-        if asset_item is None or not asset_item.isValid():
-            return
+        asset_item = assets_model.get_active_asset()
+        if asset_item is None:
+            document_id = None
+            document_name = None
+            document_silo = None
+        elif asset_item["type"] == "silo":
+            document_id = None
+            document_name = None
+            document_silo = asset_item["name"]
+        else:
+            document = asset_item["_document"]
+            document_id = document["_id"]
+            document_name = document["name"]
+            document_silo = document.get("silo")
 
-        document = asset_item.data(DocumentRole)
-        subsets_model.set_asset(document["_id"])
+        subsets_model.set_asset(document_id)
 
         # Clear the version information on asset change
         self.data["model"]["version"].set_version(None)
 
-        self.data["state"]["context"]["asset"] = document["name"]
-        self.data["state"]["context"]["assetId"] = document["_id"]
-        self.data["state"]["context"]["silo"] = document.get("silo")
+        self.data["state"]["context"]["asset"] = document_name
+        self.data["state"]["context"]["assetId"] = document_id
+        self.data["state"]["context"]["silo"] = document_silo
         self.echo("Duration: %.3fs" % (time.time() - t1))
 
     def _versionschanged(self):

--- a/avalon/tools/loader/model.py
+++ b/avalon/tools/loader/model.py
@@ -17,15 +17,18 @@ def is_filtering_recursible():
 
 
 class SubsetsModel(TreeModel):
-    Columns = ["subset",
-               "family",
-               "version",
-               "time",
-               "author",
-               "frames",
-               "duration",
-               "handles",
-               "step"]
+    Columns = [
+        "subset",
+        "asset",
+        "family",
+        "version",
+        "time",
+        "author",
+        "frames",
+        "duration",
+        "handles",
+        "step"
+    ]
 
     SortAscendingRole = QtCore.Qt.UserRole + 2
     SortDescendingRole = QtCore.Qt.UserRole + 3
@@ -35,8 +38,9 @@ class SubsetsModel(TreeModel):
         self._asset_id = None
         self._sorter = None
         self._grouping = grouping
-        self._icons = {"subset": qtawesome.icon("fa.file-o",
-                                                color=style.colors.default)}
+        self._icons = {
+            "subset": qtawesome.icon("fa.file-o", color=style.colors.default)
+        }
 
     def set_asset(self, asset_id):
         self._asset_id = asset_id
@@ -50,7 +54,7 @@ class SubsetsModel(TreeModel):
 
         # Trigger additional edit when `version` column changed
         # because it also updates the information in other columns
-        if index.column() == 2:
+        if index.column() == self.Columns.index("version"):
             item = index.internalPointer()
             parent = item["_id"]
             version = io.find_one({"name": value,
@@ -206,7 +210,7 @@ class SubsetsModel(TreeModel):
             return
 
         if role == QtCore.Qt.DisplayRole:
-            if index.column() == 1:
+            if index.column() == self.Columns.index("family"):
                 # Show familyLabel instead of family
                 item = index.internalPointer()
                 return item.get("familyLabel", None)
@@ -214,7 +218,7 @@ class SubsetsModel(TreeModel):
         if role == QtCore.Qt.DecorationRole:
 
             # Add icon to subset column
-            if index.column() == 0:
+            if index.column() == self.Columns.index("subset"):
                 item = index.internalPointer()
                 if item.get("isGroup"):
                     return item["icon"]
@@ -222,7 +226,7 @@ class SubsetsModel(TreeModel):
                     return self._icons["subset"]
 
             # Add icon to family column
-            if index.column() == 1:
+            if index.column() == self.Columns.index("family"):
                 item = index.internalPointer()
                 return item.get("familyIcon", None)
 
@@ -234,8 +238,9 @@ class SubsetsModel(TreeModel):
                 order = item["inverseOrder"]
             else:
                 prefix = "0"
-                order = str(super(SubsetsModel,
-                                  self).data(index, QtCore.Qt.DisplayRole))
+                order = str(super(SubsetsModel, self).data(
+                    index, QtCore.Qt.DisplayRole
+                ))
             return prefix + order
 
         if role == self.SortAscendingRole:
@@ -246,8 +251,9 @@ class SubsetsModel(TreeModel):
                 order = item["order"]
             else:
                 prefix = "1"
-                order = str(super(SubsetsModel,
-                                  self).data(index, QtCore.Qt.DisplayRole))
+                order = str(super(SubsetsModel, self).data(
+                    index, QtCore.Qt.DisplayRole
+                ))
             return prefix + order
 
         return super(SubsetsModel, self).data(index, role)
@@ -256,7 +262,7 @@ class SubsetsModel(TreeModel):
         flags = QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsSelectable
 
         # Make the version column editable
-        if index.column() == 2:  # version column
+        if index.column() == self.Columns.index("version"):  # version column
             flags |= QtCore.Qt.ItemIsEditable
 
         return flags
@@ -338,7 +344,7 @@ class FamiliesFilterProxyModel(GroupMemberFilterProxyModel):
         if not index.isValid() or index is None:
             return True
 
-        # Get the node data and validate
+        # Get the item data and validate
         item = model.data(index, TreeModel.ItemRole)
 
         if item.get("isGroup"):

--- a/avalon/tools/loader/model.py
+++ b/avalon/tools/loader/model.py
@@ -19,7 +19,6 @@ def is_filtering_recursible():
 class SubsetsModel(TreeModel):
     Columns = [
         "subset",
-        "asset",
         "family",
         "version",
         "time",

--- a/avalon/tools/loader/model.py
+++ b/avalon/tools/loader/model.py
@@ -34,6 +34,9 @@ class SubsetsModel(TreeModel):
 
     def __init__(self, grouping=True, parent=None):
         super(SubsetsModel, self).__init__(parent=parent)
+        self.columns_index = dict(
+            (key, idx) for idx, key in enumerate(self.Columns)
+        )
         self._asset_id = None
         self._sorter = None
         self._grouping = grouping
@@ -53,7 +56,7 @@ class SubsetsModel(TreeModel):
 
         # Trigger additional edit when `version` column changed
         # because it also updates the information in other columns
-        if index.column() == self.Columns.index("version"):
+        if index.column() == self.columns_index["version"]:
             item = index.internalPointer()
             parent = item["_id"]
             version = io.find_one({"name": value,
@@ -209,7 +212,7 @@ class SubsetsModel(TreeModel):
             return
 
         if role == QtCore.Qt.DisplayRole:
-            if index.column() == self.Columns.index("family"):
+            if index.column() == self.columns_index["family"]:
                 # Show familyLabel instead of family
                 item = index.internalPointer()
                 return item.get("familyLabel", None)
@@ -217,7 +220,7 @@ class SubsetsModel(TreeModel):
         if role == QtCore.Qt.DecorationRole:
 
             # Add icon to subset column
-            if index.column() == self.Columns.index("subset"):
+            if index.column() == self.columns_index["subset"]:
                 item = index.internalPointer()
                 if item.get("isGroup"):
                     return item["icon"]
@@ -225,7 +228,7 @@ class SubsetsModel(TreeModel):
                     return self._icons["subset"]
 
             # Add icon to family column
-            if index.column() == self.Columns.index("family"):
+            if index.column() == self.columns_index["family"]:
                 item = index.internalPointer()
                 return item.get("familyIcon", None)
 
@@ -261,7 +264,7 @@ class SubsetsModel(TreeModel):
         flags = QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsSelectable
 
         # Make the version column editable
-        if index.column() == self.Columns.index("version"):  # version column
+        if index.column() == self.columns_index["version"]:
             flags |= QtCore.Qt.ItemIsEditable
 
         return flags

--- a/avalon/tools/models.py
+++ b/avalon/tools/models.py
@@ -213,19 +213,34 @@ class TasksModel(TreeModel):
                                       color=style.colors.default)
                 self._icons[task["name"]] = icon
 
-    def set_assets(self, asset_ids):
+    def set_assets(self, asset_ids=[], asset_entities=None):
         """Set assets to track by their database id
 
         Arguments:
             asset_ids (list): List of asset ids.
+            asset_entities (list): List of asset entities from MongoDB.
 
         """
 
         assets = list()
-        for asset_id in asset_ids:
-            asset = io.find_one({"_id": asset_id, "type": "asset"})
-            assert asset, "Asset not found by id: {0}".format(asset_id)
-            assets.append(asset)
+        if asset_entities is not None:
+            assets = asset_entities
+        elif asset_ids:
+            # prepare filter query
+            _filter = {"type": "asset", "_id": {"$in": asset_ids}}
+
+            # find assets in db by query
+            assets = list(io.find(_filter))
+            db_assets_ids = [asset["_id"] for asset in assets]
+
+            # check if all assets were found
+            not_found = [
+                str(a_id) for a_id in asset_ids if a_id not in db_assets_ids
+            ]
+
+            assert not not_found, "Assets not found by id: {0}".format(
+                ", ".join(not_found)
+            )
 
         self._num_assets = len(assets)
 

--- a/avalon/tools/models.py
+++ b/avalon/tools/models.py
@@ -343,7 +343,7 @@ class AssetModel(TreeModel):
         """
         if silos:
             # WARNING: Silo item "_id" is set to silo value
-            # mainly because GUI issue with perserve selection and expanded row
+            # mainly because GUI issue with preserve selection and expanded row
             # and because of easier hierarchy parenting (in "assets")
             for silo in silos:
                 item = Item({

--- a/avalon/tools/models.py
+++ b/avalon/tools/models.py
@@ -6,7 +6,7 @@ from ..vendor.Qt import QtCore, QtGui
 from ..vendor import qtawesome
 from .. import io
 from .. import style
-from .. import lib
+from . import lib
 
 log = logging.getLogger(__name__)
 
@@ -397,7 +397,7 @@ class AssetModel(TreeModel):
         project_doc = io.find({"type": "project"})
 
         silos = None
-        if lib.roject_use_silo(project_doc):
+        if lib.project_use_silo(project_doc):
             silos = db_assets.distinct("silo")
 
         # Group the assets by their visual parent's id

--- a/avalon/tools/models.py
+++ b/avalon/tools/models.py
@@ -6,6 +6,7 @@ from ..vendor.Qt import QtCore, QtGui
 from ..vendor import qtawesome
 from .. import io
 from .. import style
+from .. import lib
 
 log = logging.getLogger(__name__)
 
@@ -393,11 +394,11 @@ class AssetModel(TreeModel):
 
         # Get all assets sorted by name
         db_assets = io.find({"type": "asset"}).sort("name", 1)
-        silos = db_assets.distinct("silo") or None
+        project_doc = io.find({"type": "project"})
 
-        # if any silo is set to None then it's expected it should not be used
-        if silos and None in silos:
-            silos = None
+        silos = None
+        if lib.roject_use_silo(project_doc):
+            silos = db_assets.distinct("silo")
 
         # Group the assets by their visual parent's id
         assets_by_parent = collections.defaultdict(list)

--- a/avalon/tools/models.py
+++ b/avalon/tools/models.py
@@ -399,10 +399,9 @@ class AssetModel(TreeModel):
         # Group the assets by their visual parent's id
         assets_by_parent = collections.defaultdict(list)
         for asset in db_assets:
-            parent_id = (
-                asset.get("data", {}).get("visualParent") or
-                asset.get("silo")
-            )
+            parent_id = asset.get("data", {}).get("visualParent")
+            if parent_id is None and silos is not None:
+                parent_id = asset.get("silo")
             assets_by_parent[parent_id].append(asset)
 
         # Build the hierarchical tree items recursively

--- a/avalon/tools/projectmanager/app.py
+++ b/avalon/tools/projectmanager/app.py
@@ -1,7 +1,7 @@
 import sys
 
 from ...vendor.Qt import QtWidgets, QtCore
-from ... import io, schema, api, style
+from ... import io, schema, api, style, lib
 
 from .. import lib as tools_lib
 from ..widgets import AssetWidget
@@ -20,15 +20,15 @@ class Window(QtWidgets.QDialog):
 
     def __init__(self, is_silo_project=None, parent=None):
         super(Window, self).__init__(parent)
-        project_name = io.active_project()
+        project_doc = io.find({"type": "project"})
+        project_name = project_doc["name"]
+
         self.setWindowTitle("Project Manager ({0})".format(project_name))
         self.setFocusPolicy(QtCore.Qt.StrongFocus)
         self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
 
         if is_silo_project is None:
-            is_silo_project = True
-            if not io.distinct("silo"):
-                is_silo_project = False
+            is_silo_project = lib.project_use_silo(project_doc)
         self.is_silo_project = is_silo_project
 
         # assets

--- a/avalon/tools/projectmanager/app.py
+++ b/avalon/tools/projectmanager/app.py
@@ -1,7 +1,7 @@
 import sys
 
 from ...vendor.Qt import QtWidgets, QtCore
-from ... import io, schema, api, style, lib
+from ... import io, schema, api, style
 
 from .. import lib as tools_lib
 from ..widgets import AssetWidget
@@ -28,7 +28,7 @@ class Window(QtWidgets.QDialog):
         self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
 
         if is_silo_project is None:
-            is_silo_project = lib.project_use_silo(project_doc)
+            is_silo_project = tools_lib.project_use_silo(project_doc)
         self.is_silo_project = is_silo_project
 
         # assets

--- a/avalon/tools/projectmanager/app.py
+++ b/avalon/tools/projectmanager/app.py
@@ -222,7 +222,7 @@ class Window(QtWidgets.QDialog):
 
         model = self.data["model"]["assets"]
         selected = model.get_selected_assets()
-        self.data["model"]["tasks"].set_assets(asset_entities=selected)
+        self.data["model"]["tasks"].set_assets(selected)
 
 
 def show(root=None, debug=False, parent=None):

--- a/avalon/tools/projectmanager/app.py
+++ b/avalon/tools/projectmanager/app.py
@@ -247,8 +247,8 @@ def show(root=None, debug=False, parent=None):
 
     with tools_lib.application():
         window = Window(parent=parent)
-        window.setStyleSheet(style.load_stylesheet())
         window.show()
+        window.setStyleSheet(style.load_stylesheet())
         window.refresh()
 
         module.window = window

--- a/avalon/tools/projectmanager/app.py
+++ b/avalon/tools/projectmanager/app.py
@@ -118,9 +118,7 @@ class Window(QtWidgets.QDialog):
 
         # Get parent asset (active index in selection)
         model = self.data["model"]["assets"]
-        parent_id = model.get_active_asset()
-
-        parent = model.get_active_asset()
+        parent = model.get_active_asset_document()
 
         if parent and parent["type"] == "silo":
             parent_id = None

--- a/avalon/tools/projectmanager/app.py
+++ b/avalon/tools/projectmanager/app.py
@@ -118,7 +118,7 @@ class Window(QtWidgets.QDialog):
 
         # Get parent asset (active index in selection)
         model = self.data["model"]["assets"]
-        parent = model.get_active_asset_document()
+        parent = model.get_active_asset()
 
         if parent and parent["type"] == "silo":
             parent_id = None
@@ -131,7 +131,9 @@ class Window(QtWidgets.QDialog):
             is_silo_required=self.is_silo_project, parent=self
         )
         if self.is_silo_project:
-            dialog.set_silo_input_enable(silo is None)
+            dialog.set_silo_input_enable(
+                parent_id is None or silo is None
+            )
 
         def _on_asset_created(data):
             """Callback whenever asset gets created"""
@@ -165,7 +167,9 @@ class Window(QtWidgets.QDialog):
             dialog.set_parent(_parent_id)
             dialog.set_silo(_silo)
             if self.is_silo_project:
-                dialog.set_silo_input_enable(_silo is None)
+                dialog.set_silo_input_enable(
+                    _parent_id is None or _silo is None
+                )
 
         # Set initial values
         dialog.set_parent(parent_id)

--- a/avalon/tools/projectmanager/app.py
+++ b/avalon/tools/projectmanager/app.py
@@ -158,7 +158,9 @@ class Window(QtWidgets.QDialog):
                 _silo = parent["name"]
             else:
                 _parent_id = parent["_id"] if parent else None
-                _silo = parent.get("_document", {}).get("silo") if parent else None
+                _silo = None
+                if parent:
+                    _silo = parent.get("_document", {}).get("silo")
 
             dialog.set_parent(_parent_id)
             dialog.set_silo(_silo)

--- a/avalon/tools/projectmanager/app.py
+++ b/avalon/tools/projectmanager/app.py
@@ -18,12 +18,18 @@ class Window(QtWidgets.QDialog):
 
     """
 
-    def __init__(self, parent=None):
+    def __init__(self, is_silo_project=None, parent=None):
         super(Window, self).__init__(parent)
         project_name = io.active_project()
         self.setWindowTitle("Project Manager ({0})".format(project_name))
         self.setFocusPolicy(QtCore.Qt.StrongFocus)
         self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
+
+        if is_silo_project is None:
+            is_silo_project = True
+            if not io.distinct("silo"):
+                is_silo_project = False
+        self.is_silo_project = is_silo_project
 
         # assets
         assets_widgets = QtWidgets.QWidget()
@@ -91,7 +97,6 @@ class Window(QtWidgets.QDialog):
         add_asset.clicked.connect(self.on_add_asset)
         add_task.clicked.connect(self.on_add_task)
         assets.selection_changed.connect(self.on_asset_changed)
-        assets.silo_changed.connect(self.on_silo_changed)
 
         self.resize(800, 500)
 
@@ -115,15 +120,20 @@ class Window(QtWidgets.QDialog):
         model = self.data["model"]["assets"]
         parent_id = model.get_active_asset()
 
-        # Get active silo
-        silo = model.get_current_silo()
-        if not silo:
-            QtWidgets.QMessageBox.critical(self, "Missing silo",
-                                           "Please create a silo first.\n"
-                                           "Use the + tab at the top left.")
-            return
+        parent = model.get_active_asset()
 
-        dialog = AssetCreateDialog(parent=self)
+        if parent and parent["type"] == "silo":
+            parent_id = None
+            silo = parent["name"]
+        else:
+            parent_id = parent["_id"] if parent else None
+            silo = parent.get("_document", {}).get("silo") if parent else None
+
+        dialog = AssetCreateDialog(
+            is_silo_required=self.is_silo_project, parent=self
+        )
+        if self.is_silo_project:
+            dialog.set_silo_input_enable(silo is None)
 
         def _on_asset_created(data):
             """Callback whenever asset gets created"""
@@ -145,8 +155,17 @@ class Window(QtWidgets.QDialog):
             """
 
             parent = model.get_active_asset()
-            dialog.set_parent(parent)
-            dialog.set_silo(model.get_current_silo())
+            if parent and parent["type"] == "silo":
+                _parent_id = None
+                _silo = parent["name"]
+            else:
+                _parent_id = parent["_id"] if parent else None
+                _silo = parent.get("_document", {}).get("silo") if parent else None
+
+            dialog.set_parent(_parent_id)
+            dialog.set_silo(_silo)
+            if self.is_silo_project:
+                dialog.set_silo_input_enable(_silo is None)
 
         # Set initial values
         dialog.set_parent(parent_id)
@@ -175,9 +194,8 @@ class Window(QtWidgets.QDialog):
         # Add tasks in database for selected assets
         model = self.data["model"]["assets"]
         selected = model.get_selected_assets()
-        for asset_id in selected:
-            _filter = {"_id": asset_id}
-            asset = io.find_one(_filter)
+        for asset in selected:
+            _filter = {"_id": asset["_id"]}
             asset_tasks = asset.get("data", {}).get("tasks", [])
             for task in tasks:
                 if task not in asset_tasks:
@@ -189,7 +207,8 @@ class Window(QtWidgets.QDialog):
             schema.validate(asset)
             io.replace_one(_filter, asset)
 
-        # Refresh the tasks model
+        # Refresh assets from db and the tasks model with new task
+        self.refresh()
         self.on_asset_changed()
 
         self.echo("Added tasks: {0}".format(", ".join(tasks)))
@@ -203,12 +222,7 @@ class Window(QtWidgets.QDialog):
 
         model = self.data["model"]["assets"]
         selected = model.get_selected_assets()
-        self.data["model"]["tasks"].set_assets(selected)
-
-    def on_silo_changed(self, silo):
-        """Callback on asset silo changed"""
-        if silo:
-            self.echo("Silo changed to: {0}".format(silo))
+        self.data["model"]["tasks"].set_assets(asset_entities=selected)
 
 
 def show(root=None, debug=False, parent=None):
@@ -232,9 +246,9 @@ def show(root=None, debug=False, parent=None):
         io.install()
 
     with tools_lib.application():
-        window = Window(parent)
-        window.show()
+        window = Window(parent=parent)
         window.setStyleSheet(style.load_stylesheet())
+        window.show()
         window.refresh()
 
         module.window = window

--- a/avalon/tools/projectmanager/dialogs.py
+++ b/avalon/tools/projectmanager/dialogs.py
@@ -197,8 +197,19 @@ class AssetCreateDialog(QtWidgets.QDialog):
             "label": label,
             "visualParent": parent_id
         }
+
         if self.is_silo_required:
             data["silo"] = silo
+
+        else:
+            # Add "parents" key if not silo required
+            parents = []
+            if self.parent_doc:
+                # Use parent's "parents" value and append it's "label"
+                # WARNING this requires to have already set "parents" on asset
+                parents = self.parent_doc["data"]["parents"]
+                parents.append(self.parent_doc["data"]["label"])
+            data["parents"] = parents
 
         # For the launcher automatically add a `group` dataa when the asset
         # is added under a visual parent to look as if it's grouped underneath

--- a/avalon/tools/projectmanager/dialogs.py
+++ b/avalon/tools/projectmanager/dialogs.py
@@ -57,18 +57,25 @@ class AssetCreateDialog(QtWidgets.QDialog):
 
     asset_created = QtCore.Signal(dict)
 
-    def __init__(self, parent=None):
+    def __init__(self, is_silo_required=True, parent=None):
         super(AssetCreateDialog, self).__init__(parent=parent)
         self.setWindowTitle("Add asset")
+        self.is_silo_required = is_silo_required
 
         self.parent_id = None
         self.parent_name = ""
-        self.silo = ""
 
         # Label
         label_label = QtWidgets.QLabel("Label:")
         label = QtWidgets.QLineEdit()
         label.setPlaceholderText("<label>")
+
+        # Silo - backwards compatibility
+        silo_label = QtWidgets.QLabel("Silo:")
+        silo_label.setVisible(is_silo_required)
+        silo_field = QtWidgets.QLineEdit()
+        silo_field.setPlaceholderText("<silo>")
+        silo_field.setVisible(is_silo_required)
 
         # Parent
         parent_label = QtWidgets.QLabel("Parent:")
@@ -89,6 +96,8 @@ class AssetCreateDialog(QtWidgets.QDialog):
         layout = QtWidgets.QVBoxLayout(self)
         layout.addWidget(label_label)
         layout.addWidget(label)
+        layout.addWidget(silo_label)
+        layout.addWidget(silo_field)
         layout.addWidget(parent_label)
         layout.addWidget(parent_field)
         layout.addWidget(name_label)
@@ -96,8 +105,15 @@ class AssetCreateDialog(QtWidgets.QDialog):
         layout.addWidget(add_asset)
 
         self.data = {
+            "labels": {
+                "parent": parent_label,
+                "silo": silo_label,
+                "label": label_label,
+                "name": name_label
+            },
             "label": {
                 "parent": parent_field,
+                "silo": silo_field,
                 "label": label,
                 "name": name
             }
@@ -112,8 +128,10 @@ class AssetCreateDialog(QtWidgets.QDialog):
         add_asset.clicked.connect(self.on_add_asset)
 
     def set_silo(self, silo):
-        assert silo
-        self.silo = silo
+        self.data["label"]["silo"].setText(silo or "")
+
+    def set_silo_input_enable(self, enabled=False):
+        self.data["label"]["silo"].setEnabled(enabled)
 
     def set_parent(self, parent_id):
 
@@ -155,18 +173,20 @@ class AssetCreateDialog(QtWidgets.QDialog):
         parent_id = self.parent_id
         name = self.data["label"]["name"].text()
         label = self.data["label"]["label"].text()
-        silo = self.silo
 
         if not label:
             QtWidgets.QMessageBox.warning(self, "Missing required label",
                                           "Please fill in asset label.")
             return
 
-        if not silo:
-            QtWidgets.QMessageBox.critical(self, "Missing silo",
-                                           "Please create a silo first.\n"
-                                           "Use the + tab at the top.")
-            return
+        if self.is_silo_required:
+            silo_field = self.data["label"]["silo"]
+            silo = silo_field.text()
+            if not silo:
+                QtWidgets.QMessageBox.critical(
+                    self, "Missing silo", "Please enter a silo."
+                )
+                return
 
         # Name is based on label, so if label passes then name should too
         assert name, "This is a bug"
@@ -174,9 +194,10 @@ class AssetCreateDialog(QtWidgets.QDialog):
         data = {
             "name": name,
             "label": label,
-            "silo": silo,
             "visualParent": parent_id
         }
+        if self.is_silo_required:
+            data["silo"] = silo
 
         # For the launcher automatically add a `group` dataa when the asset
         # is added under a visual parent to look as if it's grouped underneath
@@ -188,7 +209,7 @@ class AssetCreateDialog(QtWidgets.QDialog):
                 data["group"] = group
 
         try:
-            lib.create_asset(data)
+            lib.create_asset(data, self.is_silo_required)
         except (RuntimeError, AssertionError) as exc:
             QtWidgets.QMessageBox.critical(self, "Add asset failed",
                                            str(exc))

--- a/avalon/tools/projectmanager/dialogs.py
+++ b/avalon/tools/projectmanager/dialogs.py
@@ -62,8 +62,7 @@ class AssetCreateDialog(QtWidgets.QDialog):
         self.setWindowTitle("Add asset")
         self.is_silo_required = is_silo_required
 
-        self.parent_id = None
-        self.parent_name = ""
+        self.parent_doc = None
 
         # Label
         label_label = QtWidgets.QLabel("Label:")
@@ -136,18 +135,16 @@ class AssetCreateDialog(QtWidgets.QDialog):
     def set_parent(self, parent_id):
 
         # Get the parent asset (if any provided)
-        parent_name = ""
         if parent_id:
-            parent_asset = io.find_one({"_id": parent_id, "type": "asset"})
-            assert parent_asset, "Parent asset does not exist."
-            parent_name = parent_asset["name"]
+            parent_doc = io.find_one({"_id": parent_id, "type": "asset"})
+            assert parent_doc, "Parent asset does not exist."
+            parent_name = parent_doc["name"]
 
-            self.parent_name = parent_name
-            self.parent_id = parent_id
+            self.parent_doc = parent_doc
         else:
             # Clear the parent
-            self.parent_name = ""
-            self.parent_id = None
+            parent_name = ""
+            self.parent_doc = None
 
         self.data["label"]["parent"].setText(parent_name)
 
@@ -163,14 +160,18 @@ class AssetCreateDialog(QtWidgets.QDialog):
         name = label
 
         # Prefix with parent name (if parent)
-        if self.parent_name:
-            name = self.parent_name + "_" + name
+        if self.parent_doc:
+            name = "_".join((self.parent_doc["name"], name))
 
         self.data["label"]["name"].setText(name)
 
     def on_add_asset(self):
 
-        parent_id = self.parent_id
+        if self.parent_doc:
+            parent_id = self.parent_doc["_id"]
+        else:
+            parent_id = None
+
         name = self.data["label"]["name"].text()
         label = self.data["label"]["label"].text()
 

--- a/avalon/tools/projectmanager/lib.py
+++ b/avalon/tools/projectmanager/lib.py
@@ -21,8 +21,7 @@ def create_asset(data, silo_required):
     """Create asset
 
     Requires:
-        {"name": "uniquecode",
-         "silo": "assets"}
+        {"name": "uniquecode"}
 
      Optional:
         {"data": {}}
@@ -34,12 +33,17 @@ def create_asset(data, silo_required):
     if project is None:
         raise RuntimeError("Project must exist prior to creating assets")
 
+    # Use asset schema 2.0 when silo is required
+    if silo_required:
+        schema_name = "avalon-core:asset-2.0"
+    else:
+        schema_name = "avalon-core:asset-3.0"
+
     asset = {
-        "schema": "avalon-core:asset-2.0",
+        "schema": schema_name,
         "parent": project["_id"],
         "name": data.pop("name"),
-        "type": "asset",
-        "data": data
+        "type": "asset"
     }
 
     # Asset *must* have a name
@@ -48,6 +52,9 @@ def create_asset(data, silo_required):
     if silo_required:
         asset["silo"] = data.pop("silo")
         assert asset["silo"], "Asset has no silo"
+
+    # Set asset's data when all keys are popped
+    asset["data"] = data
 
     # Ensure it has a unique name
     asset_doc = io.find_one({

--- a/avalon/tools/projectmanager/lib.py
+++ b/avalon/tools/projectmanager/lib.py
@@ -17,7 +17,7 @@ provides a bridge between the file-based project inventory and configuration.
 from ... import schema, io
 
 
-def create_asset(data):
+def create_asset(data, silo_required):
     """Create asset
 
     Requires:
@@ -38,14 +38,16 @@ def create_asset(data):
         "schema": "avalon-core:asset-2.0",
         "parent": project["_id"],
         "name": data.pop("name"),
-        "silo": data.pop("silo"),
         "type": "asset",
         "data": data
     }
 
-    # Asset *must* have a name and silo
+    # Asset *must* have a name
     assert asset["name"], "Asset has no name"
-    assert asset["silo"], "Asset has no silo"
+    # Backwards compatibility with required silo
+    if silo_required:
+        asset["silo"] = data.pop("silo")
+        assert asset["silo"], "Asset has no silo"
 
     # Ensure it has a unique name
     asset_doc = io.find_one({

--- a/avalon/tools/widgets.py
+++ b/avalon/tools/widgets.py
@@ -90,7 +90,12 @@ class AssetWidget(QtWidgets.QWidget):
     def get_active_asset(self):
         """Return the asset id the current asset."""
         current = self.view.currentIndex()
-        return current.data(self.model.ItemRole)
+        return current.data(self.model.ObjectIdRole)
+
+    def get_active_asset_document(self):
+        """Return the asset id the current asset."""
+        current = self.view.currentIndex()
+        return current.data(self.model.DocumentRole)
 
     def get_active_index(self):
         return self.view.currentIndex()

--- a/avalon/tools/widgets.py
+++ b/avalon/tools/widgets.py
@@ -90,7 +90,7 @@ class AssetWidget(QtWidgets.QWidget):
     def get_active_asset(self):
         """Return the asset id the current asset."""
         current = self.view.currentIndex()
-        return current.data(self.model.ObjectIdRole)
+        return current.data(self.model.ItemRole)
 
     def get_active_asset_document(self):
         """Return the asset id the current asset."""

--- a/avalon/tools/widgets.py
+++ b/avalon/tools/widgets.py
@@ -152,7 +152,7 @@ class AssetWidget(QtWidgets.QWidget):
                 continue
 
             # Remove processed asset
-            assets.discard(assets.index(value))
+            assets.discard(value)
 
             selection_model.select(index, mode)
             if expand:

--- a/avalon/tools/widgets.py
+++ b/avalon/tools/widgets.py
@@ -88,12 +88,12 @@ class AssetWidget(QtWidgets.QWidget):
         self._refresh_model()
 
     def get_active_asset(self):
-        """Return the asset id the current asset."""
+        """Return the asset item of the current selection."""
         current = self.view.currentIndex()
         return current.data(self.model.ItemRole)
 
     def get_active_asset_document(self):
-        """Return the asset id the current asset."""
+        """Return the asset document of the current selection."""
         current = self.view.currentIndex()
         return current.data(self.model.DocumentRole)
 
@@ -122,11 +122,10 @@ class AssetWidget(QtWidgets.QWidget):
             None
 
         Default `key` is "name" in that case `assets` should contain single
-        asset name or list of asset names. (It is good idea to use "_id" key
-        instead of name in that case `assets` must contain `ObjectId` object/s)
-        It is expected that each value in `assets` will be found only once.
-        If the filters according to the `key` and `assets` correspond to
-        the more asset, only the first found will be selected.
+        asset name or list of asset names. It is recommended to use "_id" key
+        instead of name. In that case `assets` must contain `ObjectId` objects.
+        It is assumed that each value in `assets` is found only once.
+        On multiple matches only the first found will be selected.
         """
         # TODO: Instead of individual selection optimize for many assets
 

--- a/avalon/tools/widgets.py
+++ b/avalon/tools/widgets.py
@@ -23,31 +23,17 @@ class AssetWidget(QtWidgets.QWidget):
 
     """
 
-    silo_changed = QtCore.Signal(str)    # on silo combobox change
     assets_refreshed = QtCore.Signal()   # on model refresh
     selection_changed = QtCore.Signal()  # on view selection change
     current_changed = QtCore.Signal()    # on view current index change
 
-    def __init__(self, silo_creatable=True, parent=None):
+    def __init__(self, parent=None):
         super(AssetWidget, self).__init__(parent=parent)
         self.setContentsMargins(0, 0, 0, 0)
 
         layout = QtWidgets.QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(4)
-
-        # Header
-        header = QtWidgets.QHBoxLayout()
-
-        silo = SiloTabWidget(silo_creatable=silo_creatable)
-
-        icon = qtawesome.icon("fa.refresh", color=style.colors.light)
-        refresh = QtWidgets.QPushButton(icon, "")
-        refresh.setToolTip("Refresh items")
-
-        header.addWidget(silo)
-        header.addStretch(1)
-        header.addWidget(refresh)
 
         # Tree View
         model = AssetModel()
@@ -61,98 +47,89 @@ class AssetWidget(QtWidgets.QWidget):
         view.setHeaderHidden(True)
         view.setModel(proxy)
 
+        # Header
+        header = QtWidgets.QHBoxLayout()
+
+        icon = qtawesome.icon("fa.refresh", color=style.colors.light)
+        refresh = QtWidgets.QPushButton(icon, "")
+        refresh.setToolTip("Refresh items")
+
         filter = QtWidgets.QLineEdit()
         filter.textChanged.connect(proxy.setFilterFixedString)
         filter.setPlaceholderText("Filter assets..")
 
+        header.addWidget(filter)
+        header.addWidget(refresh)
+
         # Layout
         layout.addLayout(header)
-        layout.addWidget(filter)
         layout.addWidget(view)
 
         # Signals/Slots
         selection = view.selectionModel()
         selection.selectionChanged.connect(self.selection_changed)
         selection.currentChanged.connect(self.current_changed)
-        silo.silo_changed.connect(self._on_silo_changed)
         refresh.clicked.connect(self.refresh)
 
         self.refreshButton = refresh
-        self.silo = silo
         self.model = model
         self.proxy = proxy
         self.view = view
 
-    def _on_silo_changed(self):
-        """Callback for silo change"""
-
-        self._refresh_model()
-        silo = self.get_current_silo()
-        self.silo_changed.emit(silo)
-        self.selection_changed.emit()
-
     def _refresh_model(self):
-
-        silo = self.get_current_silo()
-        with lib.preserve_expanded_rows(self.view,
-                                        column=0,
-                                        role=self.model.ObjectIdRole):
-            with lib.preserve_selection(self.view,
-                                        column=0,
-                                        role=self.model.ObjectIdRole):
-                self.model.set_silo(silo)
+        with lib.preserve_states(
+            self.view, column=0, role=self.model.ObjectIdRole
+        ):
+            self.model.refresh()
 
         self.assets_refreshed.emit()
 
     def refresh(self):
-
-        silos = _list_project_silos()
-        self.silo.set_silos(silos)
-
         self._refresh_model()
-
-    def get_current_silo(self):
-        """Returns the currently active silo."""
-        return self.silo.get_current_silo()
 
     def get_active_asset(self):
         """Return the asset id the current asset."""
         current = self.view.currentIndex()
-        return current.data(self.model.ObjectIdRole)
-
-    def get_active_asset_document(self):
-        """Return the asset id the current asset."""
-        current = self.view.currentIndex()
-        return current.data(self.model.DocumentRole)
+        return current.data(self.model.ItemRole)
 
     def get_active_index(self):
         return self.view.currentIndex()
 
     def get_selected_assets(self):
-        """Return the assets' ids that are selected."""
+        """Return the documents of selected assets."""
         selection = self.view.selectionModel()
         rows = selection.selectedRows()
-        return [row.data(self.model.ObjectIdRole) for row in rows]
+        assets = [row.data(self.model.DocumentRole) for row in rows]
 
-    def set_silo(self, silo):
-        """Set the active silo tab"""
-        self.silo.set_current_silo(silo)
+        # NOTE: skip None object assumed they are silo (backwards comp.)
+        return [asset for asset in assets if asset]
 
-    def select_assets(self, assets, expand=True):
-        """Select assets by name.
+    def select_assets(self, assets, expand=True, key="name"):
+        """Select assets by item key.
 
         Args:
-            assets (list): List of asset names
+            assets (list): List of asset values that can be found under
+                specified `key`
             expand (bool): Whether to also expand to the asset in the view
+            key (string): Key that specifies where to look for `assets` values
 
         Returns:
             None
 
+        Default `key` is "name" in that case `assets` should contain single
+        asset name or list of asset names. (It is good idea to use "_id" key
+        instead of name in that case `assets` must contain `ObjectId` object/s)
+        It is expected that each value in `assets` will be found only once.
+        If the filters according to the `key` and `assets` correspond to
+        the more asset, only the first found will be selected.
         """
         # TODO: Instead of individual selection optimize for many assets
 
-        assert isinstance(assets,
-                          (tuple, list)), "Assets must be list or tuple"
+        if not isinstance(assets, (tuple, list)):
+            assets = [assets]
+
+        # convert to list - tuple cant be modified
+        assets = list(assets)
 
         # Clear selection
         selection_model = self.view.selectionModel()
@@ -160,173 +137,27 @@ class AssetWidget(QtWidgets.QWidget):
 
         # Select
         mode = selection_model.Select | selection_model.Rows
-        for index in lib.iter_model_rows(self.proxy,
-                                         column=0,
-                                         include_root=False):
-            data = index.data(self.model.ItemRole)
-            name = data["name"]
-            if name in assets:
-                selection_model.select(index, mode)
-
-                if expand:
-                    self.view.expand(index)
-
-                # Set the currently active index
-                self.view.setCurrentIndex(index)
-
-
-class SiloTabWidget(QtWidgets.QTabBar):
-    """Silo widget
-
-    Allows to add a silo, with "+" tab.
-
-    Note:
-        When no silos are present an empty stub silo is added to
-        use as the "blank" tab to start on, so the + tab becomes
-        clickable.
-
-    """
-
-    silo_changed = QtCore.Signal(str)
-    silo_added = QtCore.Signal(str)
-
-    def __init__(self, silo_creatable=True, parent=None):
-        super(SiloTabWidget, self).__init__(parent=parent)
-        self.silo_creatable = silo_creatable
-        self._previous_tab_index = -1
-        self.set_silos([])
-
-        self.setContentsMargins(0, 0, 0, 0)
-        self.setFixedHeight(28)
-        font = QtGui.QFont()
-        font.setBold(True)
-        self.setFont(font)
-
-        self.currentChanged.connect(self.on_tab_changed)
-
-    def on_tab_changed(self, index):
-
-        if index == self._previous_tab_index:
-            return
-
-        # If it's the last tab
-        num = self.count()
-        if self.silo_creatable and index == num - 1:
-            self.on_add_silo()
-            self.setCurrentIndex(self._previous_tab_index)
-            return
-
-        silo = self.tabText(index)
-        self.silo_changed.emit(silo)
-
-        # Store for the next calls
-        self._previous_tab_index = index
-
-    def clear(self):
-        """Removes all tabs.
-
-        Implemented similar to `QTabWidget.clear()`
-
-        """
-        for i in range(self.count()):
-            self.removeTab(0)
-
-    def set_silos(self, silos):
-
-        current_silo = self.get_current_silo()
-
-        if not silos:
-            # Add an emtpy stub tab to start on.
-            silos = [""]
-
-        # Populate the silos without emitting signals
-        self.blockSignals(True)
-        self.clear()
-        for silo in sorted(silos):
-            self.addTab(silo)
-
-        if self.silo_creatable:
-            # Add the "+" tab
-            self.addTab("+")
-
-        self.set_current_silo(current_silo)
-        self.blockSignals(False)
-
-        # Assume the current index is "fine"
-        self._previous_tab_index = self.currentIndex()
-
-        # Only emit a silo changed signal if the new signal
-        # after refresh is not the same as prior to it (e.g.
-        # when the silo was removed, or alike.)
-        if current_silo != self.get_current_silo():
-            self.currentChanged.emit(self.currentIndex())
-
-    def set_current_silo(self, silo):
-        """Set the active silo by name or index.
-
-        Args:
-            silo (str or int): The silo name or index.
-
-        """
-
-        # Already set
-        if silo == self.get_current_silo():
-            return
-
-        # Otherwise change the silo box to the name
-        for i in range(self.count()):
-            text = self.tabText(i)
-            if text == silo:
-                self.setCurrentIndex(i)
+        for index in lib.iter_model_rows(
+            self.proxy, column=0, include_root=False
+        ):
+            # stop iteration if there are no assets to process
+            if not assets:
                 break
 
-    def get_current_silo(self):
-        index = self.currentIndex()
-        return self.tabText(index)
-
-    def on_add_silo(self):
-        silo, state = QtWidgets.QInputDialog.getText(self,
-                                                     "Silo name",
-                                                     "Create new silo:")
-        if not state or not silo:
-            return
-
-        self.add_silo(silo)
-
-    def get_silos(self):
-        """Return the currently available silos"""
-
-        # Ignore first tab if empty
-        # Ignore the last tab because it is the "+" tab
-        silos = []
-        for i in range(self.count() - 1):
-            label = self.tabText(i)
-            if i == 0 and not label:
+            value = index.data(self.model.ItemRole).get(key)
+            if value not in assets:
                 continue
-            silos.append(label)
-        return silos
 
-    def add_silo(self, silo):
+            # Remove processed asset
+            assets.pop(assets.index(value))
 
-        # Add the silo
-        silos = self.get_silos()
-        silos.append(silo)
-        silos = list(set(silos))  # ensure unique
-        self.set_silos(silos)
-        self.silo_added.emit(silo)
+            selection_model.select(index, mode)
+            if expand:
+                # Expand parent index
+                self.view.expand(self.proxy.parent(index))
 
-        self.set_current_silo(silo)
-
-
-def _list_project_silos():
-    """List the silos from the project's configuration"""
-    silos = io.distinct("silo")
-
-    if not silos:
-        project = io.find_one({"type": "project"})
-        log.warning("Project '%s' has no active silos", project["name"])
-
-    return list(sorted(silos))
+            # Set the currently active index
+            self.view.setCurrentIndex(index)
 
 
 class OptionalMenu(QtWidgets.QMenu):

--- a/avalon/tools/widgets.py
+++ b/avalon/tools/widgets.py
@@ -127,13 +127,12 @@ class AssetWidget(QtWidgets.QWidget):
         It is assumed that each value in `assets` is found only once.
         On multiple matches only the first found will be selected.
         """
-        # TODO: Instead of individual selection optimize for many assets
 
         if not isinstance(assets, (tuple, list)):
             assets = [assets]
 
         # convert to list - tuple cant be modified
-        assets = list(assets)
+        assets = set(assets)
 
         # Clear selection
         selection_model = self.view.selectionModel()
@@ -153,7 +152,7 @@ class AssetWidget(QtWidgets.QWidget):
                 continue
 
             # Remove processed asset
-            assets.pop(assets.index(value))
+            assets.discard(assets.index(value))
 
             selection_model.select(index, mode)
             if expand:

--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -306,7 +306,7 @@ class TasksWidget(QtWidgets.QWidget):
         if current:
             self._last_selected_task = current
 
-        self.models["tasks"].set_assets(asset_entities=assets)
+        self.models["tasks"].set_assets(assets)
 
         if self._last_selected_task:
             self.select_task(self._last_selected_task)

--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -746,7 +746,7 @@ class Window(QtWidgets.QMainWindow):
         widgets = {
             "pages": QtWidgets.QStackedWidget(),
             "body": QtWidgets.QWidget(),
-            "assets": AssetWidget(parent=self),
+            "assets": AssetWidget(),
             "tasks": TasksWidget(),
             "files": FilesWidget()
         }

--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -297,10 +297,7 @@ class TasksWidget(QtWidgets.QWidget):
 
     def set_asset(self, asset):
 
-        assets = []
-        if asset is not None:
-            # Asset deselected
-            assets.append(asset)
+        assets = [asset] if asset else []
 
         # Try and preserve the last selected task and reselect it
         # after switching assets. If there's no currently selected


### PR DESCRIPTION
## Problem
The concept of silos becomes problematic as projects grow larger and longer. The problem is visual where it's uncomfortable to browse through them with tabs, but also it's a bit limiting in terms of project structure.

## Suggested solution

We suggest dropping them completely and instead consider any asset witch has `visualParent` set to `Null` as highest hierarchy member to be shown directly under the project in the GUIs. We've run this at all our sites for around 6 months now, so the key question is backwards compatibility, which I hope we achieved.

This is what the loader for example looks like without the silo tabs.
![image](https://user-images.githubusercontent.com/3333008/76879879-2a66d280-6877-11ea-8182-32e8e673e10e.png)

------
This is a revival of an old PR #372 that was closed after we discovered more caveats to this. General consensus seemed to be towards this change though so hopefully this will work for everyone too.

If someone could give this a shot it would help a lot. Unfortunately, our setups have quite some dependency on Pype and it's hard to be sure that the backwards compatibility doesn't catch on something somewhere on projects of others. 

