### PR TITLE
Change inventory action select back to select all columns in row

### DIFF
--- a/avalon/tools/sceneinventory/app.py
+++ b/avalon/tools/sceneinventory/app.py
@@ -250,7 +250,12 @@ class View(QtWidgets.QTreeView):
             name = node.get("objectName")
             if name in object_names:
                 self.scrollTo(item)  # Ensure item is visible
-                selection_model.select(item, select_mode)
+                # Select entire row
+                for i in range(model.columnCount()):
+                    column = item.sibling(item.row(), i)
+                    if column.isValid():
+                        selection_model.select(column, select_mode)
+
                 object_names.remove(name)
 
             if len(object_names) == 0:

--- a/avalon/tools/sceneinventory/app.py
+++ b/avalon/tools/sceneinventory/app.py
@@ -250,11 +250,8 @@ class View(QtWidgets.QTreeView):
             name = node.get("objectName")
             if name in object_names:
                 self.scrollTo(item)  # Ensure item is visible
-                # Select entire row
-                for i in range(model.columnCount()):
-                    column = item.sibling(item.row(), i)
-                    if column.isValid():
-                        selection_model.select(column, select_mode)
+                flags = select_mode | selection_model.Rows
+                selection_model.select(item, flags)
 
                 object_names.remove(name)
 


### PR DESCRIPTION
### What's changed ?
The scene inventory will select entire rows by action process result, instead of selecting only first column of rows. And will fixes #536.