### PR TITLE
Speed up getting assets for asset switcher

### DIFF
--- a/avalon/tools/sceneinventory/app.py
+++ b/avalon/tools/sceneinventory/app.py
@@ -677,14 +677,12 @@ class SwitchAssetDialog(QtWidgets.QDialog):
 
     def _get_assets(self):
         filtered_assets = []
+        subsets = list(io.find({"type": "subset"}))
         for asset in io.find({"type": "asset"}):
-            subsets = io.find({
-                "type": "subset",
-                "parent": asset["_id"]
-            })
-            for subs in subsets:
-                filtered_assets.append(asset["name"])
-                break
+            for subset in subsets:
+                if asset["_id"] == subset["parent"]:
+                    filtered_assets.append(asset["name"])
+                    break
 
         return filtered_assets
 


### PR DESCRIPTION
**What's changed?**

When querying the assets to populate the asset switcher a database call was made for every asset. If you have lots of assets this can really add up and take quite some time (for me roughly 30 seconds for 2000 assets).

This change does only 2 database calls and then does the filtering afterwards. In my case this reduces the time taken to around 3 seconds for 2000 assets.