### PR TITLE
Prevent double save confirmation

### DIFF
--- a/avalon/nuke/workio.py
+++ b/avalon/nuke/workio.py
@@ -13,7 +13,7 @@ def has_unsaved_changes():
 
 def save_file(filepath):
     path = filepath.replace("\\", "/")
-    nuke.scriptSaveAs(path)
+    nuke.scriptSave()
     nuke.Root()["name"].setValue(path)
     nuke.Root()["project_directory"].setValue(os.path.dirname(path))
     nuke.Root().setModified(False)


### PR DESCRIPTION
Previous behaviour resulted in double confirmation about saving the Nuke script. To be precise with "saveScriptAs" Nuke asks whether to overwrite the file, but this has already been confirmed by the user in the Workfiles app.