### PR TITLE
Fix hound with a bit better flake8 setup

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,9 @@
 [flake8]
-ignore = BLK100
+
+# BLK100: Black would make changes
+#   W503: line break before binary operator
+ignore = BLK100,W503
+
+exclude =
+    vendor,
+    style,


### PR DESCRIPTION
### What's changed

* Decided which rule to follow, line break before binary operator or after.
* Added `exclude`, so `flake8` won't look into modules that can be ignored when invoking `flake8` on local.

### Discussion

Which should we follow ?

1) Write with line break **before** binary op (W503)
```python
foo = ("hello"
       + "world,"
       + "bar")
```
or,

2) write line break **after** binary op (W504)
```python
foo = ("hello" +
       "world," +
       "bar")
```

I now like to break *before* (option 1), since I can view all the operations in a aligned stack, what do you guys think ?

### Additional notes

How to invoke `flake8` on local
```
$ pip install flake8
$ cd avalon-core
$ flake8
```