### PR TITLE
Toggle "Save As" button in Workfiles.

### DIFF
--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -854,7 +854,7 @@ class Window(QtWidgets.QMainWindow):
         files.refresh()
 
 
-def show(root=None, debug=False, parent=None, use_context=True):
+def show(root=None, debug=False, parent=None, use_context=True, save=True):
     """Show Work Files GUI"""
     # todo: remove `root` argument to show()
 
@@ -896,6 +896,8 @@ def show(root=None, debug=False, parent=None, use_context=True):
                        "silo": api.Session["AVALON_SILO"],
                        "task": api.Session["AVALON_TASK"]}
             window.set_context(context)
+
+        window.widgets["files"].widgets["save"].setEnabled(save)
 
         window.show()
         window.setStyleSheet(style.load_stylesheet())


### PR DESCRIPTION
**Changes**
This PR enables developers to disable the "Save As" button when showing the Workfiles app.

```
import avalon.tools.workfiles
avalon.tools.workfiles.show(save=False)
```

**Motivation**
The specific use-case for this is the Harmony host. Unfortunately you cannot open a scene in an active application instance of Harmony, so you need to relaunch Harmony as a new process. For the Workfiles flow this means the user has to open an instance of Harmony then open it again to launch the scene they want.
With this PR we can show the Workfiles tool before the application is launched, and the user can open the scene file they want, reducing the wait by one application launch.

This "launch before application" behaviour can be ported to other hosts, but its less necessary if you can prevent launching a new process.