### PR TITLE
Asset multiselection in loader 

### DIFF
--- a/avalon/style/style.qss
+++ b/avalon/style/style.qss
@@ -1221,3 +1221,7 @@ QSplitter::handle:horizontal:hover {
 QSplitter {
     border: 0px;
 }
+
+#AssetsView[multiselection=true] {
+    selection-background-color: rgba(0, 0, 0, 0);
+}

--- a/avalon/tools/delegates.py
+++ b/avalon/tools/delegates.py
@@ -3,10 +3,16 @@ from datetime import datetime
 import logging
 import numbers
 
-from ..vendor.Qt import QtWidgets, QtCore
-from .. import io
+from .models import TreeModel, AssetModel
 
-from .models import TreeModel
+from .. import io
+from ..vendor.Qt import QtWidgets, QtGui, QtCore
+
+from ..vendor import Qt
+if Qt.__binding__ == "PySide":
+    from PySide.QtGui import QStyleOptionViewItemV4
+elif Qt.__binding__ == "PyQt4":
+    from PyQt4.QtGui import QStyleOptionViewItemV4
 
 log = logging.getLogger(__name__)
 
@@ -28,7 +34,7 @@ class VersionDelegate(QtWidgets.QStyledItemDelegate):
 
     def createEditor(self, parent, option, index):
         item = index.data(TreeModel.ItemRole)
-        if item.get("isGroup"):
+        if item.get("isGroup") or item.get("isMerged"):
             return
 
         editor = QtWidgets.QComboBox(parent)
@@ -181,3 +187,147 @@ class PrettyTimeDelegate(QtWidgets.QStyledItemDelegate):
             return
 
         return pretty_timestamp(value)
+
+
+class AssetDelegate(QtWidgets.QItemDelegate):
+    bar_height = 3
+
+    def sizeHint(self, option, index):
+        result = super(AssetDelegate, self).sizeHint(option, index)
+        result.setHeight(result.height() + self.bar_height)
+
+        return result
+
+    def paint(self, painter, option, index):
+        # Qt4 compat
+        if Qt.__binding__ in ("PySide", "PyQt4"):
+            option = QStyleOptionViewItemV4(option)
+
+        painter.save()
+
+        item_rect = QtCore.QRect(option.rect)
+        item_rect.setHeight(option.rect.height() - self.bar_height)
+
+        subset_colors = index.data(AssetModel.subsetColorsRole)
+        subset_colors_width = 0
+        if subset_colors:
+            subset_colors_width = option.rect.width() / len(subset_colors)
+
+        subset_rects = []
+        counter = 0
+        for subset_c in subset_colors:
+            new_color = None
+            new_rect = None
+            if subset_c:
+                new_color = QtGui.QColor(*subset_c)
+
+                new_rect = QtCore.QRect(
+                    option.rect.left() + (counter * subset_colors_width),
+                    option.rect.top() + (
+                        option.rect.height() - self.bar_height
+                    ),
+                    subset_colors_width,
+                    self.bar_height
+                )
+            subset_rects.append((new_color, new_rect))
+            counter += 1
+
+        # Background
+        bg_color = QtGui.QColor(60, 60, 60)
+        if option.state & QtWidgets.QStyle.State_Selected:
+            if len(subset_colors) == 0:
+                item_rect.setTop(item_rect.top() + (self.bar_height / 2))
+            if option.state & QtWidgets.QStyle.State_MouseOver:
+                bg_color.setRgb(70, 70, 70)
+        else:
+            item_rect.setTop(item_rect.top() + (self.bar_height / 2))
+            if option.state & QtWidgets.QStyle.State_MouseOver:
+                bg_color.setAlpha(100)
+            else:
+                bg_color.setAlpha(0)
+
+        pen = painter.pen()
+        pen.setStyle(QtCore.Qt.NoPen)
+        pen.setWidth(0)
+        painter.setPen(pen)
+        painter.setBrush(QtGui.QBrush(bg_color))
+        painter.drawRoundedRect(option.rect, 3, 3)
+
+        if option.state & QtWidgets.QStyle.State_Selected:
+            for color, subset_rect in subset_rects:
+                if not color or not subset_rect:
+                    continue
+                painter.fillRect(subset_rect, QtGui.QBrush(color))
+
+        painter.restore()
+        painter.save()
+
+        # Icon
+        icon_index = index.model().index(
+            index.row(), index.column(), index.parent()
+        )
+        # - Default icon_rect if not icon
+        icon_rect = QtCore.QRect(
+            item_rect.left(),
+            item_rect.top(),
+            # To make sure it's same size all the time
+            option.rect.height() - self.bar_height,
+            option.rect.height() - self.bar_height
+        )
+        icon = index.model().data(icon_index, QtCore.Qt.DecorationRole)
+
+        if icon:
+            mode = QtGui.QIcon.Normal
+            if not (option.state & QtWidgets.QStyle.State_Enabled):
+                mode = QtGui.QIcon.Disabled
+            elif option.state & QtWidgets.QStyle.State_Selected:
+                mode = QtGui.QIcon.Selected
+
+            if isinstance(icon, QtGui.QPixmap):
+                icon = QtGui.QIcon(icon)
+                option.decorationSize = icon.size() / icon.devicePixelRatio()
+
+            elif isinstance(icon, QtGui.QColor):
+                pixmap = QtGui.QPixmap(option.decorationSize)
+                pixmap.fill(icon)
+                icon = QtGui.QIcon(pixmap)
+
+            elif isinstance(icon, QtGui.QImage):
+                icon = QtGui.QIcon(QtGui.QPixmap.fromImage(icon))
+                option.decorationSize = icon.size() / icon.devicePixelRatio()
+
+            elif isinstance(icon, QtGui.QIcon):
+                state = QtGui.QIcon.Off
+                if option.state & QtWidgets.QStyle.State_Open:
+                    state = QtGui.QIcon.On
+                actualSize = option.icon.actualSize(
+                    option.decorationSize, mode, state
+                )
+                option.decorationSize = QtCore.QSize(
+                    min(option.decorationSize.width(), actualSize.width()),
+                    min(option.decorationSize.height(), actualSize.height())
+                )
+
+            state = QtGui.QIcon.Off
+            if option.state & QtWidgets.QStyle.State_Open:
+                state = QtGui.QIcon.On
+
+            icon.paint(
+                painter, icon_rect,
+                QtCore.Qt.AlignLeft, mode, state
+            )
+
+        # Text
+        text_rect = QtCore.QRect(
+            icon_rect.left() + icon_rect.width() + 2,
+            item_rect.top(),
+            item_rect.width(),
+            item_rect.height()
+        )
+
+        painter.drawText(
+            text_rect, QtCore.Qt.AlignVCenter,
+            index.data(QtCore.Qt.DisplayRole)
+        )
+
+        painter.restore()

--- a/avalon/tools/loader/app.py
+++ b/avalon/tools/loader/app.py
@@ -88,25 +88,21 @@ class Window(QtWidgets.QDialog):
                 "message": message,
             },
             "state": {
-                "template": None,
-                "locations": list(),
-                "context": {
-                    "root": None,
-                    "project": None,
-                    "asset": None,
-                    "assetId": None,
-                    "silo": None,
-                    "subset": None,
-                    "version": None,
-                    "representation": None,
-                },
+                "assetIds": None
             }
         }
 
         families.active_changed.connect(subsets.set_family_filters)
         assets.selection_changed.connect(self.on_assetschanged)
+        assets.view.clicked.connect(self.on_assetview_click)
         subsets.active_changed.connect(self.on_subsetschanged)
         subsets.version_changed.connect(self.on_versionschanged)
+
+        lib.refresh_family_config_cache()
+        lib.refresh_group_config_cache()
+
+        self._refresh()
+        self._assetschanged()
 
         # Defaults
         self.resize(1330, 700)
@@ -114,6 +110,12 @@ class Window(QtWidgets.QDialog):
     # -------------------------------
     # Delay calling blocking methods
     # -------------------------------
+
+    def on_assetview_click(self, *args):
+        subsets_widget = self.data["model"]["subsets"]
+        selection_model = subsets_widget.view.selectionModel()
+        if selection_model.selectedIndexes():
+            selection_model.clearSelection()
 
     def refresh(self):
         self.echo("Fetching results..")
@@ -152,55 +154,56 @@ class Window(QtWidgets.QDialog):
         families = self.data["widgets"]["families"]
         families.refresh()
 
-        # Update state
-        state = self.data["state"]
-        state["template"] = project["config"]["template"]["publish"]
-        state["context"]["root"] = api.registered_root()
-        state["context"]["project"] = project["name"]
+    def clear_assets_underlines(self):
+        """Clear colors from asset data to remove colored underlines
+        When multiple assets are selected colored underlines mark which asset
+        own selected subsets. These colors must be cleared from asset data
+        on selection change so they match current selection.
+        """
+        last_asset_ids = self.data["state"]["assetIds"]
+        if not last_asset_ids:
+            return
+
+        assets_widget = self.data["model"]["assets"]
+        id_role = assets_widget.model.ObjectIdRole
+
+        for index in lib.iter_model_rows(assets_widget.model, 0):
+            if index.data(id_role) not in last_asset_ids:
+                continue
+
+            assets_widget.model.setData(
+                index, [], assets_widget.model.subsetColorsRole
+            )
 
     def _assetschanged(self):
         """Selected assets have changed"""
-
-        assets_model = self.data["model"]["assets"]
-        subsets_widget = self.data["model"]["subsets"]
-        subsets_model = subsets_widget.model
-
         t1 = time.time()
 
-        asset_item = assets_model.get_active_asset()
-        if asset_item is None:
-            document_id = None
-            document_name = None
-            document_silo = None
-        elif asset_item["type"] == "silo":
-            document_id = None
-            document_name = None
-            document_silo = asset_item["name"]
-        else:
-            document = asset_item["_document"]
-            document_id = document["_id"]
-            document_name = document["name"]
-            document_silo = document.get("silo")
+        assets_widget = self.data["model"]["assets"]
+        subsets_widget = self.data["model"]["subsets"]
 
-        # Start loading
-        subsets_widget.set_loading_state(loading=bool(document_name),
-                                         empty=True)
+        subsets_widget.model.clear()
+        self.clear_assets_underlines()
 
-        def on_refreshed(has_item):
-            empty = not has_item
-            subsets_widget.set_loading_state(loading=False, empty=empty)
-            subsets_model.refreshed.disconnect()
-            self.echo("Duration: %.3fs" % (time.time() - t1))
+        # filter None docs they are silo
+        asset_docs = assets_widget.get_selected_assets()
+        if len(asset_docs) == 0:
+            return
 
-        subsets_model.refreshed.connect(on_refreshed)
-        subsets_model.set_asset(document_id)
+        asset_ids = [asset_doc["_id"] for asset_doc in asset_docs]
+        subsets_widget.model.set_assets(asset_ids)
+        subsets_widget.view.setColumnHidden(
+            subsets_widget.model.Columns.index("asset"),
+            len(asset_ids) < 2
+        )
 
         # Clear the version information on asset change
         self.data["model"]["version"].set_version(None)
 
-        self.data["state"]["context"]["asset"] = document_name
-        self.data["state"]["context"]["assetId"] = document_id
-        self.data["state"]["context"]["silo"] = document_silo
+        self.data["state"]["assetIds"] = asset_ids
+
+        self.echo("Duration: %.3fs" % (time.time() - t1))
+
     def _subsetschanged(self):
         asset_ids = self.data["state"]["assetIds"]
         # Skip setting colors if not asset multiselection
@@ -286,7 +289,7 @@ class Window(QtWidgets.QDialog):
     def _set_context(self, context, refresh=True):
         """Set the selection in the interface using a context.
 
-        The context must contain `silo` and `asset` data by name.
+        The context must contain `asset` data by name.
 
         Note: Prior to setting context ensure `refresh` is triggered so that
               the "silos" are listed correctly, aside from that setting the
@@ -356,7 +359,18 @@ class Window(QtWidgets.QDialog):
             self.echo("Grouping not enabled.")
             return
 
-        selected = subsets.selected_subsets()
+        selected = []
+        merged_items = []
+        for item in subsets.selected_subsets(_merged=True):
+            if item.get("isMerged"):
+                merged_items.append(item)
+            else:
+                selected.append(item)
+
+        for merged_item in merged_items:
+            for child_item in merged_item.children():
+                selected.append(child_item)
+
         if not selected:
             self.echo("No selected subset.")
             return
@@ -378,7 +392,7 @@ class SubsetGroupingDialog(QtWidgets.QDialog):
 
         self.items = items
         self.subsets = parent.data["model"]["subsets"]
-        self.asset_id = parent.data["state"]["context"]["assetId"]
+        self.asset_ids = parent.data["state"]["assetIds"]
 
         name = QtWidgets.QLineEdit()
         name.setPlaceholderText("Remain blank to ungroup..")
@@ -419,12 +433,20 @@ class SubsetGroupingDialog(QtWidgets.QDialog):
         if group:
             group.deleteLater()
 
-        active_groups = lib.get_active_group_config(self.asset_id,
-                                                    include_predefined=True)
+        active_groups = list()
+        for asset_id in self.asset_ids:
+            active_groups.extend(lib.get_active_group_config(
+                asset_id, include_predefined=True
+            ))
+
         # Build new action group
         group = QtWidgets.QActionGroup(button)
+        group_names = list()
         for data in sorted(active_groups, key=lambda x: x["order"]):
             name = data["name"]
+            if name in group_names:
+                continue
+            group_names.append(name)
             icon = data["icon"]
 
             action = group.addAction(name)
@@ -439,7 +461,7 @@ class SubsetGroupingDialog(QtWidgets.QDialog):
 
     def on_group(self):
         name = self.name.text().strip()
-        self.subsets.group_subsets(name, self.asset_id, self.items)
+        self.subsets.group_subsets(name, self.asset_ids, self.items)
 
         with lib.preserve_selection(tree_view=self.subsets.view,
                                     current_index=False):

--- a/avalon/tools/loader/app.py
+++ b/avalon/tools/loader/app.py
@@ -209,16 +209,35 @@ class Window(QtWidgets.QDialog):
 
         # Active must be in the selected rows otherwise we
         # assume it's not actually an "active" current index.
-        version = None
+        version_docs = None
+        version_doc = None
         active = selection.currentIndex()
+        rows = selection.selectedRows(column=active.column())
         if active:
-            rows = selection.selectedRows(column=active.column())
             if active in rows:
-                node = active.data(subsets.model.ItemRole)
-                if node is not None and not node.get("isGroup"):
-                    version = node["version_document"]["_id"]
+                item = active.data(subsets.model.ItemRole)
+                if (
+                    item is not None and
+                    not (item.get("isGroup") or item.get("isMerged"))
+                ):
+                    version_doc = item["version_document"]
 
-        self.data["model"]["version"].set_version(version)
+        if rows:
+            version_docs = []
+            for index in rows:
+                if not index or not index.isValid():
+                    continue
+                item = index.data(subsets.model.ItemRole)
+                if (
+                    item is None
+                    or item.get("isGroup")
+                    or item.get("isMerged")
+                ):
+                    continue
+                version_docs.append(item["version_document"])
+
+        self.data["model"]["version"].set_version(version_doc)
+
 
     def _set_context(self, context, refresh=True):
         """Set the selection in the interface using a context.

--- a/avalon/tools/loader/app.py
+++ b/avalon/tools/loader/app.py
@@ -39,9 +39,9 @@ class Window(QtWidgets.QDialog):
 
         container = QtWidgets.QWidget()
 
-        assets = AssetWidget()
+        assets = AssetWidget(multiselection=True, parent=self)
         families = FamilyListWidget()
-        subsets = SubsetWidget()
+        subsets = SubsetWidget(parent=self)
         version = VersionWidget()
 
         # Create splitter to show / hide family filters

--- a/avalon/tools/loader/model.py
+++ b/avalon/tools/loader/model.py
@@ -2,7 +2,7 @@ import copy
 import collections
 
 from ... import io, style
-from ...vendor.Qt import QtCore, QtGui
+from ...vendor.Qt import QtCore
 from ...vendor import qtawesome
 
 from ..models import TreeModel, Item

--- a/avalon/tools/loader/model.py
+++ b/avalon/tools/loader/model.py
@@ -265,57 +265,6 @@ class SubsetsModel(TreeModel):
         self.clear()
         self.beginResetModel()
 
-        active_groups = lib.get_active_group_config(self._asset_id)
-
-        # Generate subset group nodes
-        group_items = dict()
-
-        if self._grouping:
-            for data in active_groups:
-                name = data.pop("name")
-                group = Item()
-                group.update({"subset": name, "isGroup": True, "childRow": 0})
-                group.update(data)
-
-                group_items[name] = group
-                self.add_child(group)
-
-        # Process subsets
-        row = len(group_items)
-        has_item = False
-        for subset, last_version in self._doc_payload:
-            if not last_version:
-                # No published version for the subset
-                continue
-
-            data = subset.copy()
-            data["subset"] = data["name"]
-
-            group_name = subset["data"].get("subsetGroup")
-            if self._grouping and group_name:
-                group = group_items[group_name]
-                parent = group
-                parent_index = self.createIndex(0, 0, group)
-                row_ = group["childRow"]
-                group["childRow"] += 1
-            else:
-                parent = None
-                parent_index = QtCore.QModelIndex()
-                row_ = row
-                row += 1
-
-            item = Item()
-            item.update(data)
-
-            self.add_child(item, parent=parent)
-
-            # Set the version information
-            index = self.index(row_, 0, parent=parent_index)
-            self.set_version(index, last_version)
-            has_item = True
-
-        self.endResetModel()
-        self.refreshed.emit(has_item)
 
     def data(self, index, role):
 

--- a/avalon/tools/loader/model.py
+++ b/avalon/tools/loader/model.py
@@ -64,23 +64,26 @@ class SubsetsModel(TreeModel):
 
     def __init__(self, grouping=True, parent=None):
         super(SubsetsModel, self).__init__(parent=parent)
+
         self.columns_index = dict(
             (key, idx) for idx, key in enumerate(self.Columns)
         )
-        self._asset_id = None
+        self._asset_ids = None
+
         self._sorter = None
         self._grouping = grouping
         self._icons = {
             "subset": qtawesome.icon("fa.file-o", color=style.colors.default)
         }
+
         self._doc_fetching_thread = None
         self._doc_fetching_stop = False
         self._doc_payload = {}
 
         self.doc_fetched.connect(self.on_doc_fetched)
 
-    def set_asset(self, asset_id):
-        self._asset_id = asset_id
+    def set_assets(self, asset_ids):
+        self._asset_ids = asset_ids
         self.refresh()
 
     def set_grouping(self, state):
@@ -252,8 +255,10 @@ class SubsetsModel(TreeModel):
     def refresh(self):
         self.stop_fetch_thread()
         self.clear()
-        if not self._asset_id:
+
+        if not self._asset_ids:
             return
+
         self.fetch_subset_and_version()
 
     def on_doc_fetched(self):

--- a/avalon/tools/loader/model.py
+++ b/avalon/tools/loader/model.py
@@ -23,6 +23,7 @@ class SubsetsModel(TreeModel):
 
     Columns = [
         "subset",
+        "asset",
         "family",
         "version",
         "time",

--- a/avalon/tools/loader/model.py
+++ b/avalon/tools/loader/model.py
@@ -49,6 +49,18 @@ class SubsetsModel(TreeModel):
 
     SortAscendingRole = QtCore.Qt.UserRole + 2
     SortDescendingRole = QtCore.Qt.UserRole + 3
+    merged_subset_colors = [
+        (55, 161, 222), # Light Blue
+        (231, 176, 0), # Yellow
+        (154, 13, 255), # Purple
+        (130, 184, 30), # Light Green
+        (211, 79, 63), # Light Red
+        (179, 181, 182), # Grey
+        (194, 57, 179), # Pink
+        (0, 120, 215), # Dark Blue
+        (0, 204, 106), # Dark Green
+        (247, 99, 12), # Orange
+    ]
 
     def __init__(self, grouping=True, parent=None):
         super(SubsetsModel, self).__init__(parent=parent)

--- a/avalon/tools/loader/model.py
+++ b/avalon/tools/loader/model.py
@@ -53,16 +53,26 @@ class SubsetsModel(TreeModel):
     SortAscendingRole = QtCore.Qt.UserRole + 2
     SortDescendingRole = QtCore.Qt.UserRole + 3
     merged_subset_colors = [
-        (55, 161, 222), # Light Blue
-        (231, 176, 0), # Yellow
-        (154, 13, 255), # Purple
-        (130, 184, 30), # Light Green
-        (211, 79, 63), # Light Red
-        (179, 181, 182), # Grey
-        (194, 57, 179), # Pink
-        (0, 120, 215), # Dark Blue
-        (0, 204, 106), # Dark Green
-        (247, 99, 12), # Orange
+        # Light Blue
+        (55, 161, 222),
+        # Yellow
+        (231, 176, 0),
+        # Purple
+        (154, 13, 255),
+        # Light Green
+        (130, 184, 30),
+        # Light Red
+        (211, 79, 63),
+        # Grey
+        (179, 181, 182),
+        # Pink
+        (194, 57, 179),
+        # Dark Blue
+        (0, 120, 215),
+        # Dark Green
+        (0, 204, 106),
+        # Orange
+        (247, 99, 12),
     ]
 
     def __init__(self, grouping=True, parent=None):

--- a/avalon/tools/loader/model.py
+++ b/avalon/tools/loader/model.py
@@ -267,30 +267,8 @@ class SubsetsModel(TreeModel):
 
 
     def data(self, index, role):
-
         if not index.isValid():
             return
-
-        if role == QtCore.Qt.DisplayRole:
-            if index.column() == self.columns_index["family"]:
-                # Show familyLabel instead of family
-                item = index.internalPointer()
-                return item.get("familyLabel", None)
-
-        if role == QtCore.Qt.DecorationRole:
-
-            # Add icon to subset column
-            if index.column() == self.columns_index["subset"]:
-                item = index.internalPointer()
-                if item.get("isGroup"):
-                    return item["icon"]
-                else:
-                    return self._icons["subset"]
-
-            # Add icon to family column
-            if index.column() == self.columns_index["family"]:
-                item = index.internalPointer()
-                return item.get("familyIcon", None)
 
         if role == self.SortDescendingRole:
             item = index.internalPointer()
@@ -323,6 +301,25 @@ class SubsetsModel(TreeModel):
                     index, QtCore.Qt.DisplayRole
                 ))
             return prefix + order
+
+        if role == QtCore.Qt.DisplayRole:
+            if index.column() == self.columns_index["family"]:
+                # Show familyLabel instead of family
+                item = index.internalPointer()
+                return item.get("familyLabel", None)
+
+        elif role == QtCore.Qt.DecorationRole:
+            # Add icon to subset column
+            if index.column() == self.columns_index["subset"]:
+                item = index.internalPointer()
+                if item.get("isGroup") or item.get("isMerged"):
+                    return item["icon"]
+                return self._icons["subset"]
+
+            # Add icon to family column
+            if index.column() == self.columns_index["family"]:
+                item = index.internalPointer()
+                return item.get("familyIcon", None)
 
         return super(SubsetsModel, self).data(index, role)
 

--- a/avalon/tools/loader/model.py
+++ b/avalon/tools/loader/model.py
@@ -246,7 +246,6 @@ class SubsetsModel(TreeModel):
                 doc["_id"] = doc.pop("_version_id")
                 last_versions_by_subset_id[doc["parent"]] = doc
 
-
             self._doc_payload = {
                 "asset_docs_by_id": asset_docs_by_id,
                 "subset_docs_by_id": subset_docs_by_id,

--- a/avalon/tools/loader/model.py
+++ b/avalon/tools/loader/model.py
@@ -296,10 +296,13 @@ class SubsetsModel(TreeModel):
             item = index.internalPointer()
             if item.get("isGroup"):
                 # Ensure groups be on top when sorting by descending order
-                prefix = "1"
-                order = item["inverseOrder"]
+                prefix = "2"
+                order = item["order"]
             else:
-                prefix = "0"
+                if item.get("isMerged"):
+                    prefix = "1"
+                else:
+                    prefix = "0"
                 order = str(super(SubsetsModel, self).data(
                     index, QtCore.Qt.DisplayRole
                 ))
@@ -312,7 +315,10 @@ class SubsetsModel(TreeModel):
                 prefix = "0"
                 order = item["order"]
             else:
-                prefix = "1"
+                if item.get("isMerged"):
+                    prefix = "1"
+                else:
+                    prefix = "2"
                 order = str(super(SubsetsModel, self).data(
                     index, QtCore.Qt.DisplayRole
                 ))

--- a/avalon/tools/loader/model.py
+++ b/avalon/tools/loader/model.py
@@ -34,6 +34,19 @@ class SubsetsModel(TreeModel):
         "step"
     ]
 
+    column_labels_mapping = {
+        "subset": "Subset",
+        "asset": "Asset",
+        "family": "Family",
+        "version": "Version",
+        "time": "Time",
+        "author": "Author",
+        "frames": "Frames",
+        "duration": "Duration",
+        "handles": "Handles",
+        "step": "Step"
+    }
+
     SortAscendingRole = QtCore.Qt.UserRole + 2
     SortDescendingRole = QtCore.Qt.UserRole + 3
 
@@ -349,6 +362,15 @@ class SubsetsModel(TreeModel):
             flags |= QtCore.Qt.ItemIsEditable
 
         return flags
+
+    def headerData(self, section, orientation, role):
+        """Remap column names to labels"""
+        if role == QtCore.Qt.DisplayRole:
+            if section < len(self.Columns):
+                key = self.Columns[section]
+                return self.column_labels_mapping.get(key) or key
+
+        super(TreeModel, self).headerData(section, orientation, role)
 
 
 class GroupMemberFilterProxyModel(QtCore.QSortFilterProxyModel):

--- a/avalon/tools/loader/widgets.py
+++ b/avalon/tools/loader/widgets.py
@@ -59,6 +59,7 @@ class SubsetWidget(QtWidgets.QWidget):
         top_bar_layout.addWidget(groupable)
 
         view = SubsetTreeView()
+        view.setObjectName("SubsetView")
         view.setIndentation(20)
         view.setStyleSheet("""
             QTreeView::item{
@@ -592,9 +593,10 @@ class VersionWidget(QtWidgets.QWidget):
 
         layout = QtWidgets.QVBoxLayout(self)
 
-        label = QtWidgets.QLabel("Version")
+        label = QtWidgets.QLabel("Version", self)
         data = VersionTextEdit()
         data.setReadOnly(True)
+
         layout.addWidget(label)
         layout.addWidget(data)
 

--- a/avalon/tools/loader/widgets.py
+++ b/avalon/tools/loader/widgets.py
@@ -27,6 +27,19 @@ class SubsetWidget(QtWidgets.QWidget):
     active_changed = QtCore.Signal()    # active index changed
     version_changed = QtCore.Signal()   # version state changed for a subset
 
+    default_widths = (
+        ("subset", 190),
+        ("asset", 130),
+        ("family", 90),
+        ("version", 60),
+        ("time", 120),
+        ("author", 85),
+        ("frames", 80),
+        ("duration", 60),
+        ("handles", 55),
+        ("step", 50)
+    )
+
     def __init__(self, enable_grouping=True, parent=None):
         super(SubsetWidget, self).__init__(parent=parent)
 
@@ -99,15 +112,9 @@ class SubsetWidget(QtWidgets.QWidget):
         self.view.setModel(self.family_proxy)
         self.view.customContextMenuRequested.connect(self.on_context_menu)
 
-        view.setColumnWidth(0, 240)  # subset
-        view.setColumnWidth(1, 120)  # family
-        view.setColumnWidth(2, 100)  # version
-        view.setColumnWidth(3, 120)  # time
-        view.setColumnWidth(4, 100)  # author
-        view.setColumnWidth(5, 80)  # frames
-        view.setColumnWidth(6, 60)  # duration
-        view.setColumnWidth(7, 50)  # handles
-        view.setColumnWidth(8, 50)  # step
+        for column_name, width in self.default_widths:
+            idx = model.Columns.index(column_name)
+            view.setColumnWidth(idx, width)
 
         selection = view.selectionModel()
         selection.selectionChanged.connect(self.active_changed)

--- a/avalon/tools/loader/widgets.py
+++ b/avalon/tools/loader/widgets.py
@@ -297,15 +297,32 @@ class SubsetWidget(QtWidgets.QWidget):
                 self.echo(exc)
                 continue
 
-    def selected_subsets(self):
+    def selected_subsets(self, _groups=False, _merged=False, _other=True):
         selection = self.view.selectionModel()
         rows = selection.selectedRows(column=0)
 
         subsets = list()
+        if not any([_groups, _merged, _other]):
+            self.echo((
+                "This is a BUG: Selected_subsets args must contain"
+                " at least one value set to True"
+            ))
+            return subsets
+
         for row in rows:
-            node = row.data(self.model.ItemRole)
-            if not node.get("isGroup"):
-                subsets.append(node)
+            item = row.data(self.model.ItemRole)
+            if item.get("isGroup"):
+                if not _groups:
+                    continue
+
+            elif item.get("isMerged"):
+                if not _merged:
+                    continue
+            else:
+                if not _other:
+                    continue
+
+            subsets.append(item)
 
         return subsets
 

--- a/avalon/tools/loader/widgets.py
+++ b/avalon/tools/loader/widgets.py
@@ -11,7 +11,7 @@ from ... import pipeline
 from ... import style
 
 from .. import lib as tools_lib
-from ..delegates import VersionDelegate
+from ..delegates import VersionDelegate, PrettyTimeDelegate
 from ..widgets import OptionalMenu, OptionalAction, OptionDialog
 
 from .model import (
@@ -19,7 +19,6 @@ from .model import (
     SubsetFilterProxyModel,
     FamiliesFilterProxyModel,
 )
-from ..delegates import PrettyTimeDelegate
 
 
 class SubsetWidget(QtWidgets.QWidget):

--- a/avalon/tools/loader/widgets.py
+++ b/avalon/tools/loader/widgets.py
@@ -600,8 +600,8 @@ class VersionWidget(QtWidgets.QWidget):
 
         self.data = data
 
-    def set_version(self, version_id):
-        self.data.set_version(version_id)
+    def set_version(self, version_doc):
+        self.data.set_version(version_doc)
 
 
 class FamilyListWidget(QtWidgets.QListWidget):

--- a/avalon/tools/loader/widgets.py
+++ b/avalon/tools/loader/widgets.py
@@ -309,7 +309,7 @@ class SubsetWidget(QtWidgets.QWidget):
 
         return subsets
 
-    def group_subsets(self, name, asset_id, nodes):
+    def group_subsets(self, name, asset_ids, items):
         field = "data.subsetGroup"
 
         if name:
@@ -320,15 +320,16 @@ class SubsetWidget(QtWidgets.QWidget):
             self.echo("Ungroup subsets..")
 
         subsets = list()
-        for node in nodes:
-            subsets.append(node["subset"])
+        for item in items:
+            subsets.append(item["subset"])
 
-        filter = {
-            "type": "subset",
-            "parent": asset_id,
-            "name": {"$in": subsets},
-        }
-        io.update_many(filter, update)
+        for asset_id in asset_ids:
+            filter = {
+                "type": "subset",
+                "parent": asset_id,
+                "name": {"$in": subsets},
+            }
+            io.update_many(filter, update)
 
     def echo(self, message):
         print(message)

--- a/avalon/tools/models.py
+++ b/avalon/tools/models.py
@@ -217,22 +217,16 @@ class TasksModel(TreeModel):
                                       color=style.colors.default)
                 self._icons[task["name"]] = icon
 
-    def set_assets(self, asset_docs):
+    def set_assets(self, asset_ids=None, asset_docs=None):
         """Set assets to track by their database id
 
         Arguments:
-            asset_docs (list): List of asset documents from MongoDB.
+            asset_ids (list): List of asset ids.
+            asset_docs (list): List of asset entities from MongoDB.
 
         """
 
-        # Backwards compatibility if anyone use this model in his tools
-        asset_ids = None
-        for doc in asset_docs:
-            if isinstance(doc, io.ObjectId):
-                asset_ids = asset_docs
-            break
-
-        if asset_ids:
+        if asset_docs is None and asset_ids is not None:
             # prepare filter query
             _filter = {"type": "asset", "_id": {"$in": asset_ids}}
 
@@ -248,6 +242,13 @@ class TasksModel(TreeModel):
             assert not not_found, "Assets not found by id: {0}".format(
                 ", ".join(not_found)
             )
+
+            assert not not_found, "Assets not found by id: {0}".format(
+                ", ".join(not_found)
+            )
+
+        if asset_docs is None:
+            asset_docs = list()
 
         self._num_assets = len(asset_docs)
 

--- a/avalon/tools/models.py
+++ b/avalon/tools/models.py
@@ -105,10 +105,10 @@ class TreeModel(QtCore.QAbstractItemModel):
 
         return self.createIndex(parent_item.row(), 0, parent_item)
 
-    def index(self, row, column, parent):
+    def index(self, row, column, parent=None):
         """Return index for row/column under parent"""
 
-        if not parent.isValid():
+        if parent is None or not parent.isValid():
             parent_item = self._root_item
         else:
             parent_item = parent.internalPointer()

--- a/avalon/tools/models.py
+++ b/avalon/tools/models.py
@@ -182,6 +182,7 @@ class Item(dict):
         if self._parent is not None:
             siblings = self.parent().children()
             return siblings.index(self)
+        return -1
 
     def add_child(self, child):
         """Add a child to this item"""

--- a/avalon/tools/models.py
+++ b/avalon/tools/models.py
@@ -3,7 +3,7 @@ import logging
 import collections
 
 from ..vendor.Qt import QtCore, QtGui
-from ..vendor import qtawesome
+from ..vendor import Qt, qtawesome
 from .. import io
 from .. import style
 from . import lib
@@ -63,7 +63,10 @@ class TreeModel(QtCore.QAbstractItemModel):
                 item[key] = value
 
                 # passing `list()` for PyQt5 (see PYSIDE-462)
-                self.dataChanged.emit(index, index, list())
+                if Qt.__binding__ in ("PyQt4", "PySide"):
+                    self.dataChanged.emit(index, index)
+                else:
+                    self.dataChanged.emit(index, index, [role])
 
                 # must return true if successful
                 return True

--- a/avalon/tools/models.py
+++ b/avalon/tools/models.py
@@ -328,9 +328,11 @@ class AssetModel(TreeModel):
 
     DocumentRole = QtCore.Qt.UserRole + 2
     ObjectIdRole = QtCore.Qt.UserRole + 3
+    subsetColorsRole = QtCore.Qt.UserRole + 4
 
     def __init__(self, parent=None):
         super(AssetModel, self).__init__(parent=parent)
+        self.asset_colors = {}
         self.refresh()
 
     def _add_hierarchy(self, assets, parent=None, silos=None):
@@ -348,6 +350,9 @@ class AssetModel(TreeModel):
             None
 
         """
+        # Reset colors
+        self.asset_colors = {}
+
         if silos:
             # WARNING: Silo item "_id" is set to silo value
             # mainly because GUI issue with preserve selection and expanded row
@@ -389,6 +394,8 @@ class AssetModel(TreeModel):
             if asset["_id"] in assets:
                 self._add_hierarchy(assets, parent=item)
 
+            self.asset_colors[asset["_id"]] = []
+
     def refresh(self):
         """Refresh the data for the model."""
 
@@ -423,6 +430,24 @@ class AssetModel(TreeModel):
     def flags(self, index):
         return QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsSelectable
 
+    def setData(self, index, value, role=QtCore.Qt.EditRole):
+        if not index.isValid():
+            return False
+
+        if role == self.subsetColorsRole:
+            asset_id = index.data(self.ObjectIdRole)
+            self.asset_colors[asset_id] = value
+
+            # passing `list()` for PyQt5 (see PYSIDE-462)
+            if Qt.__binding__ in ("PyQt4", "PySide"):
+                self.dataChanged.emit(index, index)
+            else:
+                self.dataChanged.emit(index, index, [role])
+
+            return True
+
+        return super(AssetModel, self).setData(index, value, role)
+
     def data(self, index, role):
 
         if not index.isValid():
@@ -433,6 +458,7 @@ class AssetModel(TreeModel):
 
             column = index.column()
             if column == self.Name:
+
                 # Allow a custom icon and custom icon color to be defined
                 data = item.get("_document", {}).get("data", {})
                 icon = data.get("icon", None)
@@ -471,6 +497,10 @@ class AssetModel(TreeModel):
 
         if role == self.DocumentRole:
             return item.get("_document", None)
+
+        if role == self.subsetColorsRole:
+            asset_id = item.get("_id", None)
+            return self.asset_colors.get(asset_id) or []
 
         return super(AssetModel, self).data(index, role)
 

--- a/avalon/tools/projectmanager/app.py
+++ b/avalon/tools/projectmanager/app.py
@@ -236,7 +236,8 @@ class Window(QtWidgets.QDialog):
 
         model = self.data["model"]["assets"]
         selected = model.get_selected_assets()
-        self.data["model"]["tasks"].set_assets(selected)
+
+        self.data["model"]["tasks"].set_assets(asset_docs=selected)
 
 
 def show(root=None, debug=False, parent=None):

--- a/avalon/tools/views.py
+++ b/avalon/tools/views.py
@@ -14,3 +14,27 @@ class DeselectableTreeView(QtWidgets.QTreeView):
             self.setCurrentIndex(QtCore.QModelIndex())
 
         QtWidgets.QTreeView.mousePressEvent(self, event)
+
+
+class AssetsView(DeselectableTreeView):
+    """Item view.
+    This implements a context menu.
+    """
+
+    def __init__(self):
+        super(AssetsView, self).__init__()
+        self.setIndentation(15)
+        self.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+        self.setHeaderHidden(True)
+        self.setObjectName("AssetsView")
+
+    def mousePressEvent(self, event):
+        index = self.indexAt(event.pos())
+        if not index.isValid():
+            modifiers = QtWidgets.QApplication.keyboardModifiers()
+            if modifiers == QtCore.Qt.ShiftModifier:
+                return
+            elif modifiers == QtCore.Qt.ControlModifier:
+                return
+
+        super(AssetsView, self).mousePressEvent(event)

--- a/avalon/tools/widgets.py
+++ b/avalon/tools/widgets.py
@@ -9,7 +9,6 @@ from ..vendor import qtawesome, qargparse
 from ..vendor.Qt import QtWidgets, QtCore, QtGui
 
 from .. import style
-from .. import io
 
 log = logging.getLogger(__name__)
 

--- a/avalon/tools/widgets.py
+++ b/avalon/tools/widgets.py
@@ -3,7 +3,8 @@ import logging
 from . import lib
 
 from .models import AssetModel, RecursiveSortFilterProxyModel
-from .views import DeselectableTreeView
+from .views import AssetsView
+from .delegates import AssetDelegate
 from ..vendor import qtawesome, qargparse
 from ..vendor.Qt import QtWidgets, QtCore, QtGui
 
@@ -27,7 +28,7 @@ class AssetWidget(QtWidgets.QWidget):
     selection_changed = QtCore.Signal()  # on view selection change
     current_changed = QtCore.Signal()    # on view current index change
 
-    def __init__(self, parent=None):
+    def __init__(self, multiselection=False, parent=None):
         super(AssetWidget, self).__init__(parent=parent)
         self.setContentsMargins(0, 0, 0, 0)
 
@@ -36,15 +37,12 @@ class AssetWidget(QtWidgets.QWidget):
         layout.setSpacing(4)
 
         # Tree View
-        model = AssetModel()
+        model = AssetModel(self)
         proxy = RecursiveSortFilterProxyModel()
         proxy.setSourceModel(model)
         proxy.setFilterCaseSensitivity(QtCore.Qt.CaseInsensitive)
 
-        view = DeselectableTreeView()
-        view.setIndentation(15)
-        view.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
-        view.setHeaderHidden(True)
+        view = AssetsView()
         view.setModel(proxy)
 
         # Header
@@ -122,10 +120,12 @@ class AssetWidget(QtWidgets.QWidget):
             None
 
         Default `key` is "name" in that case `assets` should contain single
-        asset name or list of asset names. It is recommended to use "_id" key
-        instead of name. In that case `assets` must contain `ObjectId` objects.
-        It is assumed that each value in `assets` is found only once.
-        On multiple matches only the first found will be selected.
+        asset name or list of asset names. (It is good idea to use "_id" key
+        instead of name in that case `assets` must contain `ObjectId` object/s)
+        It is expected that each value in `assets` will be found only once.
+        If the filters according to the `key` and `assets` correspond to
+        the more asset, only the first found will be selected.
+
         """
 
         if not isinstance(assets, (tuple, list)):

--- a/avalon/tools/widgets.py
+++ b/avalon/tools/widgets.py
@@ -44,6 +44,11 @@ class AssetWidget(QtWidgets.QWidget):
 
         view = AssetsView()
         view.setModel(proxy)
+        view.setProperty("multiselection", multiselection)
+        if multiselection:
+            asset_delegate = AssetDelegate()
+            view.setSelectionMode(view.ExtendedSelection)
+            view.setItemDelegate(asset_delegate)
 
         # Header
         header = QtWidgets.QHBoxLayout()

--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -600,11 +600,15 @@ class FilesWidget(QtWidgets.QWidget):
 
         filter = " *".join(self.host.file_extensions())
         filter = "Work File (*{0})".format(filter)
-        work_file = QtWidgets.QFileDialog.getOpenFileName(
-            caption="Work Files",
-            dir=self.root,
-            filter=filter
-        )[0]
+        kwargs = {
+            "caption": "Work Files",
+            "filter": filter
+        }
+        if Qt.__binding__ in ("PySide", "PySide2"):
+            kwargs["dir"] = self.root
+        else:
+            kwargs["directory"] = self.root
+        work_file = QtWidgets.QFileDialog.getOpenFileName(**kwargs)[0]
 
         if not work_file:
             return

--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -6,6 +6,7 @@ import shutil
 import logging
 import platform
 
+from ...vendor import Qt
 from ...vendor.Qt import QtWidgets, QtCore
 from ... import style, io, api, pipeline
 
@@ -296,8 +297,9 @@ class TasksWidget(QtWidgets.QWidget):
         self._last_selected_task = None
 
     def set_asset(self, asset):
-
-        assets = [asset] if asset else []
+        if asset is None:
+            # Asset deselected
+            return
 
         # Try and preserve the last selected task and reselect it
         # after switching assets. If there's no currently selected
@@ -306,7 +308,7 @@ class TasksWidget(QtWidgets.QWidget):
         if current:
             self._last_selected_task = current
 
-        self.models["tasks"].set_assets(assets)
+        self.models["tasks"].set_assets(asset_docs=[asset])
 
         if self._last_selected_task:
             self.select_task(self._last_selected_task)
@@ -727,7 +729,7 @@ class FilesWidget(QtWidgets.QWidget):
                 continue
 
             modified = index.data(role)
-            if modified > highest:
+            if modified is not None and modified > highest:
                 highest_index = index
                 highest = modified
 
@@ -833,7 +835,7 @@ class Window(QtWidgets.QMainWindow):
         self._on_task_changed()
 
     def _on_asset_changed(self):
-        asset = self.widgets["assets"].get_active_asset_document()
+        asset = self.widgets["assets"].get_selected_assets() or None
 
         if not asset:
             # Force disable the other widgets if no
@@ -841,13 +843,16 @@ class Window(QtWidgets.QMainWindow):
             self.widgets["tasks"].setEnabled(False)
             self.widgets["files"].setEnabled(False)
         else:
+            asset = asset[0]
             self.widgets["tasks"].setEnabled(True)
 
         self.widgets["tasks"].set_asset(asset)
 
     def _on_task_changed(self):
 
-        asset = self.widgets["assets"].get_active_asset_document()
+        asset = self.widgets["assets"].get_selected_assets() or None
+        if asset is not None:
+            asset = asset[0]
         task = self.widgets["tasks"].get_current_task()
 
         self.widgets["tasks"].setEnabled(bool(asset))


### PR DESCRIPTION
# Feature: Multiselection of assets in loader
With this feature it is possible to load multiple subsets from multiple assets at once.
![65226426-1eb47200-dac7-11e9-80f8-ad4f5f4f5a35](https://user-images.githubusercontent.com/43494761/82918722-64d6a500-9f75-11ea-8c3f-de37a11a96d3.gif)

This feature is used only in loader, rest of tools should work the same (visually) as before and if only one asset is selected then nothing should change too.

How it works (basics):
- When multiple assets are selected, subsets with same name are grouped in subsets view with colored circle, other are just kept in list.
- At the same time "Asset" column is added to know which item is related to which asset.
- Subset group has number representing number of assets having the subset.
- Group color is helper to identify the subset. There are 10 predefined(hardcoded) colors atm. They are reused if more than 10 subsets has same name.
    - If colored group is selected you can see in assets view that selected assets has bar with colors. The color helps to identify which subsets are available for the asset -> `missing color == missing subset`.
- It is not possible to see subset groups when multiple assets are selected.

RESOLVES: https://github.com/getavalon/core/issues/453