### PR TITLE
Fix ci coverage & azure

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,12 @@
 [run]
 source = avalon
 
+[paths]
+# Remap source root path in docker
+source =
+    avalon
+    /workspace/avalon
+
 [report]
 include = *avalon*
 omit = 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: python
 python:
   - 3.7
 
+env:
+  global:
+    - COVERALLS_SERVICE_NAME=travis-ci
+
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
 
 after_success:
   - coverage combine
-  - coveralls
+  - coveralls debug
 
 before_deploy:
   - sudo chmod -R 777 docs/build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,11 @@ language: python
 python:
   - 3.7
 
-env:
-  global:
-    - COVERALLS_SERVICE_NAME=travis-ci
-
 services:
   - docker
 
 install:
-  - pip install coverage coveralls
+  - pip install coverage python-coveralls
   - docker run --name avalon-mongo -d mongo
   - . build_docker.sh
 
@@ -21,7 +17,7 @@ script:
 
 after_success:
   - coverage combine
-  - coveralls debug
+  - coveralls
 
 before_deploy:
   - sudo chmod -R 777 docs/build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,23 @@
 language: python
 
 python:
-  - 2.7
+  - 3.7
 
 services:
   - docker
 
 install:
+  - pip install coverage coveralls
   - docker run --name avalon-mongo -d mongo
-  - docker build -t avalon/core -f Dockerfile-maya2016 .
+  - docker build -t avalon/core:maya -f Dockerfile-maya2016 .
 
 script:
   - . test_docker.sh
   - . build_docs.sh
+
+after_success:
+  - coverage combine
+  - coveralls
 
 before_deploy:
   - sudo chmod -R 777 docs/build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ services:
   - docker
 
 install:
-  - pip install coverage python-coveralls
+  - pip install coverage==4.5.4
+  - pip install python-coveralls
   - docker run --name avalon-mongo -d mongo
   - . build_docker.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
 install:
   - pip install coverage coveralls
   - docker run --name avalon-mongo -d mongo
-  - docker build -t avalon/core:maya -f Dockerfile-maya2016 .
+  - . build_docker.sh
 
 script:
   - . test_docker.sh

--- a/Dockerfile-maya2016
+++ b/Dockerfile-maya2016
@@ -13,7 +13,7 @@ RUN wget https://bootstrap.pypa.io/get-pip.py && \
 		six \
 		sphinxcontrib-napoleon
 
-# Avoid creation of auxilliary files
+# Avoid creation of auxiliary files
 ENV PYTHONDONTWRITEBYTECODE=1
 
 WORKDIR /workspace

--- a/Dockerfile-maya2016
+++ b/Dockerfile-maya2016
@@ -22,5 +22,5 @@ ENV PYTHONDONTWRITEBYTECODE=1
 WORKDIR /workspace
 
 ENTRYPOINT \
-	PYTHONPATH=$(pwd):$PYTHONPATH mayapy -u run_maya_tests.py && \
-	mayapy -c "import sys, os, coveralls;coveralls.wear() if os.getenv('TRAVIS_JOB_ID') else sys.stdout.write('Skipping coveralls')"
+	PYTHONPATH=$(pwd):$PYTHONPATH && \
+	mayapy -u run_maya_tests.py

--- a/Dockerfile-maya2016
+++ b/Dockerfile-maya2016
@@ -5,16 +5,13 @@ RUN wget https://bootstrap.pypa.io/get-pip.py && \
 	mayapy -m pip install \
 		nose \
 		nose-exclude \
-		coverage==4.5.4 \
-		pyblish-base==1.4.2 \
+		coverage \
+		pyblish-base \
 		pyblish-maya \
 		pymongo \
-		# Sphinx 1.8.0 fail to build doc, pin version to 1.7.9
-		# see https://github.com/sphinx-doc/sphinx/issues/5417
-		sphinx==1.7.9 \
+		sphinx \
 		six \
-		sphinxcontrib-napoleon \
-		python-coveralls
+		sphinxcontrib-napoleon
 
 # Avoid creation of auxilliary files
 ENV PYTHONDONTWRITEBYTECODE=1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,7 @@ jobs:
 
   - job: MacOS
     pool:
-      vmImage: "macOS-10.13"  # High-Sierra
+      vmImage: "macOS-10.15"  # Catalina
     strategy:
       matrix:
         Python27:

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,1 +1,1 @@
-docker build -t avalon/core -f Dockerfile-maya2016 .
+docker build -t avalon/core:maya -f Dockerfile-maya2016 .

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -1,11 +1,11 @@
 docker run \
-	--rm \
-	-v $(pwd):/workspace \
-	--link avalon-mongo:mongo \
-	-e AVALON_SILENT \
-	-e AVALON_MONGO=mongodb://mongo:27017 \
-	-e PYTHONPATH=/workspace:/usr/local/lib/python2.6/site-packages \
-	--entrypoint mayapy \
-	--workdir /workspace/docs \
-	avalon/core \
-	-m sphinx source build -E -v
+  --rm \
+  --volume $(pwd):/workspace \
+  --link avalon-mongo:mongo \
+  --env AVALON_SILENT \
+  --env AVALON_MONGO=mongodb://mongo:27017 \
+  --env PYTHONPATH=/workspace:/usr/local/lib/python2.6/site-packages \
+  --entrypoint mayapy \
+  --workdir /workspace/docs \
+  avalon/core:maya \
+  -m sphinx source build -E -v

--- a/test_docker.sh
+++ b/test_docker.sh
@@ -6,6 +6,9 @@ docker run \
   --link avalon-mongo:mongo \
   --env AVALON_SILENT \
   --env AVALON_MONGO=mongodb://mongo:27017 \
+  --env TRAVIS_JOB_ID \
+  --env TRAVIS_BRANCH \
+  --env COVERALLS_REPO_TOKEN \
   avalon/core:maya
 # Rename coverage data file and will be combined later
 mv .coverage .coverage.maya

--- a/test_docker.sh
+++ b/test_docker.sh
@@ -1,9 +1,13 @@
+
+# Run Maya test
 docker run \
-	--rm \
-	-v $(pwd):/workspace \
-	--link avalon-mongo:mongo \
-    -e COVERALLS_REPO_TOKEN \
-    -e TRAVIS_JOB_ID \
-	-e AVALON_SILENT \
-	-e AVALON_MONGO=mongodb://mongo:27017 \
-	avalon/core
+  --rm \
+  --volume $(pwd):/workspace \
+  --link avalon-mongo:mongo \
+  --env AVALON_SILENT \
+  --env AVALON_MONGO=mongodb://mongo:27017 \
+  avalon/core:maya
+# Rename coverage data file and will be combined later
+mv .coverage .coverage.maya
+
+# docker run other DCC tools..

--- a/test_docker.sh
+++ b/test_docker.sh
@@ -6,9 +6,6 @@ docker run \
   --link avalon-mongo:mongo \
   --env AVALON_SILENT \
   --env AVALON_MONGO=mongodb://mongo:27017 \
-  --env TRAVIS_JOB_ID \
-  --env TRAVIS_BRANCH \
-  --env COVERALLS_REPO_TOKEN \
   avalon/core:maya
 # Rename coverage data file and will be combined later
 mv .coverage .coverage.maya


### PR DESCRIPTION
### What's changed

This PR fix #558.

The code coverage submission was decoupled from maya test script, and provide a new scheme for future testing on multiple DCC tools or versions.

### New code coverage scheme

1. The test script generates a `.coverage` data file after complete.
2. Rename the `.coverage` into `.coverage.{subject}`, where the *subject* could be DCC tool name and version.
3. After all test scripts completed, run `coverage combine` to combine all `.coverage` prefixed data file into one.
4. Submit to coveralls.
