### PR TITLE
Fix project query in tools

### DIFF
--- a/avalon/tools/models.py
+++ b/avalon/tools/models.py
@@ -394,7 +394,7 @@ class AssetModel(TreeModel):
 
         # Get all assets sorted by name
         db_assets = io.find({"type": "asset"}).sort("name", 1)
-        project_doc = io.find({"type": "project"})
+        project_doc = io.find_one({"type": "project"})
 
         silos = None
         if lib.project_use_silo(project_doc):

--- a/avalon/tools/projectmanager/app.py
+++ b/avalon/tools/projectmanager/app.py
@@ -20,7 +20,7 @@ class Window(QtWidgets.QDialog):
 
     def __init__(self, is_silo_project=None, parent=None):
         super(Window, self).__init__(parent)
-        project_doc = io.find({"type": "project"})
+        project_doc = io.find_one({"type": "project"})
         project_name = project_doc["name"]
 
         self.setWindowTitle("Project Manager ({0})".format(project_name))


### PR DESCRIPTION
# Problem
For query project documents is used `find` method which returns iterable instead of single document. Issue cause by PR https://github.com/getavalon/core/pull/535.

# Solution
For project document query is used `find_one` method.
