### PR TITLE
Resilience against missing paths

### DIFF
--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -1240,8 +1240,10 @@ def get_representation_path(representation):
             # Template references unavailable data
             return None
 
-        if os.path.exists(path):
-            return os.path.normpath(path)
+        normalized_path = os.path.normpath(path)
+        if os.path.exists(normalized_path):
+            return normalized_path
+        return path
 
     def path_from_config():
         try:
@@ -1282,16 +1284,20 @@ def get_representation_path(representation):
             log.debug("Template references unavailable data: %s" % e)
             return None
 
-        if os.path.exists(path):
-            return os.path.normpath(path)
+        normalized_path = os.path.normpath(path)
+        if os.path.exists(normalized_path):
+            return normalized_path
+        return path
 
     def path_from_data():
         if "path" not in representation["data"]:
             return None
 
         path = representation["data"]["path"]
-        if os.path.exists(path):
-            return os.path.normpath(path)
+        normalized_path = os.path.normpath(path)
+        if os.path.exists(normalized_path):
+            return normalized_path
+        return path
 
     return (
         path_from_represenation() or


### PR DESCRIPTION
New PR based on https://github.com/getavalon/core/pull/424/files.

- each of 3 methods in `get_representation_path` return path even if formatted path does not exist
- returned path is not normalized if path does not exist