### PR TITLE
Add current index preserving in qtreeview context

### DIFF
--- a/avalon/tools/lib.py
+++ b/avalon/tools/lib.py
@@ -113,6 +113,7 @@ def preserve_states(tree_view,
                     role=None,
                     preserve_expanded=True,
                     preserve_selection=True,
+                    current_index=True,
                     expanded_role=QtCore.Qt.DisplayRole,
                     selection_role=QtCore.Qt.DisplayRole):
     """Preserves row selection in QTreeView by column's data role.
@@ -151,6 +152,11 @@ def preserve_states(tree_view,
         if selected_rows:
             selected = set(row.data(selection_role) for row in selected_rows)
 
+    if current_index:
+        current_index_value = tree_view.currentIndex().data(role)
+    else:
+        current_index_value = None
+
     try:
         yield
     finally:
@@ -175,6 +181,10 @@ def preserve_states(tree_view,
                 if state:
                     tree_view.scrollTo(index)  # Ensure item is visible
                     selection_model.select(index, flags)
+
+                if current_index_value and value == current_index_value:
+                    selection_model.setCurrentIndex(index,
+                                                    selection_model.NoUpdate)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
### Problem

Loader's subset view gets flushed after clicking asset widget's refresh button.

Subset widget needs asset document id to get subsets. And the asset document id is retrived from view's `currentIndex`.

https://github.com/getavalon/core/blob/3761095b151c47f5f6a905e1628900def51f7c47/avalon/tools/widgets.py#L90-L93

And it looks like the `tools.lib.preserve_states` did not preserve the asset's `view.currentIndex` while refresh the asset model.

https://github.com/getavalon/core/blob/3761095b151c47f5f6a905e1628900def51f7c47/avalon/tools/loader/app.py#L171-L173

https://github.com/getavalon/core/blob/3761095b151c47f5f6a905e1628900def51f7c47/avalon/tools/widgets.py#L79-L83

### Solution

Add `currentIndex` preserve function into `tools.lib.preserve_states`.

